### PR TITLE
Change the DB used in the CI from MySQL to PostgreSQL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,32 +2,29 @@
 version: '3.7'
 services:
   zabbix-db:
-    image: mysql:5.7
+    image: postgres:latest
     environment:
-      MYSQL_DATABASE: "zabbix"
-      MYSQL_USER: "zabbix"
-      MYSQL_PASSWORD: "zabbix"
-      MYSQL_ROOT_PASSWORD: "zabbix"
+      POSTGRES_DB: "zabbix"
+      POSTGRES_USER: "zabbix"
+      POSTGRES_PASSWORD: "zabbix"
   zabbix-server:
-    image: zabbix/zabbix-server-mysql:ubuntu-${zabbix_version}-latest
+    image: zabbix/zabbix-server-pgsql:ubuntu-${zabbix_version}-latest
     environment:
       DB_SERVER_HOST: "zabbix-db"
-      MYSQL_USER: "zabbix"
-      MYSQL_PASSWORD: "zabbix"
-      MYSQL_DATABASE: "zabbix"
-      MYSQL_ROOT_PASSWORD: "zabbix"
+      POSTGRES_USER: "zabbix"
+      POSTGRES_PASSWORD: "zabbix"
+      POSTGRES_DB: "zabbix"
     depends_on:
       - "zabbix-db"
     links:
       - "zabbix-db"
   zabbix-web:
-    image: zabbix/zabbix-web-nginx-mysql:ubuntu-${zabbix_version}-latest
+    image: zabbix/zabbix-web-nginx-pgsql:ubuntu-${zabbix_version}-latest
     environment:
       DB_SERVER_HOST: "zabbix-db"
-      MYSQL_USER: "zabbix"
-      MYSQL_PASSWORD: "zabbix"
-      MYSQL_DATABASE: "zabbix"
-      MYSQL_ROOT_PASSWORD: "zabbix"
+      POSTGRES_USER: "zabbix"
+      POSTGRES_PASSWORD: "zabbix"
+      POSTGRES_DB: "zabbix"
       ZBX_SERVER_HOST: "zabbix-server"
       PHP_TZ: "Asia/Tokyo"
     depends_on:

--- a/tests/integration/targets/setup_zabbix/defaults/main.yml
+++ b/tests/integration/targets/setup_zabbix/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 zabbix_server_url: http://127.0.0.1:8080
-zabbix_login_user: admin
+zabbix_login_user: Admin
 zabbix_login_password: zabbix


### PR DESCRIPTION
##### SUMMARY
Using MySQL with Zabbix introduces the following bugs.

https://support.zabbix.com/browse/ZBX-17357

This bug does not occur when using PostgreSQL, so change DB from MySQL to PostgreSQL.
After making this change, the case of the username will be strictly evaluated.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
docker-compose.yml
integration/targets/setup_zabbix/defaults/main.yml

##### ADDITIONAL INFORMATION

