### PR TITLE
Documented sub-option value2 for zabbix_action option conditions

### DIFF
--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -86,7 +86,7 @@ options:
                     - ' - C(time_period)'
                     - ' - C(host_template)'
                     - ' - C(application)'
-                    - ' - C(maintenance_status)'
+                    - ' - C(maintenance_status) known in Zabbix 4.0 and above as "Problem is suppressed"'
                     - ' - C(event_tag)'
                     - ' - C(event_tag_value)'
                     - 'Possible values when I(event_source=discovery):'
@@ -215,6 +215,11 @@ options:
             type:
                 description:
                     - Type of operation.
+                    - 'Valid choices when setting type for I(recovery_operations) and I(acknowledge_operations):'
+                    - ' - C(send_message)'
+                    - ' - C(remote_command)'
+                    - ' - C(notify_all_involved)'
+                    - Choice C(notify_all_involved) only supported in I(recovery_operations) and I(acknowledge_operations).
                 choices:
                     - send_message
                     - remote_command
@@ -227,6 +232,7 @@ options:
                     - enable_host
                     - disable_host
                     - set_host_inventory_mode
+                    - notify_all_involved
             esc_period:
                 description:
                     - Duration of an escalation step in seconds.
@@ -357,8 +363,10 @@ options:
         type: list
         description:
             - List of acknowledge operations.
+            - Action acknowledge operations are known as update operations since Zabbix 4.0.
             - C(Suboptions) are the same as for I(operations).
             - Works only with >= Zabbix 3.4
+        aliases: [ update_operations ]
 
 notes:
     - Only Zabbix >= 3.0 is supported.
@@ -1718,7 +1726,10 @@ def main():
                     type=dict(type='str', required=True),
                     value=dict(type='str', required=True),
                     value2=dict(type='str', required=False)
-                )
+                ),
+                required_if=[
+                    ['type', 'event_tag_value', ['value2']],
+                ]
             ),
             formula=dict(type='str', required=False, default=None),
             eval_type=dict(type='str', required=False, default=None, choices=['andor', 'and', 'or', 'custom_expression']),
@@ -1920,6 +1931,7 @@ def main():
                 required=False,
                 default=[],
                 elements='dict',
+                aliases=['update_operations'],
                 options=dict(
                     type=dict(
                         type='str',

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -138,6 +138,10 @@ options:
                     - Irrespective of user-visible names being changed in Zabbix. Defaults to C(not classified) if omitted.
                     - Besides the above options, this is usually either the name
                       of the object or a string to compare with.
+            value2:
+                description:
+                    - Secondary value to compare with.
+                    - Required for trigger actions when condition I(type=event_tag_value).
             operator:
                 description:
                     - Condition operator.


### PR DESCRIPTION
##### SUMMARY
At first, I thought this was just an oversight, but it turns out that option `conditions` for zabbix_action module does accept sub-option `value2`. It just wasn't documented in module's `DOCUMENTATION` block.

Fixes #13 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/zabbix_action

##### ADDITIONAL INFORMATION
Module attempts to load `value2` for `condition` on L1554:
```python
            constructed_data['conditions'].append({
                "conditiontype": condition_type,
                "value": self._construct_value(condition_type, cond.get("value")),
                "value2": cond.get("value2"),
```
It is even defined in `module.argument_spec` on L1720:
```python
            conditions=dict(
                type='list',
                required=False,
                default=[],
                elements='dict',
                options=dict(
                    formulaid=dict(type='str', required=False),
                    operator=dict(type='str', required=True),
                    type=dict(type='str', required=True),
                    value=dict(type='str', required=True),
                    value2=dict(type='str', required=False)
```