### PR TITLE
Refactor GitHub action

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: ./ansible_collections/community/zabbix
 
   integration:
-    runs-on: ubuntu-latestDISABLE
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -63,36 +63,46 @@ jobs:
             port: "8080"
           - version: "5.0"
             port: "8080"
+        ansible:
+          # - stable-2.9 # Only if your collection supports Ansible 2.9
+          - stable-2.10
+          #- devel
+        python:
+          - 2.7
+          - 3.7
+          #- 3.8 blocked by https://github.com/ansible/ansible/pull/70155
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           path: ansible_collections/community/zabbix
 
-      - name: Set up Python 3.6
+      - name: Set up Python ${{ matrix.ansible }}
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python }}
+
+      - name: Install ansible-base (${{ matrix.ansible }})
+        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Install dependencies
         run: pip install docker-compose zabbix-api
 
-      - name: Install ansible-base (stable-2.10)
-        run: pip install https://github.com/ansible/ansible/archive/stable-2.10.tar.gz --disable-pip-version-check
-
       - name: Zabbix container server provisioning
         run: docker-compose up -d
+        working-directory: ./ansible_collections/community/zabbix
         env:
           zabbix_version: ${{ matrix.zabbix_container.version }}
           zabbix_port: ${{ matrix.zabbix_container.port }}
 
       - name: Run integration test
-        run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff --requirements --coverage
+        run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python }} --requirements --coverage
+        working-directory: ./ansible_collections/community/zabbix
 
       - name: Generate coverage report.
         run: ansible-test coverage xml -v --requirements --group-by command --group-by version
-        #working-directory: ./ansible_collections/community/zabbix
+        working-directory: ./ansible_collections/community/zabbix
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   sanity:
-    name: Sanity (${{ matrix.ansible }})
+    name: Sanity (${{ matrix.ansible }}) py${{ matrix.python }}
     strategy:
       matrix:
         ansible:
@@ -45,7 +45,8 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Run sanity tests
-        run: ansible-test sanity --docker -v --color --python 3.6
+        run: ansible-test sanity --docker -v --color --python ${{ matrix.python }}
+        working-directory: ./ansible_collections/community/zabbix
 
   integration:
     runs-on: ubuntu-latestDISABLE

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,5 +1,6 @@
 name: plugins
 on:
+# FIXME: Is `push` and `pull_request` right
   push:
     paths:
       - 'plugins/**'
@@ -21,20 +22,24 @@ jobs:
     strategy:
       matrix:
         ansible:
-        - stable-2.10
-        - devel
+          # - stable-2.9 # Only if your collection supports Ansible 2.9
+          - stable-2.10
+          - devel
+        python:
+          - 2.7
+          - 3.8
     runs-on: ubuntu-latest
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           path: ansible_collections/community/zabbix
 
-      - name: Set up Python 3.6
+      - name: Set up Python ${{ matrix.ansible }}
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python }}
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -43,7 +48,7 @@ jobs:
         run: ansible-test sanity --docker -v --color --python 3.6
 
   integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latestDISABLE
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -115,7 +115,7 @@ jobs:
       # As we need to connect to an existing docker container we can't use `--docker` here as the VMs would be on different
       # (non-routing) networks, so we run them locally and ensure any required dependencies are installed via `--requirements`
       - name: Run integration test
-        run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python }} --requirements --coverage --allow-unstable
+        run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python }} --requirements --coverage
         working-directory: ./ansible_collections/community/zabbix
 
         # ansible-test support producing code coverage date

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -2,15 +2,11 @@ name: plugins
 on:
 # Run CI against all pushes (direct commits) and Pull Requests
 # push: ensure we always run tests
-# pull_requests: only run if the PR contains one of the specified "paths"
+# pull_requests: skip if PR only modifies "./roles/"
   push:
   pull_request:
-    paths:
-      - 'plugins/**'
-      - 'tests/**'
-      - 'scripts/**'
-      - '.github/workflows/plugins.yml'
-      - 'docker-compose.yml'
+    ignore_paths:
+      - 'roles/**'
 
 jobs:
   sanity:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -27,7 +27,8 @@ jobs:
           - devel
         python:
           - 2.7
-          - 3.8
+          - 3.7
+          #- 3.8 blocked by https://github.com/ansible/ansible/pull/70155
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,20 +1,16 @@
 name: plugins
 on:
 # Run CI against all pushes (direct commits) and Pull Requests
+# push: ensure we always run tests
+# pull_requests: only run if the PR contains one of the specified "paths"
   push:
-#    paths:
-#      - 'plugins/**'
-#      - 'tests/**'
-#      - 'scripts/**'
-#      - '.github/workflows/plugins.yml'
-#      - 'docker-compose.yml'
   pull_request:
-#    paths:
-#      - 'plugins/**'
-#      - 'tests/**'
-#      - 'scripts/**'
-#      - '.github/workflows/plugins.yml'
-#      - 'docker-compose.yml'
+    paths:
+      - 'plugins/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - '.github/workflows/plugins.yml'
+      - 'docker-compose.yml'
 
 jobs:
   sanity:
@@ -22,7 +18,7 @@ jobs:
     strategy:
       matrix:
         ansible:
-          # It's important that Sanity is tested against all stable-X.Y branches 
+          # It's important that Sanity is tested against all stable-X.Y branches
           # Testing against `devel` may fail as new tests are added.
         # - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
@@ -32,7 +28,7 @@ jobs:
           - 3.7
           - 3.8
         exclude:
-          - python: 3.8  # blocked by https://github.com/ansible/ansible/pull/70155
+          - python: 3.8  # blocked by ansible/ansible#70155
     runs-on: ubuntu-latest
     steps:
 
@@ -84,7 +80,8 @@ jobs:
         python:
           - 2.7
           - 3.7
-          #- 3.8 blocked by https://github.com/ansible/ansible/pull/70155
+        exclude:
+          - python: 3.8  # blocked by ansible/ansible#70155
 
     steps:
       - name: Check out code

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -115,7 +115,7 @@ jobs:
       # As we need to connect to an existing docker container we can't use `--docker` here as the VMs would be on different
       # (non-routing) networks, so we run them locally and ensure any required dependencies are installed via `--requirements`
       - name: Run integration test
-        run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python }} --requirements --coverage
+        run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python }} --requirements --coverage --allow-unstable
         working-directory: ./ansible_collections/community/zabbix
 
         # ansible-test support producing code coverage date

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -29,10 +29,13 @@ jobs:
           - 2.7
           - 3.7
           - 3.8
-          exclude:
+        exclude:
           - python: 3.8  # blocked by https://github.com/ansible/ansible/pull/70155
     runs-on: ubuntu-latest
     steps:
+
+      # ansible-test requires the collection to be in a directory in the form
+      # .../ansible_collections/NAMESPACE/COLLECTION_NAME/
 
       - name: Check out code
         uses: actions/checkout@v2
@@ -40,19 +43,26 @@ jobs:
           path: ansible_collections/community/zabbix
 
       - name: Set up Python ${{ matrix.ansible }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
 
+      # Install the head of the given branch (devel, stable-2.10)
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
+      # run ansible-test sanity inside of Docker.
+      # The docker container has all the pinned dependencies that are required.
+      # Explicity specify the version of Python we want to test
       - name: Run sanity tests
         run: ansible-test sanity --docker -v --color --python ${{ matrix.python }}
         working-directory: ./ansible_collections/community/zabbix
 
+# FIXME IN TEMPLATE: UNIT TESTS WOULD GO HERE
+
   integration:
     runs-on: ubuntu-latest
+    name: I (${{ matrix.zabbix_container.version}}:${{ matrix.zabbix_container.port } Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}})
     strategy:
       fail-fast: false
       matrix:
@@ -91,6 +101,9 @@ jobs:
       - name: Install dependencies
         run: pip install docker-compose zabbix-api
 
+      # For Zabbix integration tests we need to test against different versions of
+      # the Zabbix server. To do this we spin up a Docker container using the `matrix`
+      # of version and ports specified earlier.
       - name: Zabbix container server provisioning
         run: docker-compose up -d
         working-directory: ./ansible_collections/community/zabbix
@@ -98,14 +111,19 @@ jobs:
           zabbix_version: ${{ matrix.zabbix_container.version }}
           zabbix_port: ${{ matrix.zabbix_container.port }}
 
+      # Run the integration tests
+      # As we need to connect to an existing docker container we can't use `--docker` here as the VMs would be on different
+      # (non-routing) networks, so we run them locally and ensure any required dependencies are installed via `--requirements`
       - name: Run integration test
         run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python }} --requirements --coverage
         working-directory: ./ansible_collections/community/zabbix
 
-      - name: Generate coverage report.
+        # ansible-test support producing code coverage date
+      - name: Generate coverage report
         run: ansible-test coverage xml -v --requirements --group-by command --group-by version
         working-directory: ./ansible_collections/community/zabbix
 
+      # See the repots at https://codecov.io/gh/ansible-collections/community.zabbix
       - uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: false

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -22,7 +22,9 @@ jobs:
     strategy:
       matrix:
         ansible:
-          # - stable-2.9 # Only if your collection supports Ansible 2.9
+          # It's important that Sanity is tested against all stable-X.Y branches 
+          # Testing against `devel` may fail as new tests are added.
+        # - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
           - devel
         python:
@@ -78,7 +80,7 @@ jobs:
         ansible:
           # - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
-          #- devel
+          - devel
         python:
           - 2.7
           - 3.7

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,24 +1,24 @@
 name: plugins
 on:
-# FIXME: Is `push` and `pull_request` right
+# Run CI against all pushes (direct commits) and Pull Requests
   push:
-    paths:
-      - 'plugins/**'
-      - 'tests/**'
-      - 'scripts/**'
-      - '.github/workflows/plugins.yml'
-      - 'docker-compose.yml'
+#    paths:
+#      - 'plugins/**'
+#      - 'tests/**'
+#      - 'scripts/**'
+#      - '.github/workflows/plugins.yml'
+#      - 'docker-compose.yml'
   pull_request:
-    paths:
-      - 'plugins/**'
-      - 'tests/**'
-      - 'scripts/**'
-      - '.github/workflows/plugins.yml'
-      - 'docker-compose.yml'
+#    paths:
+#      - 'plugins/**'
+#      - 'tests/**'
+#      - 'scripts/**'
+#      - '.github/workflows/plugins.yml'
+#      - 'docker-compose.yml'
 
 jobs:
   sanity:
-    name: Sanity (${{ matrix.ansible }}) py${{ matrix.python }}
+    name: Sanity (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
       matrix:
         ansible:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -28,7 +28,9 @@ jobs:
         python:
           - 2.7
           - 3.7
-          #- 3.8 blocked by https://github.com/ansible/ansible/pull/70155
+          - 3.8
+          exclude:
+          - python: 3.8  # blocked by https://github.com/ansible/ansible/pull/70155
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -56,7 +56,7 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    name: I (${{ matrix.zabbix_container.version}}:${{ matrix.zabbix_container.port }} Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}})
+    name: I (${{ matrix.zabbix_container.version}} Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -81,7 +81,7 @@ jobs:
           path: ansible_collections/community/zabbix
 
       - name: Set up Python ${{ matrix.ansible }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -62,7 +62,7 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    name: I (${{ matrix.zabbix_container.version}}:${{ matrix.zabbix_container.port } Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}})
+    name: I (${{ matrix.zabbix_container.version}}:${{ matrix.zabbix_container.port }} Ⓐ${{ matrix.ansible }}+py${{ matrix.python }}})
     strategy:
       fail-fast: false
       matrix:

--- a/tests/integration/targets/test_zabbix_maintenance/aliases
+++ b/tests/integration/targets/test_zabbix_maintenance/aliases
@@ -1,0 +1,1 @@
+unstable

--- a/tests/integration/targets/test_zabbix_maintenance/aliases
+++ b/tests/integration/targets/test_zabbix_maintenance/aliases
@@ -1,1 +1,1 @@
-unstable
+disabled


### PR DESCRIPTION
##### SUMMARY

Follow on from https://github.com/ansible-collections/community.zabbix/pull/105

My aim in refactoring this is we can use it to replace https://github.com/ansible-collections/collection_template/tree/master/.github/workflows which is how new Collection repos will be created
- [X] Full use of `matrix` to make it easier to update in the future
- [X] Move to `actions/checkout@v2`
- [x] Review `on` `push` and `pull_request`, not sure why we have both
- [x] Zabbix team to decide which mix of Python/Zabbix/Ansible version to test for integration
- [x] Add more comments
- [ ] Add `/rebase` workflow