### PR TITLE
Zabbix screen/add multi group filtering support

### DIFF
--- a/plugins/modules/zabbix_screen.py
+++ b/plugins/modules/zabbix_screen.py
@@ -37,9 +37,11 @@ options:
                 required: true
             host_group:
                 description:
-                    - Host group will be used for searching hosts.
+                    - Host group(s) will be used for searching hosts.
                     - Required if I(state=present).
-                type: str
+                type: list
+                elements: str
+                aliases: [ 'host_groups' ]
             state:
                 description:
                     - I(present) - Create a screen if it doesn't exist. If the screen already exists, the screen will be updated as needed.
@@ -145,6 +147,25 @@ EXAMPLES = r'''
         graph_width: 200
         graph_height: 100
   when: inventory_hostname==groups['group_name'][0]
+
+# Create/update using multiple hosts_groups. Hosts NOT present in all listed host_groups will be skipped.
+- name: Create new screen or update the existing screen's items for hosts in both given groups
+  local_action:
+    module: zabbix_screen
+    server_url: http://monitor.example.com
+    login_user: username
+    login_password: password
+    screens:
+      - screen_name: ExampleScreen1
+        host_group:
+          - Example group1
+          - Example group2
+        state: present
+        graph_names:
+          - Example graph1
+          - Example graph2
+        graph_width: 200
+        graph_height: 100
 '''
 
 
@@ -169,29 +190,33 @@ class Screen(object):
         self._module = module
         self._zapi = zbx
 
-    # get group id by group name
-    def get_host_group_id(self, group_name):
-        if group_name == "":
+    # get list of group ids by list of group names
+    def get_host_group_ids(self, group_names):
+        if not group_names:
             self._module.fail_json(msg="group_name is required")
-        hostGroup_list = self._zapi.hostgroup.get({'output': 'extend', 'filter': {'name': group_name}})
-        if len(hostGroup_list) < 1:
-            self._module.fail_json(msg="Host group not found: %s" % group_name)
+        hostGroup_list = self._zapi.hostgroup.get({'output': 'extend', 'filter': {'name': group_names}})
+        if not hostGroup_list:
+            self._module.fail_json(msg="Host group not found: {0}".format(group_names))
         else:
-            hostGroup_id = hostGroup_list[0]['groupid']
-            return hostGroup_id
+            hostGroup_ids = [g['groupid'] for g in hostGroup_list]
+            return hostGroup_ids
 
-    # get monitored host_id by host_group_id
-    def get_host_ids_by_group_id(self, group_id, sort):
-        host_list = self._zapi.host.get({'output': 'extend', 'groupids': group_id, 'monitored_hosts': 1})
-        if len(host_list) < 1:
-            self._module.fail_json(msg="No host in the group.")
+    # get monitored host_ids by host_group_ids
+    # (the hosts belonging to all given groups)
+    def get_host_ids_by_group_ids(self, group_ids, sort):
+        host_list = self._zapi.host.get({'output': 'extend', 'selectGroups': 'groupid', 'groupids': group_ids, 'monitored_hosts': 1})
+        if not host_list:
+            self._module.fail_json(msg="No hosts in the all group(s) with ids {0}".format(group_ids))
         else:
             if sort:
                 host_list = sorted(host_list, key=lambda name: name['name'])
             host_ids = []
-            for i in host_list:
-                host_id = i['hostid']
-                host_ids.append(host_id)
+            for host in host_list:
+                host_group_ids = [g['groupid'] for g in host['groups']]
+                # Check if all search group ids are in hosts group ids
+                if set(group_ids).issubset(host_group_ids):
+                    host_id = host['hostid']
+                    host_ids.append(host_id)
             return host_ids
 
     # get screen
@@ -352,7 +377,7 @@ def main():
                 required=True,
                 options=dict(
                     screen_name=dict(type='str', required=True),
-                    host_group=dict(type='str'),
+                    host_group=dict(type='list', aliases=['host_groups'], elements='str'),
                     state=dict(type='str', default='present', choices=['absent', 'present']),
                     graph_names=dict(type='list', elements='str'),
                     graph_width=dict(type='int', default=None),
@@ -418,9 +443,10 @@ def main():
             graphs_in_row = zabbix_screen['graphs_in_row']
             graph_width = zabbix_screen['graph_width']
             graph_height = zabbix_screen['graph_height']
-            host_group_id = screen.get_host_group_id(host_group)
-            hosts = screen.get_host_ids_by_group_id(host_group_id, sort)
-
+            host_group_ids = screen.get_host_group_ids(host_group)
+            hosts = screen.get_host_ids_by_group_ids(host_group_ids, sort)
+            if not hosts:
+                module.fail_json(msg="No hosts found belongin to all given groups: %s" % host_group)
             screen_item_id_list = []
             resource_id_list = []
 


### PR DESCRIPTION
##### SUMMARY

Allow host search/filter to be done using multiple groups.
Will give hosts that has link to all the given groups.

Instead of just picking hosts in host_group, use list of host_groups. This allows easily
to filter by multiple host groups.

Example use-case:
- Multiple different types of services that each type has separate measurements and groups on zabbix
- Multiple different environments that has similar type of services. All environments has related host groups on zabbix
-> By using multiple groups for host filtering screen creation, it is easily possible to create screens for all different type of services on for all different environments.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_screen

##### ADDITIONAL INFORMATION
xample Use case:
Hosts are grouped in zabbix by service type and by customer.
Need to create screen wich has all customer 1 service type A hosts.

The change allows the creation by giving 
host_groups: ['environment1','service type A']
host_groups: ['environment1','service type B']
host_groups: ['environment2','service type A']
host_groups: ['environment2','service type B']

Was originally created: https://github.com/ansible/ansible/pull/64428
