### PR TITLE
Change module names to FQCN in the EXAMPLES block

### DIFF
--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -374,7 +374,7 @@ extends_documentation_fragment:
 EXAMPLES = '''
 # Trigger action with only one condition
 - name: Deploy trigger action
-  zabbix_action:
+  community.zabbix.zabbix_action:
     server_url: "http://zabbix.example.com/zabbix/"
     login_user: Admin
     login_password: secret
@@ -397,7 +397,7 @@ EXAMPLES = '''
 
 # Trigger action with multiple conditions and operations
 - name: Deploy trigger action
-  zabbix_action:
+  community.zabbix.zabbix_action:
     server_url: "http://zabbix.example.com/zabbix/"
     login_user: Admin
     login_password: secret
@@ -430,7 +430,7 @@ EXAMPLES = '''
 
 # Trigger action with recovery and acknowledge operations
 - name: Deploy trigger action
-  zabbix_action:
+  community.zabbix.zabbix_action:
     server_url: "http://zabbix.example.com/zabbix/"
     login_user: Admin
     login_password: secret

--- a/plugins/modules/zabbix_group.py
+++ b/plugins/modules/zabbix_group.py
@@ -50,7 +50,7 @@ EXAMPLES = r'''
 # Base create host groups example
 - name: Create host groups
   local_action:
-    module: zabbix_group
+    module: community.zabbix.zabbix_group
     server_url: http://monitor.example.com
     login_user: username
     login_password: password
@@ -62,7 +62,7 @@ EXAMPLES = r'''
 # Limit the Zabbix group creations to one host since Zabbix can return an error when doing concurrent updates
 - name: Create host groups
   local_action:
-    module: zabbix_group
+    module: community.zabbix.zabbix_group
     server_url: http://monitor.example.com
     login_user: username
     login_password: password

--- a/plugins/modules/zabbix_group_info.py
+++ b/plugins/modules/zabbix_group_info.py
@@ -45,7 +45,7 @@ extends_documentation_fragment:
 EXAMPLES = r'''
 - name: Get hostgroup info
   local_action:
-    module: zabbix_group_info
+    module: community.zabbix.zabbix_group_info
     server_url: http://monitor.example.com
     login_user: username
     login_password: password

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -355,7 +355,7 @@ extends_documentation_fragment:
 EXAMPLES = r'''
 - name: Create a new host or update an existing host's info
   local_action:
-    module: zabbix_host
+    module: community.zabbix.zabbix_host
     server_url: http://monitor.example.com
     login_user: username
     login_password: password
@@ -410,7 +410,7 @@ EXAMPLES = r'''
 
 - name: Update an existing host's TLS settings
   local_action:
-    module: zabbix_host
+    module: community.zabbix.zabbix_host
     server_url: http://monitor.example.com
     login_user: username
     login_password: password

--- a/plugins/modules/zabbix_host_events_info.py
+++ b/plugins/modules/zabbix_host_events_info.py
@@ -185,7 +185,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 - name: exclude machine if alert active on it
-  zabbix_host_events_info:
+  community.zabbix.zabbix_host_events_info:
       server_url: "{{ zabbix_url }}"
       login_user: "{{ lookup('env','ZABBIX_USER') }}"
       login_password: "{{ lookup('env','ZABBIX_PASSWORD') }}"

--- a/plugins/modules/zabbix_host_info.py
+++ b/plugins/modules/zabbix_host_info.py
@@ -70,7 +70,7 @@ extends_documentation_fragment:
 EXAMPLES = r'''
 - name: Get host info
   local_action:
-    module: zabbix_host_info
+    module: community.zabbix.zabbix_host_info
     server_url: http://monitor.example.com
     login_user: username
     login_password: password
@@ -82,7 +82,7 @@ EXAMPLES = r'''
 
 - name: Reduce host inventory information to provided keys
   local_action:
-    module: zabbix_host_info
+    module: community.zabbix.zabbix_host_info
     server_url: http://monitor.example.com
     login_user: username
     login_password: password

--- a/plugins/modules/zabbix_hostmacro.py
+++ b/plugins/modules/zabbix_hostmacro.py
@@ -59,7 +59,7 @@ extends_documentation_fragment:
 EXAMPLES = r'''
 - name: Create new host macro or update an existing macro's value
   local_action:
-    module: zabbix_hostmacro
+    module: community.zabbix.zabbix_hostmacro
     server_url: http://monitor.example.com
     login_user: username
     login_password: password
@@ -71,7 +71,7 @@ EXAMPLES = r'''
 # Values with curly brackets need to be quoted otherwise they will be interpreted as a dictionary
 - name: Create new host macro in Zabbix native format
   local_action:
-    module: zabbix_hostmacro
+    module: community.zabbix.zabbix_hostmacro
     server_url: http://monitor.example.com
     login_user: username
     login_password: password
@@ -82,7 +82,7 @@ EXAMPLES = r'''
 
 - name: Delete existing host macro
   local_action:
-    module: zabbix_hostmacro
+    module: community.zabbix.zabbix_hostmacro
     server_url: http://monitor.example.com
     login_user: username
     login_password: password

--- a/plugins/modules/zabbix_maintenance.py
+++ b/plugins/modules/zabbix_maintenance.py
@@ -75,7 +75,7 @@ notes:
 
 EXAMPLES = r'''
 - name: Create a named maintenance window for host www1 for 90 minutes
-  zabbix_maintenance:
+  community.zabbix.zabbix_maintenance:
     name: Update of www1
     host_name: www1.example.com
     state: present
@@ -85,7 +85,7 @@ EXAMPLES = r'''
     login_password: pAsSwOrD
 
 - name: Create a named maintenance window for host www1 and host groups Office and Dev
-  zabbix_maintenance:
+  community.zabbix.zabbix_maintenance:
     name: Update of www1
     host_name: www1.example.com
     host_groups:
@@ -97,7 +97,7 @@ EXAMPLES = r'''
     login_password: pAsSwOrD
 
 - name: Create a named maintenance window for hosts www1 and db1, without data collection.
-  zabbix_maintenance:
+  community.zabbix.zabbix_maintenance:
     name: update
     host_names:
       - www1.example.com
@@ -109,7 +109,7 @@ EXAMPLES = r'''
     login_password: pAsSwOrD
 
 - name: Remove maintenance window by name
-  zabbix_maintenance:
+  community.zabbix.zabbix_maintenance:
     name: Test1
     state: absent
     server_url: https://monitoring.example.com

--- a/plugins/modules/zabbix_map.py
+++ b/plugins/modules/zabbix_map.py
@@ -159,7 +159,7 @@ EXAMPLES = r'''
 ###
 ### Create Zabbix map "Demo Map" made of template 'map.j2'
 - name: Create Zabbix map
-  zabbix_map:
+  community.zabbix.zabbix_map:
     server_url: http://zabbix.example.com
     login_user: username
     login_password: password

--- a/plugins/modules/zabbix_mediatype.py
+++ b/plugins/modules/zabbix_mediatype.py
@@ -171,7 +171,7 @@ RETURN = r''' # '''
 
 EXAMPLES = r'''
 - name: 'Create an email mediatype with SMTP authentication'
-  zabbix_mediatype:
+  community.zabbix.zabbix_mediatype:
     name: "Ops email"
     server_url: "http://example.com/zabbix/"
     login_user: Admin
@@ -185,7 +185,7 @@ EXAMPLES = r'''
     password: 'smtp_pass'
 
 - name: 'Create a script mediatype'
-  zabbix_mediatype:
+  community.zabbix.zabbix_mediatype:
     name: "my script"
     server_url: "http://example.com/zabbix/"
     login_user: Admin
@@ -197,7 +197,7 @@ EXAMPLES = r'''
       - 'arg2'
 
 - name: 'Create a jabber mediatype'
-  zabbix_mediatype:
+  community.zabbix.zabbix_mediatype:
     name: "My jabber"
     server_url: "http://example.com/zabbix/"
     login_user: Admin
@@ -207,7 +207,7 @@ EXAMPLES = r'''
     password: 'jabber_pass'
 
 - name: 'Create an SMS mediatype'
-  zabbix_mediatype:
+  community.zabbix.zabbix_mediatype:
     name: "My SMS Mediatype"
     server_url: "http://example.com/zabbix/"
     login_user: Admin

--- a/plugins/modules/zabbix_proxy.py
+++ b/plugins/modules/zabbix_proxy.py
@@ -158,7 +158,7 @@ extends_documentation_fragment:
 EXAMPLES = r'''
 - name: Create or update a proxy with proxy type active
   local_action:
-    module: zabbix_proxy
+    module: community.zabbix.zabbix_proxy
     server_url: http://monitor.example.com
     login_user: username
     login_password: password
@@ -170,7 +170,7 @@ EXAMPLES = r'''
 
 - name: Create a new passive proxy using only it's IP
   local_action:
-    module: zabbix_proxy
+    module: community.zabbix.zabbix_proxy
     server_url: http://monitor.example.com
     login_user: username
     login_password: password
@@ -185,7 +185,7 @@ EXAMPLES = r'''
 
 - name: Create a new passive proxy using only it's DNS
   local_action:
-    module: zabbix_proxy
+    module: community.zabbix.zabbix_proxy
     server_url: http://monitor.example.com
     login_user: username
     login_password: password

--- a/plugins/modules/zabbix_screen.py
+++ b/plugins/modules/zabbix_screen.py
@@ -89,7 +89,7 @@ EXAMPLES = r'''
 # Create/update a screen.
 - name: Create a new screen or update an existing screen's items 5 in a row
   local_action:
-    module: zabbix_screen
+    module: community.zabbix.zabbix_screen
     server_url: http://monitor.example.com
     login_user: username
     login_password: password
@@ -107,7 +107,7 @@ EXAMPLES = r'''
 # Create/update multi-screen
 - name: Create two of new screens or update the existing screens' items
   local_action:
-    module: zabbix_screen
+    module: community.zabbix.zabbix_screen
     server_url: http://monitor.example.com
     login_user: username
     login_password: password
@@ -132,7 +132,7 @@ EXAMPLES = r'''
 # Limit the Zabbix screen creations to one host since Zabbix can return an error when doing concurrent updates
 - name: Create a new screen or update an existing screen's items
   local_action:
-    module: zabbix_screen
+    module: community.zabbix.zabbix_screen
     server_url: http://monitor.example.com
     login_user: username
     login_password: password
@@ -151,7 +151,7 @@ EXAMPLES = r'''
 # Create/update using multiple hosts_groups. Hosts NOT present in all listed host_groups will be skipped.
 - name: Create new screen or update the existing screen's items for hosts in both given groups
   local_action:
-    module: zabbix_screen
+    module: community.zabbix.zabbix_screen
     server_url: http://monitor.example.com
     login_user: username
     login_password: password

--- a/plugins/modules/zabbix_service.py
+++ b/plugins/modules/zabbix_service.py
@@ -78,7 +78,7 @@ EXAMPLES = '''
 # Creates a new Zabbix service
 - name: Manage services
   local_action:
-        module: zabbix_service
+        module: community.zabbix.zabbix_service
         server_url: "https://192.168.1.1"
         login_user: username
         login_password: password

--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -125,7 +125,7 @@ EXAMPLES = r'''
 ---
 - name: Create a new Zabbix template linked to groups, macros and templates
   local_action:
-    module: zabbix_template
+    module: community.zabbix.zabbix_template
     server_url: http://127.0.0.1
     login_user: username
     login_password: password
@@ -147,7 +147,7 @@ EXAMPLES = r'''
 
 - name: Unlink and clear templates from the existing Zabbix template
   local_action:
-    module: zabbix_template
+    module: community.zabbix.zabbix_template
     server_url: http://127.0.0.1
     login_user: username
     login_password: password
@@ -159,7 +159,7 @@ EXAMPLES = r'''
 
 - name: Import Zabbix templates from JSON
   local_action:
-    module: zabbix_template
+    module: community.zabbix.zabbix_template
     server_url: http://127.0.0.1
     login_user: username
     login_password: password
@@ -168,7 +168,7 @@ EXAMPLES = r'''
 
 - name: Import Zabbix templates from XML
   local_action:
-    module: zabbix_template
+    module: community.zabbix.zabbix_template
     server_url: http://127.0.0.1
     login_user: username
     login_password: password
@@ -176,7 +176,7 @@ EXAMPLES = r'''
     state: present
 
 - name: Import Zabbix template from Ansible dict variable
-  zabbix_template:
+  community.zabbix.zabbix_template:
     login_user: username
     login_password: password
     server_url: http://127.0.0.1
@@ -195,7 +195,7 @@ EXAMPLES = r'''
 
 - name: Configure macros on the existing Zabbix template
   local_action:
-    module: zabbix_template
+    module: community.zabbix.zabbix_template
     server_url: http://127.0.0.1
     login_user: username
     login_password: password
@@ -207,7 +207,7 @@ EXAMPLES = r'''
 
 - name: Delete Zabbix template
   local_action:
-    module: zabbix_template
+    module: community.zabbix.zabbix_template
     server_url: http://127.0.0.1
     login_user: username
     login_password: password
@@ -216,7 +216,7 @@ EXAMPLES = r'''
 
 - name: Dump Zabbix template as JSON
   local_action:
-    module: zabbix_template
+    module: community.zabbix.zabbix_template
     server_url: http://127.0.0.1
     login_user: username
     login_password: password
@@ -227,7 +227,7 @@ EXAMPLES = r'''
 
 - name: Dump Zabbix template as XML
   local_action:
-    module: zabbix_template
+    module: community.zabbix.zabbix_template
     server_url: http://127.0.0.1
     login_user: username
     login_password: password

--- a/plugins/modules/zabbix_template_info.py
+++ b/plugins/modules/zabbix_template_info.py
@@ -42,7 +42,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 - name: Get Zabbix template as JSON
-  zabbix_template_info:
+  community.zabbix.zabbix_template_info:
     server_url: "http://zabbix.example.com/zabbix/"
     login_user: admin
     login_password: secret
@@ -52,7 +52,7 @@ EXAMPLES = '''
   register: template_json
 
 - name: Get Zabbix template as XML
-  zabbix_template_info:
+  community.zabbix.zabbix_template_info:
     server_url: "http://zabbix.example.com/zabbix/"
     login_user: admin
     login_password: secret

--- a/plugins/modules/zabbix_user.py
+++ b/plugins/modules/zabbix_user.py
@@ -205,7 +205,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r'''
 - name: create of zabbix user.
-  zabbix_user:
+  community.zabbix.zabbix_user:
     server_url: "http://zabbix.example.com/zabbix/"
     login_user: Admin
     login_password: secret
@@ -239,7 +239,7 @@ EXAMPLES = r'''
     state: present
 
 - name: delete of zabbix user.
-  zabbix_user:
+  community.zabbix.zabbix_user:
     server_url: "http://zabbix.example.com/zabbix/"
     login_user: admin
     login_password: secret

--- a/plugins/modules/zabbix_user_info.py
+++ b/plugins/modules/zabbix_user_info.py
@@ -31,7 +31,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 - name: Get zabbix user info
-  zabbix_user_info:
+  community.zabbix.zabbix_user_info:
     server_url: "http://zabbix.example.com/zabbix/"
     login_user: admin
     login_password: secret

--- a/plugins/modules/zabbix_valuemap.py
+++ b/plugins/modules/zabbix_valuemap.py
@@ -59,7 +59,7 @@ RETURN = r'''
 EXAMPLES = r'''
 - name: Create a value map
   local_action:
-    module: zabbix_valuemap
+    module: community.zabbix.zabbix_valuemap
     server_url: http://zabbix.example.com
     login_user: username
     login_password: password


### PR DESCRIPTION
##### SUMMARY

This PR change module names to FQCN in the EXAMPLES block.
fixes: https://github.com/ansible-collections/community.zabbix/issues/44

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/zabbix_action.py
plugins/zabbix_group.py
plugins/zabbix_group_info.py
plugins/zabbix_host.py
plugins/zabbix_host_events_info.py
plugins/zabbix_host_info.py
plugins/zabbix_hostmacro.py
plugins/zabbix_maintenance.py
plugins/zabbix_map.py
plugins/zabbix_mediatype.py
plugins/zabbix_proxy.py
plugins/zabbix_screen.py
plugins/zabbix_service.py
plugins/zabbix_template.py
plugins/zabbix_template_info.py
plugins/zabbix_user.py
plugins/zabbix_user_info.py
plugins/zabbix_valuemap.py

##### ADDITIONAL INFORMATION

