### PR TITLE
fixed zabbix_action to search for mediatype by its name in Zabbix 4.4+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 #### Modules:
   - zabbix_action - fixed error on changed API fields for Zabbix 5.0 [GitHub Issue](https://github.com/rockaut/community.zabbix/edit/fix_92)
 
+### Bug Fixes:
+#### Modules:
+  - zabbix_action - now correctly selects mediatype for the (normal|recovery|update) operations with Zabbix 4.4 and newer. (PR [#90](https://github.com/ansible-collections/community.zabbix/pull/90))
+
 ## 0.2.0
 
 ### New roles:

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -492,6 +492,7 @@ except ImportError:
     HAS_ZABBIX_API = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from distutils.version import LooseVersion
 
 
 class Zapi(object):
@@ -501,6 +502,7 @@ class Zapi(object):
     def __init__(self, module, zbx):
         self._module = module
         self._zapi = zbx
+        self._zbx_api_version = zbx.api_version()[:5]
 
     def check_if_action_exists(self, name):
         """Check if action exists.
@@ -722,13 +724,18 @@ class Zapi(object):
             mediatype matching mediatype name
 
         """
+        if LooseVersion(self._zbx_api_version) >= LooseVersion('4.4'):
+            filter = {'name': [mediatype_name]}
+        else:
+            filter = {'description': [mediatype_name]}
+
         try:
             if str(mediatype_name).lower() == 'all':
                 return '0'
             mediatype_list = self._zapi.mediatype.get({
                 'output': 'extend',
                 'selectInventory': 'extend',
-                'filter': {'description': [mediatype_name]}
+                'filter': filter
             })
             if len(mediatype_list) < 1:
                 self._module.fail_json(msg="Media type not found: %s" % mediatype_name)
@@ -818,6 +825,7 @@ class Action(object):
         self._module = module
         self._zapi = zbx
         self._zapi_wrapper = zapi_wrapper
+        self._zbx_api_version = zbx.api_version()[:5]
 
     def _construct_parameters(self, **kwargs):
         """Construct parameters.
@@ -853,12 +861,12 @@ class Action(object):
         }
 
         if kwargs['event_source'] == 'trigger':
-            if float(self._zapi.api_version().rsplit('.', 1)[0]) >= 4.0:
+            if LooseVersion(self._zbx_api_version) >= LooseVersion('4.0'):
                 _params['pause_suppressed'] = '1' if kwargs['pause_in_maintenance'] else '0'
             else:
                 _params['maintenance_mode'] = '1' if kwargs['pause_in_maintenance'] else '0'
 
-        if float(self._zapi.api_version().rsplit('.', 1)[0]) >= 5.0:
+        if LooseVersion(self._zbx_api_version) >= LooseVersion('5.0'):
             # remove some fields regarding
             # https://www.zabbix.com/documentation/5.0/manual/api/reference/action/object
             _params.pop('def_longdata', None)


### PR DESCRIPTION
##### SUMMARY
Exactly the same behavior as fixed in #82 (zbx.mediatype) now uses `name` instead of `description`.

Fixes #75 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/zabbix_action.py

