### PR TITLE
Fix maintenance description didn't update problem

### DIFF
--- a/plugins/modules/zabbix_maintenance.py
+++ b/plugins/modules/zabbix_maintenance.py
@@ -353,7 +353,8 @@ def main():
             sorted(host_ids) != sorted(maintenance["hostids"]) or
             str(maintenance_type) != maintenance["maintenance_type"] or
             str(int(start_time)) != maintenance["active_since"] or
-            str(int(start_time + period)) != maintenance["active_till"]
+            str(int(start_time + period)) != maintenance["active_till"] or
+            str(desc) != maintenance['description']
         ):
             if module.check_mode:
                 changed = True

--- a/tests/integration/targets/zabbix_maintenance/tasks/main.yml
+++ b/tests/integration/targets/zabbix_maintenance/tasks/main.yml
@@ -35,6 +35,37 @@
     that:
       - create_maintenance_host_name_result.changed is sameas true
 
+- name: "test - Create maintenance with a host_name param(again - expectations: no change will occur)"
+  zabbix_maintenance:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: maintenance
+    host_name: example
+    state: present
+  register: create_maintenance_host_name_again_result
+
+- assert:
+    that:
+      - create_maintenance_host_name_again_result.changed is sameas false
+
+- name: "test - Update maintenance with a desc param"
+  zabbix_maintenance:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: maintenance
+    host_name: example
+    desc: "test description"
+    state: present
+  register: update_maintenance_desc_result
+
+- debug: msg="{{ update_maintenance_desc_result }}"
+
+- assert:
+    that:
+      - update_maintenance_desc_result.changed is sameas true
+
 - name: "test - Update maintenance with a desc param(again - expectations: no change will occur)"
   zabbix_maintenance:
     server_url: "{{ zabbix_server_url }}"


### PR DESCRIPTION
##### SUMMARY

Fix a problem where the description would not be updated when the module was run continuously.

fixes: https://github.com/ansible-collections/community.zabbix/issues/64

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/zabbix_maintenance.py
tests/integration/targets/zabbix_maintenance/tasks/main.yml

##### ADDITIONAL INFORMATION
