### PR TITLE
Updated zabbix_proxy module to support Zabbix 5.0

### DIFF
--- a/plugins/modules/zabbix_proxy.py
+++ b/plugins/modules/zabbix_proxy.py
@@ -204,6 +204,7 @@ RETURN = r''' # '''
 import traceback
 import atexit
 
+from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 try:
     from zabbix_api import ZabbixAPI
@@ -218,6 +219,7 @@ class Proxy(object):
     def __init__(self, module, zbx):
         self._module = module
         self._zapi = zbx
+        self._zbx_api_version = zbx.api_version()[:5]
         self.existing_data = None
 
     def proxy_exists(self, proxy_name):
@@ -277,6 +279,10 @@ class Proxy(object):
 
         for item in ['type', 'main']:
             new_interface.pop(item, False)
+
+        if LooseVersion(self._zbx_api_version) >= LooseVersion('5.0.0'):
+            if old_interface:
+                old_interface['details'] = str(old_interface['details'])
 
         final_interface = old_interface.copy()
         final_interface.update(new_interface)


### PR DESCRIPTION
##### SUMMARY
This PR is a modification of the `zabbix_proxy` module to support Zabbix 5.0.

Fixes https://github.com/ansible-collections/community.zabbix/issues/50

The interface configuration comparison process didn't work well because `details(list)` was converted to `str`.
I've fixed `details(list)` to convert to a string and compare.
Converting `details(list)` property to a string does not affect the creation or update of the `proxy(type=passive)` because the `details(list)` property is not required when creating or updating.

https://www.zabbix.com/documentation/current/manual/api/reference/proxy/object#proxy_interface

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/zabbix_proxy.py

##### ADDITIONAL INFORMATION

