### PR TITLE
updated ports for Zabbix 4.X containers to reflect changes in upstrea…

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -32,9 +32,9 @@ jobs:
           - version: "3.0"
             port: "80"
           - version: "4.0"
-            port: "80"
+            port: "8080"
           - version: "4.4"
-            port: "80"
+            port: "8080"
           - version: "5.0"
             port: "8080"
 


### PR DESCRIPTION
…m Dockerfiles

##### SUMMARY
New releases zabbix-web-nginx-pgsql docker images have changed `EXPOSE 80/TCP 443/TCP` to `EXPOSE 8080/TCP 8443/TCP`.

ref:
https://github.com/zabbix/zabbix-docker/blob/4.0/web-nginx-pgsql/ubuntu/Dockerfile
https://github.com/zabbix/zabbix-docker/blob/4.4/web-nginx-pgsql/ubuntu/Dockerfile

Dockerfile for 3.0 has the same change, but wasn't so far uploaded to Docker hub.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI