### PR TITLE
dump_template from zabbix_template module should not exit module even…

### DIFF
--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -472,9 +472,6 @@ class Template(object):
             return obj
 
     def dump_template(self, template_ids, template_type='json', omit_date=False):
-        if self._module.check_mode:
-            self._module.exit_json(changed=True)
-
         try:
             dump = self._zapi.configuration.export({'format': template_type, 'options': {'templates': template_ids}})
             if template_type == 'xml':


### PR DESCRIPTION
… in check mode

##### SUMMARY
Old behavior found in #49 

I believe that `zabbix_template` should return actual template with `state=dump` and `--check-mode`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/zabbix_template.py