### PR TITLE
Fix to run zabbix 5.0 in CI

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -26,11 +26,17 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        zabbix_version:
-          - "3.0"
-          - "4.0"
-          - "4.4"
+        zabbix_container:
+          - version: "3.0"
+            port: "80"
+          - version: "4.0"
+            port: "80"
+          - version: "4.4"
+            port: "80"
+          - version: "5.0"
+            port: "8080"
 
     steps:
       - name: Check out code
@@ -52,7 +58,8 @@ jobs:
       - name: Zabbix container server provisioning
         run: docker-compose up -d
         env:
-          zabbix_version: ${{ matrix.zabbix_version }}
+          zabbix_version: ${{ matrix.zabbix_container.version }}
+          zabbix_port: ${{ matrix.zabbix_container.port }}
 
       - name: Run integration test
         run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff

--- a/README.md
+++ b/README.md
@@ -112,9 +112,13 @@ Running test suites locally requires few dependencies (use virtualenv):
 
 The `tests` directory contains configuration for running sanity and integration tests using [`ansible-test`](https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html).
 
-Collection's integration test suite can be run with the commands (`zabbix_version=X.Y` will be expanded to `X.Y-latest`):
+Collection's integration test suite can be run with the commands.  
+`zabbix_version=X.Y` will be expanded to X.Y-latest and `zabbix_port=XY` is the mapping port for the container.  
+The port number that can be specified for `zabbix_port` depends on the version of Zabbix.  
+Check the [docker-compose](https://github.com/ansible-collections/community.zabbix/blob/master/docker-compose.yml) for details on the port numbers that can be specified for `zabbix_port`.
 
     export zabbix_version=X.Y
+    export zabbix_port=XY
     docker-compose up -d
     ansible-test integration -v --color --retry-on-error --continue-on-error --diff
     docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,4 +34,4 @@ services:
       - "zabbix-db"
       - "zabbix-server"
     ports:
-      - "8080:80"
+      - "8080:${zabbix_port}"


### PR DESCRIPTION
##### SUMMARY

This PR fixes `docker-compose` and `ansible-test.yml` to make zabbix 5.0 work with CI.  
It was changed container listen port from 80 to 8080 by Zabbix developer from zabbix version 5.0, so it is necessary to separate the listen port number according to the version of zabbix.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

github/workflows/ansible-test.yml  
docker-compose.yml  
README.md

##### ADDITIONAL INFORMATION