### PR TITLE
add new zabbix module - zabbix_discovery_rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## devel
 
-### New roles:
+### New modules:
   - `zabbix_discovery_rule` - Create/delete/update Zabbix discovery rules. (PR [#111](https://github.com/ansible-collections/community.zabbix/pull/111))
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## devel
 
+### New roles:
+  - `zabbix_discovery_role` - Create/delete/update Zabbix discovery rules
+
 ### Improvements
 #### Modules:
   - zabbix_action - fixed error on changed API fields `*default_message` and `*default_subject` for Zabbix 5.0 (PR [#92](https://github.com/ansible-collections/community.zabbix/pull/92)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## devel
 
 ### New roles:
-  - `zabbix_discovery_role` - Create/delete/update Zabbix discovery rules. (PR [#111](https://github.com/ansible-collections/community.zabbix/pull/111))
+  - `zabbix_discovery_rule` - Create/delete/update Zabbix discovery rules. (PR [#111](https://github.com/ansible-collections/community.zabbix/pull/111))
 
 ### Improvements
 #### Modules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## devel
 
 ### New roles:
-  - `zabbix_discovery_role` - Create/delete/update Zabbix discovery rules
+  - `zabbix_discovery_role` - Create/delete/update Zabbix discovery rules. (PR [#111](https://github.com/ansible-collections/community.zabbix/pull/111))
 
 ### Improvements
 #### Modules:

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -144,6 +144,7 @@ options:
                     - "1 - (default) DNS"
                     - "2 - IP"
                     - "3 - discovery value of this check"
+                    - Options is available since Zabbix 4.4
                 type: int
                 default: 1
                 choices: [1, 2, 3]
@@ -155,6 +156,7 @@ options:
                     - "1 - DNS"
                     - "2 - IP"
                     - "3 - discovery value of this check"
+                    - Options is available since Zabbix 4.4
                 type: int
                 default: 0
                 choices: [0, 1, 2, 3]
@@ -164,6 +166,8 @@ options:
     delay:
         description:
             - Execution interval of the discovery rule.
+            - Accepts only seconds in int for <= Zabbix 3.2
+            - Accepts seconds, time unit with suffix and user macro since => Zabbix 3.4
         type: str
         default: "1h"
     proxy:

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -231,10 +231,10 @@ EXAMPLES = r'''
           key: iso.3.6.1.2.1.1.1.0
           snmpv3_contextname: "ContextName"
           snmpv3_securityname: "SecurityName"
-          snmpv3_securitylevel: 2
-          snmpv3_authprotocol: 1
+          snmpv3_securitylevel: "authPriv"
+          snmpv3_authprotocol: "SHA"
           snmpv3_authpassphrase: "SeCrEt"
-          snmpv3_privprotocol: 1
+          snmpv3_privprotocol: "AES"
           snmpv3_privpassphrase: "TopSecret"
           uniq: no
           host_source: "DNS"

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -46,29 +46,44 @@ options:
                 description:
                     - Type of check.
                     - "Possible values:"
-                    - "0 - SSH"
-                    - "1 - LDAP"
-                    - "2 - SMTP"
-                    - "3 - FTP"
-                    - "4 - HTTP"
-                    - "5 - POP"
-                    - "6 - NNTP"
-                    - "7 - IMAP"
-                    - "8 - TCP"
-                    - "9 - Zabbix agent"
-                    - "10 - SNMPv1 agent"
-                    - "11 - SNMPv2 agent"
-                    - "12 - ICMP ping"
-                    - "13 - SNMPv3 agent"
-                    - "14 - HTTPS"
-                    - "15 - Telnet"
-                type: int
-                choices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+                    - ICMP
+                    - SSH
+                    - LDAP
+                    - SMTP
+                    - FTP
+                    - HTTP
+                    - POP
+                    - NNTP
+                    - IMAP
+                    - TCP
+                    - Zabbix
+                    - SNMPv1
+                    - SNMPv2
+                    - SNMPv3
+                    - HTTPS
+                    - Telnet
+                type: str
+                choices: ['SSH',
+                          'LDAP',
+                          'SMTP',
+                          'FTP',
+                          'HTTP',
+                          'POP',
+                          'NNTP',
+                          'IMAP',
+                          'TCP',
+                          'Zabbix',
+                          'SNMPv1',
+                          'SNMPv2',
+                          'ICMP',
+                          'SNMPv3',
+                          'HTTPS',
+                          'Telnet']
             ports:
                 description:
                     - One or several port ranges to check separated by commas. Used for all checks except for ICMP.
                 type: str
-            key_:
+            key:
                 description:
                     - "The value of this property differs depending on the type of the check:"
                     - "- key to query for Zabbix agent checks"
@@ -87,10 +102,10 @@ options:
                 description:
                     - Authentication protocol used for SNMPv3 agent checks with security level set to authNoPriv or authPriv.
                     - "Possible values:"
-                    - "0 - (default) MD5"
-                    - "1 - SHA"
-                type: int
-                choices: [0, 1]
+                    - MD5
+                    - SHA
+                type: str
+                choices: ["MD5", "SHA"]
             snmpv3_contextname:
                 description:
                     - SNMPv3 context name. Used only by SNMPv3 checks.
@@ -103,19 +118,19 @@ options:
                 description:
                     - Privacy protocol used for SNMPv3 agent checks with security level set to authPriv.
                     - "Possible values:"
-                    - "0 - (default) DES"
-                    - "1 - AES"
-                type: int
-                choices: [0, 1]
+                    - DES
+                    - AES
+                type: str
+                choices: ["DES", "AES"]
             snmpv3_securitylevel:
                 description:
                     - Security level used for SNMPv3 agent checks.
                     - "Possible values:"
-                    - "0 - noAuthNoPriv"
-                    - "1 - authNoPriv"
-                    - "2 - authPriv"
-                type: int
-                choices: [0, 1, 2]
+                    - noAuthNoPriv
+                    - authNoPriv
+                    - authPriv
+                type: str
+                choices: ["noAuthNoPriv", "authNoPriv", "authPriv"]
             snmpv3_securityname:
                 description:
                     - Security name used for SNMPv3 agent checks.
@@ -126,34 +141,33 @@ options:
                     - Only a single unique check can be configured for a discovery rule.
                     - Used for Zabbix agent, SNMPv1, SNMPv2 and SNMPv3 agent checks.
                     - "Possible values:"
-                    - "0 - (default) do not use this check as a uniqueness criteria"
-                    - "1 - use this check as a uniqueness criteria"
-                type: int
-                default: 0
-                choices: [0, 1]
+                    - "no - (default) do not use this check as a uniqueness criteria"
+                    - "yes - use this check as a uniqueness criteria"
+                type: bool
+                default: no
             host_source:
                 description:
                     - Source for host name.
                     - "Possible values:"
-                    - "1 - (default) DNS"
-                    - "2 - IP"
-                    - "3 - discovery value of this check"
+                    - "DNS (default)"
+                    - "IP"
+                    - "discovery - discovery value of this check"
                     - Options is available since Zabbix 4.4
-                type: int
-                default: 1
-                choices: [1, 2, 3]
+                type: str
+                default: "DNS"
+                choices: ["DNS", "IP", "discovery"]
             name_source:
                 description:
                     - Source for visible name.
                     - "Possible values:"
-                    - "0 - (default) not specified"
-                    - "1 - DNS"
-                    - "2 - IP"
-                    - "3 - discovery value of this check"
+                    - "none - (default) not specified"
+                    - "DNS"
+                    - "IP"
+                    - "discovery - discovery value of this check"
                     - Options is available since Zabbix 4.4
-                type: int
-                default: 0
-                choices: [0, 1, 2, 3]
+                type: str
+                default: "None"
+                choices: ["None", "DNS", "IP", "discovery"]
         type: list
         elements: dict
         aliases: [ "dcheck" ]
@@ -172,11 +186,11 @@ options:
         description:
             - Whether the discovery rule is enabled.
             - "Possible values:"
-            - "0 - (default) enabled"
-            - "1 - disabled"
-        type: int
-        default: 0
-        choices: [0, 1]
+            - enabled (default)
+            - disabled
+        type: str
+        default: "enabled"
+        choices: ["enabled", "disabled"]
 notes:
     - Only Zabbix >= 4.0 is supported.
 extends_documentation_fragment:
@@ -194,12 +208,37 @@ EXAMPLES = r'''
     state: present
     iprange: 192.168.1.1-255
     dchecks:
-        - type: 12
-        - type: 9
-          key_: "system.hostname"
+        - type: ICMP
+        - type: Zabbix
+          key: "system.hostname"
           ports: 10050
-          uniq: 1
-          host_source: 3
+          uniq: yes
+          host_source: "discovery"
+
+# Base update (add new dcheck) discovery rule example
+- name: Create discovery rule with ICMP and zabbix agent checks
+  zabbix_discovery_rule:
+    server_url: "http://zabbix.example.com/zabbix/"
+    login_user: admin
+    login_password: secret
+    name: ACME
+    state: present
+    iprange: 192.168.1.1-255
+    dchecks:
+        - type: SNMPv3
+          snmp_community: CUSTOMER@snmp3-readonly
+          ports: "161"
+          key: iso.3.6.1.2.1.1.1.0
+          snmpv3_contextname: "ContextName"
+          snmpv3_securityname: "SecurityName"
+          snmpv3_securitylevel: 2
+          snmpv3_authprotocol: 1
+          snmpv3_authpassphrase: "SeCrEt"
+          snmpv3_privprotocol: 1
+          snmpv3_privpassphrase: "TopSecret"
+          uniq: no
+          host_source: "DNS"
+          name_source: "None"
 
 # Base delete discovery rule example
 - name: Delete discovery rule
@@ -239,10 +278,8 @@ class Zapi(object):
 
     def check_if_drule_exists(self, name):
         """Check if discovery rule exists.
-
         Args:
             name: Name of the discovery rule.
-
         Returns:
             The return value. True for success, False otherwise.
         """
@@ -260,10 +297,8 @@ class Zapi(object):
 
     def get_drule_by_drule_name(self, name):
         """Get discovery rule by discovery rule name
-
         Args:
             name: discovery rule name.
-
         Returns:
             discovery rule matching discovery rule name
         """
@@ -282,10 +317,8 @@ class Zapi(object):
 
     def get_proxy_by_proxy_name(self, proxy_name):
         """Get proxy by proxy name
-
         Args:
             proxy_name: proxy name.
-
         Returns:
             proxy matching proxy name
         """
@@ -315,10 +348,8 @@ class Dchecks(object):
     def construct_the_data(self, _dchecks):
         """Construct the user defined discovery check to fit the Zabbix API
         requirements
-
         Args:
             _dchecks: discovery checks to construct
-
         Returns:
             dict: user defined discovery checks
         """
@@ -327,34 +358,75 @@ class Dchecks(object):
         constructed_data = []
         for check in _dchecks:
             constructed_check = {
-                'type': check.get('type'),
-                'uniq': check.get('uniq')
+                'type': to_numeric_value([
+                    'SSH',
+                    'LDAP',
+                    'SMTP',
+                    'FTP',
+                    'HTTP',
+                    'POP',
+                    'NNTP',
+                    'IMAP',
+                    'TCP',
+                    'Zabbix',
+                    'SNMPv1',
+                    'SNMPv2',
+                    'ICMP',
+                    'SNMPv3',
+                    'HTTPS',
+                    'Telnet'], check.get('type')
+                ),
+                'uniq': int(check.get('uniq'))
+                # 'uniq': to_numeric_value([
+                #     'False',
+                #     'True'], check.get('uniq')
+                # )
             }
             if LooseVersion(self._zbx_api_version) >= LooseVersion('4.4'):
                 constructed_check.update({
-                    'host_source': check.get('host_source'),
-                    'name_source': check.get('name_source')
+                    'host_source': to_numeric_value([
+                        'None',
+                        'DNS',
+                        'IP',
+                        'discovery'], check.get('host_source')
+                    ),
+                    'name_source': to_numeric_value([
+                        'None',
+                        'DNS',
+                        'IP',
+                        'discovery'], check.get('name_source')
+                    )
                 })
             if constructed_check['type'] in (0, 1, 2, 3, 4, 5, 6, 7, 8, 14, 15):
                 constructed_check['ports'] = check.get('ports')
             if constructed_check['type'] == 9:
                 constructed_check['ports'] = check.get('ports')
-                constructed_check['key_'] = check.get('key_')
+                constructed_check['key_'] = check.get('key')
             if constructed_check['type'] in (10, 11):
                 constructed_check['ports'] = check.get('ports')
                 constructed_check['snmp_community'] = check.get('snmp_community')
-                constructed_check['key_'] = check.get('key_')
+                constructed_check['key_'] = check.get('key')
             if constructed_check['type'] == 13:
                 constructed_check['ports'] = check.get('ports')
-                constructed_check['key_'] = check.get('key_')
+                constructed_check['key_'] = check.get('key')
                 constructed_check['snmpv3_contextname'] = check.get('snmpv3_contextname')
                 constructed_check['snmpv3_securityname'] = check.get('snmpv3_securityname')
-                constructed_check['snmpv3_securitylevel'] = check.get('snmpv3_securitylevel')
-                if check.get('snmpv3_securitylevel') in (1, 2):
-                    constructed_check['snmpv3_authprotocol'] = check.get('snmpv3_authprotocol')
+                constructed_check['snmpv3_securitylevel'] = to_numeric_value([
+                    'noAuthNoPriv',
+                    'authNoPriv',
+                    'authPriv'], check.get('snmpv3_securitylevel')
+                )
+                if constructed_check['snmpv3_securitylevel'] in (1, 2):
+                    constructed_check['snmpv3_authprotocol'] = to_numeric_value([
+                        'MD5',
+                        'SHA'], check.get('snmpv3_authprotocol')
+                    )
                     constructed_check['snmpv3_authpassphrase'] = check.get('snmpv3_authpassphrase')
-                if check.get('snmpv3_securitylevel') == 2:
-                    constructed_check['snmpv3_privprotocol'] = check.get('snmpv3_privprotocol')
+                if constructed_check['snmpv3_securitylevel'] == 2:
+                    constructed_check['snmpv3_privprotocol'] = to_numeric_value([
+                        'DES',
+                        'AES'], check.get('snmpv3_privprotocol')
+                    )
                     constructed_check['snmpv3_privpassphrase'] = check.get('snmpv3_privpassphrase')
             constructed_data.append(constructed_check)
         return cleanup_data(constructed_data)
@@ -368,10 +440,8 @@ class DiscoveryRule(object):
 
     def _construct_parameters(self, **kwargs):
         """Construct parameters.
-
         Args:
             **kwargs: Arbitrary keyword parameters.
-
         Returns:
             dict: dictionary of specified parameters
         """
@@ -379,7 +449,10 @@ class DiscoveryRule(object):
             'name': kwargs['name'],
             'iprange': ','.join(kwargs['iprange']),
             'delay': kwargs['delay'],
-            'status': kwargs['status'],
+            'status': to_numeric_value([
+                'enabled',
+                'disabled'], kwargs['status']
+            ),
             'dchecks': kwargs['dchecks']
         }
         if kwargs['proxy']:
@@ -388,10 +461,8 @@ class DiscoveryRule(object):
 
     def check_difference(self, **kwargs):
         """Check difference between discovery rule and user specified parameters.
-
         Args:
             **kwargs: Arbitrary keyword parameters.
-
         Returns:
             dict: dictionary of differences
         """
@@ -405,10 +476,8 @@ class DiscoveryRule(object):
 
     def update_drule(self, **kwargs):
         """Update discovery rule.
-
         Args:
             **kwargs: Arbitrary keyword parameters.
-
         Returns:
             drule: updated discovery rule
         """
@@ -422,10 +491,8 @@ class DiscoveryRule(object):
 
     def add_drule(self, **kwargs):
         """Add discovery rule
-
         Args:
             **kwargs: Arbitrary keyword parameters
-
         Returns:
             drule: created discovery rule
         """
@@ -440,10 +507,8 @@ class DiscoveryRule(object):
 
     def delete_drule(self, drule_id):
         """Delete discovery rule.
-
         Args:
             drule_id: Discovery rule id
-
         Returns:
             drule: deleted discovery rule
         """
@@ -459,7 +524,6 @@ def convert_unicode_to_str(data):
     """Converts unicode objects to strings in dictionary
     args:
         data: unicode object
-
     Returns:
         dict: strings in dictionary
     """
@@ -482,7 +546,6 @@ def compare_lists(l1, l2, diff_dict):
         l1: first list to compare
         l2: second list to compare
         diff_dict: dictionary to store the difference
-
     Returns:
         dict: items that are different
     """
@@ -510,7 +573,6 @@ def compare_dictionaries(d1, d2, diff_dict):
         d1: first dictionary to compare
         d2: second dictionary to compare
         diff_dict: dictionary to store the difference
-
     Returns:
         dict: items that are different
     """
@@ -542,7 +604,6 @@ def cleanup_data(obj):
     """Removes the None values from the object and returns the object
     Args:
         obj: object to cleanup
-
     Returns:
        object: cleaned object
     """
@@ -553,6 +614,19 @@ def cleanup_data(obj):
                          for k, v in obj.items() if k is not None and v is not None)
     else:
         return obj
+
+
+def to_numeric_value(strs, value):
+    """Converts string values to integers
+    Args:
+        value: string value
+    Returns:
+        int: converted integer
+    """
+    strs = [s.lower() if isinstance(s, str) else s for s in strs]
+    value = value.lower()
+    tmp_dict = dict(zip(strs, list(range(len(strs)))))
+    return tmp_dict[value]
 
 
 def main():
@@ -574,43 +648,60 @@ def main():
                 aliases=['dcheck'],
                 elements='dict',
                 options=dict(
-                    type=dict(type='int', choices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+                    type=dict(type='str', choices=[
+                        'SSH',
+                        'LDAP',
+                        'SMTP',
+                        'FTP',
+                        'HTTP',
+                        'POP',
+                        'NNTP',
+                        'IMAP',
+                        'TCP',
+                        'Zabbix',
+                        'SNMPv1',
+                        'SNMPv2',
+                        'ICMP',
+                        'SNMPv3',
+                        'HTTPS',
+                        'Telnet']
+                    ),
                     ports=dict(type='str'),
-                    key_=dict(type='str'),
+                    key=dict(type='str'),
                     snmp_community=dict(type='str'),
                     snmpv3_authpassphrase=dict(type='str'),
-                    snmpv3_authprotocol=dict(type='int', choices=[0, 1]),
+                    snmpv3_authprotocol=dict(type='str', choices=['MD5', 'SHA']),
                     snmpv3_contextname=dict(type='str'),
                     snmpv3_privpassphrase=dict(type='str'),
-                    snmpv3_privprotocol=dict(type='int', choices=[0, 1]),
-                    snmpv3_securitylevel=dict(type='int', choices=[0, 1, 2]),
+                    snmpv3_privprotocol=dict(type='str', choices=['DES', 'AES']),
+                    snmpv3_securitylevel=dict(type='str', choices=['noAuthNoPriv', 'authNoPriv', 'authPriv']),
                     snmpv3_securityname=dict(type='str'),
-                    uniq=dict(type='int', choices=[0, 1], default=0),
-                    host_source=dict(type='int', choices=[1, 2, 3], default=1),
-                    name_source=dict(type='int', choices=[0, 1, 2, 3], default=0)
+                    uniq=dict(type='bool', default=False),
+                    host_source=dict(type='str', choices=['DNS', 'IP', 'discovery'], default='DNS'),
+                    name_source=dict(type='str', choices=['None', 'DNS', 'IP', 'discovery'], default='None')
                 ),
                 required_if=[
-                    ['type', 0, ['ports']],
-                    ['type', 1, ['ports']],
-                    ['type', 2, ['ports']],
-                    ['type', 3, ['ports']],
-                    ['type', 4, ['ports']],
-                    ['type', 5, ['ports']],
-                    ['type', 6, ['ports']],
-                    ['type', 7, ['ports']],
-                    ['type', 8, ['ports']],
-                    ['type', 9, ['ports', 'key_']],
-                    ['type', 10, ['ports', 'key_', 'snmp_community']],
-                    ['type', 11, ['ports', 'key_', 'snmp_community']],
-                    ['type', 13, ['ports', 'key_']],
-                    ['type', 14, ['ports']],
-                    ['type', 15, ['ports']],
-                    ['snmpv3_securitylevel', 2, ['snmpv3_privpassphrase']]
+                    ['type', 'SSH', ['ports']],
+                    ['type', 'LDAP', ['ports']],
+                    ['type', 'SMTP', ['ports']],
+                    ['type', 'FTP', ['ports']],
+                    ['type', 'HTTP', ['ports']],
+                    ['type', 'POP', ['ports']],
+                    ['type', 'NNTP', ['ports']],
+                    ['type', 'IMAP', ['ports']],
+                    ['type', 'TCP', ['ports']],
+                    ['type', 'Zabbix', ['ports', 'key']],
+                    ['type', 'SNMPv1', ['ports', 'key', 'snmp_community']],
+                    ['type', 'SNMPv2', ['ports', 'key', 'snmp_community']],
+                    ['type', 'SNMPv3', ['ports', 'key']],
+                    ['type', 'HTTPS', ['ports']],
+                    ['type', 'Telnet', ['ports']],
+                    ['snmpv3_securitylevel', 'authPriv', ['snmpv3_privpassphrase']]
                 ]
             ),
             delay=dict(type='str', required=False, default='1h'),
             proxy=dict(type='str', required=False, default=None),
-            status=dict(type='int', default=0, choices=[0, 1])
+            status=dict(type='str', default="enabled", choices=["enabled", "disabled"])
         ),
         required_if=[
             ['state', 'present', ['name', 'iprange', 'dchecks']],

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -24,7 +24,7 @@ description:
 author:
     - "Tobias Birkefeld (@tcraxs)"
 requirements:
-    - zabbix-api
+    - "zabbix-api >= 0.5.4"
 options:
     state:
         description:

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -18,8 +18,9 @@ DOCUMENTATION = r'''
 module: zabbix_discovery_rule
 short_description: Create/delete/update Zabbix discovery rules
 description:
-   - Create discovery rules if they do not exist.
-   - Delete existing discovery rules if they exist.
+   - Create discovery rule.
+   - Delete existing discovery rule.
+   - Update existing discovery rule with new options.
 author:
     - "Tobias Birkefeld (@tcraxs)"
 requirements:

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -183,9 +183,10 @@ options:
         type: int
         default: 0
         choices: [0, 1]
-
+notes:
+    - Only Zabbix >= 4.0 is supported.
 extends_documentation_fragment:
-- community.zabbix.zabbix
+    - community.zabbix.zabbix
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -1,17 +1,11 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-#
-# (c) 2013-2014, Epic Games, Inc.
+
+# Copyright: (c) 2020, Tobias Birkefeld (@tcraxs) <t@craxs.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
 
 DOCUMENTATION = r'''
 ---

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -45,23 +45,6 @@ options:
             type:
                 description:
                     - Type of check.
-                    - "Possible values:"
-                    - ICMP
-                    - SSH
-                    - LDAP
-                    - SMTP
-                    - FTP
-                    - HTTP
-                    - POP
-                    - NNTP
-                    - IMAP
-                    - TCP
-                    - Zabbix
-                    - SNMPv1
-                    - SNMPv2
-                    - SNMPv3
-                    - HTTPS
-                    - Telnet
                 type: str
                 choices: ['SSH',
                           'LDAP',
@@ -174,8 +157,7 @@ options:
     delay:
         description:
             - Execution interval of the discovery rule.
-            - Accepts only seconds in int for <= Zabbix 3.2
-            - Accepts seconds, time unit with suffix and user macro since => Zabbix 3.4
+            - Accepts seconds, time unit with suffix and user macro.
         type: str
         default: "1h"
     proxy:

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -1,0 +1,686 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# (c) 2013-2014, Epic Games, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: zabbix_discovery_rule
+short_description: Create/delete/update Zabbix discovery rules
+description:
+   - Create discovery rules if they do not exist.
+   - Delete existing discovery rules if they exist.
+author:
+    - "Tobias Birkefeld (@tcraxs)"
+requirements:
+    - zabbix-api
+options:
+    state:
+        description:
+            - Create or delete user group.
+        required: false
+        type: str
+        default: "present"
+        choices: [ "present", "absent" ]
+    name:
+        description:
+            - Name of the discovery rule.
+        required: true
+        type: str
+    iprange:
+        description:
+            - One or several IP ranges to check separated by commas.
+        required: true
+        type: list
+        elements: str
+    dchecks:
+        description:
+            - List of dictionaries of discovery check objects.
+            - For more information, review discovery check object documentation at
+              U(https://www.zabbix.com/documentation/current/manual/api/reference/dcheck/object)
+        required: true
+        suboptions:
+            type:
+                description:
+                    - Type of check.
+                    - "Possible values:"
+                    - "0 - SSH"
+                    - "1 - LDAP"
+                    - "2 - SMTP"
+                    - "3 - FTP"
+                    - "4 - HTTP"
+                    - "5 - POP"
+                    - "6 - NNTP"
+                    - "7 - IMAP"
+                    - "8 - TCP"
+                    - "9 - Zabbix agent"
+                    - "10 - SNMPv1 agent"
+                    - "11 - SNMPv2 agent"
+                    - "12 - ICMP ping"
+                    - "13 - SNMPv3 agent"
+                    - "14 - HTTPS"
+                    - "15 - Telnet"
+                type: int
+                choices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+                required: true
+            ports:
+                description:
+                    - One or several port ranges to check separated by commas. Used for all checks except for ICMP.
+                type: str
+            key_:
+                description:
+                    - "The value of this property differs depending on the type of the check:"
+                    - "- key to query for Zabbix agent checks"
+                    - "- SNMP OID for SNMPv1, SNMPv2 and SNMPv3 checks"
+                type: str
+            snmp_community:
+                description:
+                    - SNMP community.
+                    - Required for SNMPv1 and SNMPv2 agent checks.
+                type: str
+            snmpv3_authpassphrase:
+                description:
+                    - Authentication passphrase used for SNMPv3 agent checks with security level set to authNoPriv or authPriv.
+                type: str
+            snmpv3_authprotocol:
+                description:
+                    - Authentication protocol used for SNMPv3 agent checks with security level set to authNoPriv or authPriv.
+                    - "Possible values:"
+                    - "0 - (default) MD5"
+                    - "1 - SHA"
+                type: int
+                choices: [0, 1]
+            snmpv3_contextname:
+                description:
+                    - SNMPv3 context name. Used only by SNMPv3 checks.
+                type: str
+            snmpv3_privpassphrase:
+                description:
+                    - Privacy passphrase used for SNMPv3 agent checks with security level set to authPriv.
+                type: str
+            snmpv3_privprotocol:
+                description:
+                    - Privacy protocol used for SNMPv3 agent checks with security level set to authPriv.
+                    - "Possible values:"
+                    - "0 - (default) DES"
+                    - "1 - AES"
+                type: int
+                choices: [0, 1]
+            snmpv3_securitylevel:
+                description:
+                    - Security level used for SNMPv3 agent checks.
+                    - "Possible values:"
+                    - "0 - noAuthNoPriv"
+                    - "1 - authNoPriv"
+                    - "2 - authPriv"
+                type: int
+                choices: [0, 1, 2]
+            snmpv3_securityname:
+                description:
+                    - Security name used for SNMPv3 agent checks.
+                type: str
+            uniq:
+                description:
+                    - Whether to use this check as a device uniqueness criteria.
+                    - Only a single unique check can be configured for a discovery rule.
+                    - Used for Zabbix agent, SNMPv1, SNMPv2 and SNMPv3 agent checks.
+                    - "Possible values:"
+                    - "0 - (default) do not use this check as a uniqueness criteria"
+                    - "1 - use this check as a uniqueness criteria"
+                type: int
+                default: 0
+                choices: [0, 1]
+            host_source:
+                description:
+                    - Source for host name.
+                    - "Possible values:"
+                    - "1 - (default) DNS"
+                    - "2 - IP"
+                    - "3 - discovery value of this check"
+                type: int
+                default: 1
+                choices: [1, 2, 3]
+            name_source:
+                description:
+                    - Source for visible name.
+                    - "Possible values:"
+                    - "0 - (default) not specified"
+                    - "1 - DNS"
+                    - "2 - IP"
+                    - "3 - discovery value of this check"
+                type: int
+                default: 0
+                choices: [0, 1, 2, 3]
+        type: list
+        aliases: [ "dcheck" ]
+    delay:
+        description:
+            - Execution interval of the discovery rule.
+        required: false
+        type: str
+        default: "1h"
+    proxy:
+        description:
+            - Name of the proxy used for discovery.
+        required: false
+        type: str
+    status:
+        description:
+            - Whether the discovery rule is enabled.
+            - "Possible values:"
+            - "0 - (default) enabled"
+            - "1 - disabled"
+        required: false
+        type: int
+        default: 0
+        choices: [0, 1]
+
+extends_documentation_fragment:
+- community.zabbix.zabbix
+'''
+
+EXAMPLES = r'''
+# Base create discovery rule example
+- name: Create discovery rule with ICMP and zabbix agent checks
+  zabbix_discovery_rule:
+    server_url: "http://zabbix.example.com/zabbix/"
+    login_user: admin
+    login_password: secret
+    name: ACME
+    state: present
+    iprange: 192.168.1.1-255
+    dchecks:
+        - type: 12
+        - type: 9
+          key_: "system.hostname"
+          ports: 10050
+          uniq: 1
+          host_source: 3
+
+# Base delete discovery rule example
+- name: Delete discovery rule
+  zabbix_discovery_rule:
+    server_url: "http://zabbix.example.com/zabbix/"
+    login_user: admin
+    login_password: secret
+    name: ACME
+    state: absent
+'''
+
+
+import atexit
+import traceback
+
+try:
+    from zabbix_api import ZabbixAPI
+    from zabbix_api import Already_Exists
+
+    HAS_ZABBIX_API = True
+except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
+    HAS_ZABBIX_API = False
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+
+
+class Zapi(object):
+    """
+    A simple wrapper over the Zabbix API
+    """
+    def __init__(self, module, zbx):
+        self._module = module
+        self._zapi = zbx
+        self._zbx_api_version = zbx.api_version()[:5]
+
+    def check_if_drule_exists(self, name):
+        """Check if discovery rule exists.
+
+        Args:
+            name: Name of the discovery rule.
+
+        Returns:
+            The return value. True for success, False otherwise.
+        """
+        try:
+            _drule = self._zapi.drule.get({
+                'output': 'extend',
+                'selectDChecks': 'extend',
+                'filter': {'name': [name]}
+            })
+            if len(_drule) > 0:
+                return _drule
+        except Exception as e:
+            self._module.fail_json(msg="Failed to check if discovery rule '%s' exists: %s"
+                                       % (name, e))
+
+    def get_drule_by_drule_name(self, name):
+        """Get discovery rule by discovery rule name
+
+        Args:
+            name: discovery rule name.
+
+        Returns:
+            discovery rule matching discovery rule name
+        """
+        try:
+            drule_list = self._zapi.drule.get({
+                'output': 'extend',
+                'selectDChecks': 'extend',
+                'filter': {'name': [name]}
+            })
+            if len(drule_list) < 1:
+                self._module.fail_json(msg="Discovery rule not found: %s" % name)
+            else:
+                return drule_list[0]
+        except Exception as e:
+            self._module.fail_json(msg="Failed to get discovery rule '%s': %s" % (name, e))
+
+    def get_proxy_by_proxy_name(self, proxy_name):
+        """Get proxy by proxy name
+
+        Args:
+            proxy_name: proxy name.
+
+        Returns:
+            proxy matching proxy name
+        """
+        try:
+            proxy_list = self._zapi.proxy.get({
+                'output': 'extend',
+                'selectInterface': 'extend',
+                'filter': {'host': [proxy_name]}
+            })
+            if len(proxy_list) < 1:
+                self._module.fail_json(msg="Proxy not found: %s" % proxy_name)
+            else:
+                return proxy_list[0]
+        except Exception as e:
+            self._module.fail_json(msg="Failed to get proxy '%s': %s" % (proxy_name, e))
+
+
+class Dchecks(object):
+    """
+    Restructures the user defined discovery checks to fit the Zabbix API requirements
+    """
+    def __init__(self, module, zbx):
+        self._module = module
+        self._zapi = zbx
+        self._zbx_api_version = zbx.api_version()[:5]
+
+    def construct_the_data(self, _dchecks):
+        """Construct the user defined discovery check to fit the Zabbix API
+        requirements
+
+        Args:
+            _dchecks: discovery checks to construct
+
+        Returns:
+            dict: user defined discovery checks
+        """
+        if _dchecks is None:
+            return None
+        constructed_data = []
+        for check in _dchecks:
+            constructed_check = {
+                'type': check.get('type'),
+                'uniq': check.get('uniq'),
+                'host_source': check.get('host_source'),
+                'name_source': check.get('name_source')
+            }
+            if constructed_check['type'] in (0, 1, 2, 3, 4, 5, 6, 7, 8, 14, 15):
+                constructed_check['ports'] = check.get('ports')
+            if constructed_check['type'] == 9:
+                constructed_check['ports'] = check.get('ports')
+                constructed_check['key_'] = check.get('key_')
+            if constructed_check['type'] in (10, 11):
+                constructed_check['ports'] = check.get('ports')
+                constructed_check['snmp_community'] = check.get('snmp_community')
+                constructed_check['key_'] = check.get('key_')
+            if constructed_check['type'] == 13:
+                constructed_check['ports'] = check.get('ports')
+                constructed_check['key_'] = check.get('key_')
+                constructed_check['snmpv3_contextname'] = check.get('snmpv3_contextname')
+                constructed_check['snmpv3_securityname'] = check.get('snmpv3_securityname')
+                constructed_check['snmpv3_securitylevel'] = check.get('snmpv3_securitylevel')
+                if check.get('snmpv3_securitylevel') in (1, 2):
+                    constructed_check['snmpv3_authprotocol'] = check.get('snmpv3_authprotocol')
+                    constructed_check['snmpv3_authpassphrase'] = check.get('snmpv3_authpassphrase')
+                if check.get('snmpv3_securitylevel') == 2:
+                    constructed_check['snmpv3_privprotocol'] = check.get('snmpv3_privprotocol')
+                    constructed_check['snmpv3_privpassphrase'] = check.get('snmpv3_privpassphrase')
+            constructed_data.append(constructed_check)
+        return cleanup_data(constructed_data)
+
+
+class DiscoveryRule(object):
+    def __init__(self, module, zbx, zapi_wrapper):
+        self._module = module
+        self._zapi = zbx
+        self._zapi_wrapper = zapi_wrapper
+
+    def _construct_parameters(self, **kwargs):
+        """Construct parameters.
+
+        Args:
+            **kwargs: Arbitrary keyword parameters.
+
+        Returns:
+            dict: dictionary of specified parameters
+        """
+        _params = {
+            'name': kwargs['name'],
+            'iprange': ','.join(kwargs['iprange']),
+            'delay': kwargs['delay'],
+            'status': kwargs['status'],
+            'dchecks': kwargs['dchecks']
+        }
+        if kwargs['proxy']:
+            _params['proxy_hostid'] = self._zapi_wrapper.get_proxy_by_proxy_name(kwargs['proxy'])['proxyid']
+        return _params
+
+    def check_difference(self, **kwargs):
+        """Check difference between discovery rule and user specified parameters.
+
+        Args:
+            **kwargs: Arbitrary keyword parameters.
+
+        Returns:
+            dict: dictionary of differences
+        """
+        existing_drule = convert_unicode_to_str(self._zapi_wrapper.check_if_drule_exists(kwargs['name'])[0])
+        parameters = convert_unicode_to_str(self._construct_parameters(**kwargs))
+        change_parameters = {}
+        if existing_drule['nextcheck']:
+            existing_drule.pop('nextcheck')
+        _diff = cleanup_data(compare_dictionaries(parameters, existing_drule, change_parameters))
+        return _diff
+
+    def update_drule(self, **kwargs):
+        """Update discovery rule.
+
+        Args:
+            **kwargs: Arbitrary keyword parameters.
+
+        Returns:
+            drule: updated discovery rule
+        """
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(msg="Discovery rule would be updated if check mode was not specified: %s" % kwargs['name'], changed=True)
+            kwargs['druleid'] = kwargs.pop('drule_id')
+            return self._zapi.drule.update(kwargs)
+        except Exception as e:
+            self._module.fail_json(msg="Failed to update discovery rule '%s': %s" % (kwargs['druleid'], e))
+
+    def add_drule(self, **kwargs):
+        """Add discovery rule
+
+        Args:
+            **kwargs: Arbitrary keyword parameters
+
+        Returns:
+            drule: created discovery rule
+        """
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(msg="Discovery rule would be added if check mode was not specified", changed=True)
+            parameters = self._construct_parameters(**kwargs)
+            drule_list = self._zapi.drule.create(parameters)
+            return drule_list['druleids'][0]
+        except Exception as e:
+            self._module.fail_json(msg="Failed to create discovery rule %s: %s" % (kwargs['name'], e))
+
+    def delete_drule(self, drule_id):
+        """Delete discovery rule.
+
+        Args:
+            drule_id: Discovery rule id
+
+        Returns:
+            drule: deleted discovery rule
+        """
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True, msg="Discovery rule would be deleted if check mode was not specified")
+            return self._zapi.drule.delete([drule_id])
+        except Exception as e:
+            self._module.fail_json(msg="Failed to delete discovery rule '%s': %s" % (drule_id, e))
+
+
+def convert_unicode_to_str(data):
+    """Converts unicode objects to strings in dictionary
+    args:
+        data: unicode object
+
+    Returns:
+        dict: strings in dictionary
+    """
+    if isinstance(data, dict):
+        return dict(map(convert_unicode_to_str, data.items()))
+    elif isinstance(data, (list, tuple, set)):
+        return type(data)(map(convert_unicode_to_str, data))
+    elif data is None:
+        return data
+    else:
+        return str(data)
+
+
+def compare_lists(l1, l2, diff_dict):
+    """
+    Compares l1 and l2 lists and adds the items that are different
+    to the diff_dict dictionary.
+    Used in recursion with compare_dictionaries() function.
+    Args:
+        l1: first list to compare
+        l2: second list to compare
+        diff_dict: dictionary to store the difference
+
+    Returns:
+        dict: items that are different
+    """
+    if len(l1) != len(l2):
+        diff_dict.append(l1)
+        return diff_dict
+    for i, item in enumerate(l1):
+        if isinstance(item, dict):
+            diff_dict.insert(i, {})
+            diff_dict[i] = compare_dictionaries(item, l2[i], diff_dict[i])
+        else:
+            if item != l2[i]:
+                diff_dict.append(item)
+    while {} in diff_dict:
+        diff_dict.remove({})
+    return diff_dict
+
+
+def compare_dictionaries(d1, d2, diff_dict):
+    """
+    Compares d1 and d2 dictionaries and adds the items that are different
+    to the diff_dict dictionary.
+    Used in recursion with compare_lists() function.
+    Args:
+        d1: first dictionary to compare
+        d2: second dictionary to compare
+        diff_dict: dictionary to store the difference
+
+    Returns:
+        dict: items that are different
+    """
+    for k, v in d1.items():
+        if k not in d2:
+            diff_dict[k] = v
+            continue
+        if isinstance(v, dict):
+            diff_dict[k] = {}
+            compare_dictionaries(v, d2[k], diff_dict[k])
+            if diff_dict[k] == {}:
+                del diff_dict[k]
+            else:
+                diff_dict[k] = v
+        elif isinstance(v, list):
+            diff_dict[k] = []
+            compare_lists(v, d2[k], diff_dict[k])
+            if diff_dict[k] == []:
+                del diff_dict[k]
+            else:
+                diff_dict[k] = v
+        else:
+            if v != d2[k]:
+                diff_dict[k] = v
+    return diff_dict
+
+
+def cleanup_data(obj):
+    """Removes the None values from the object and returns the object
+    Args:
+        obj: object to cleanup
+
+    Returns:
+       object: cleaned object
+    """
+    if isinstance(obj, (list, tuple, set)):
+        return type(obj)(cleanup_data(x) for x in obj if x is not None)
+    elif isinstance(obj, dict):
+        return type(obj)((cleanup_data(k), cleanup_data(v))
+                         for k, v in obj.items() if k is not None and v is not None)
+    else:
+        return obj
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            server_url=dict(type='str', required=True, aliases=['url']),
+            login_user=dict(type='str', required=True),
+            login_password=dict(type='str', required=True, no_log=True),
+            http_login_user=dict(type='str', required=False, default=None),
+            http_login_password=dict(type='str', required=False, default=None, no_log=True),
+            timeout=dict(type='int', default=10),
+            validate_certs=dict(type='bool', required=False, default=True),
+            state=dict(type='str', default='present', choices=['present', 'absent']),
+            name=dict(type='str', required=True),
+            iprange=dict(type='list', required=False),
+            dchecks=dict(
+                type='list',
+                required=False,
+                aliases=['dcheck'],
+                elements='dict',
+                options=dict(
+                    type=dict(type='int', choices=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]),
+                    ports=dict(type='str'),
+                    key_=dict(type='str'),
+                    snmp_community=dict(type='str'),
+                    snmpv3_authpassphrase=dict(type='str'),
+                    snmpv3_authprotocol=dict(type='int', choices=[0, 1]),
+                    snmpv3_contextname=dict(type='str'),
+                    snmpv3_privpassphrase=dict(type='str'),
+                    snmpv3_privprotocol=dict(type='int', choices=[0, 1]),
+                    snmpv3_securitylevel=dict(type='int', choices=[0, 1, 2]),
+                    snmpv3_securityname=dict(type='str'),
+                    uniq=dict(type='int', choices=[0, 1], default=0),
+                    host_source=dict(type='int', choices=[1, 2, 3], default=1),
+                    name_source=dict(type='int', choices=[0, 1, 2, 3], default=0)
+                ),
+                required_if=[
+                    ['type', [0, 1, 2, 3, 4, 5, 6, 7, 8, 14, 15], ['ports']],
+                    ['type', 9, ['ports', 'key_']],
+                    ['type', [10, 11], ['ports', 'key_', 'snmp_community']],
+                    ['type', 13, ['ports', 'key_']],
+                    ['snmpv3_securitylevel', 2, ['snmpv3_privpassphrase']]
+                ]
+            ),
+            delay=dict(type='str', required=False, default='1h'),
+            proxy=dict(type='str', required=False, default=None),
+            status=dict(type='int', default=0, choices=[0, 1])
+        ),
+        required_if=[
+            ['state', 'present', ['name', 'iprange', 'dchecks']],
+            ['state', 'absent', ['name']],
+        ],
+        supports_check_mode=True
+    )
+
+    if not HAS_ZABBIX_API:
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
+
+    server_url = module.params['server_url']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    http_login_user = module.params['http_login_user']
+    http_login_password = module.params['http_login_password']
+    validate_certs = module.params['validate_certs']
+    timeout = module.params['timeout']
+    state = module.params['state']
+    name = module.params['name']
+    iprange = module.params['iprange']
+    dchecks = module.params['dchecks']
+    delay = module.params['delay']
+    proxy = module.params['proxy']
+    status = module.params['status']
+
+    try:
+        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user,
+                        passwd=http_login_password, validate_certs=validate_certs)
+        zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
+    except Exception as e:
+        module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
+
+    zapi_wrapper = Zapi(module, zbx)
+
+    drule = DiscoveryRule(module, zbx, zapi_wrapper)
+
+    drule_exists = zapi_wrapper.check_if_drule_exists(name)
+    dcks = Dchecks(module, zbx)
+
+    if drule_exists:
+        drule_id = zapi_wrapper.get_drule_by_drule_name(name)['druleid']
+        if state == "absent":
+            result = drule.delete_drule(drule_id)
+            module.exit_json(changed=True, result="Discovery Rule deleted: %s, ID: %s" % (name, result))
+        else:
+            difference = drule.check_difference(
+                drule_id=drule_id,
+                name=name,
+                iprange=iprange,
+                dchecks=dcks.construct_the_data(dchecks),
+                delay=delay,
+                proxy=proxy,
+                status=status
+            )
+
+            if difference == {}:
+                module.exit_json(changed=False, msg="Discovery Rule is up to date: %s" % name)
+            else:
+                result = drule.update_drule(
+                    drule_id=drule_id,
+                    **difference
+                )
+                module.exit_json(changed=True, msg="Discovery Rule updated: %s, ID: %s" % (name, drule_id))
+    else:
+        if state == "absent":
+            module.exit_json(changed=False, warnings="Discovery rule %s does not exist, nothing to delete" % name)
+        else:
+            drule_id = drule.add_drule(
+                name=name,
+                iprange=iprange,
+                dchecks=dcks.construct_the_data(dchecks),
+                delay=delay,
+                proxy=proxy,
+                status=status
+            )
+            module.exit_json(changed=True, msg="Discovery Rule created: %s, ID: %s" % (name, drule_id))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -377,10 +377,6 @@ class Dchecks(object):
                     'Telnet'], check.get('type')
                 ),
                 'uniq': int(check.get('uniq'))
-                # 'uniq': to_numeric_value([
-                #     'False',
-                #     'True'], check.get('uniq')
-                # )
             }
             if LooseVersion(self._zbx_api_version) >= LooseVersion('4.4'):
                 constructed_check.update({

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -29,7 +29,6 @@ options:
     state:
         description:
             - Create or delete user group.
-        required: false
         type: str
         default: "present"
         choices: [ "present", "absent" ]
@@ -41,7 +40,6 @@ options:
     iprange:
         description:
             - One or several IP ranges to check separated by commas.
-        required: true
         type: list
         elements: str
     dchecks:
@@ -49,7 +47,6 @@ options:
             - List of dictionaries of discovery check objects.
             - For more information, review discovery check object documentation at
               U(https://www.zabbix.com/documentation/current/manual/api/reference/dcheck/object)
-        required: true
         suboptions:
             type:
                 description:
@@ -73,7 +70,6 @@ options:
                     - "15 - Telnet"
                 type: int
                 choices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-                required: true
             ports:
                 description:
                     - One or several port ranges to check separated by commas. Used for all checks except for ICMP.
@@ -163,17 +159,16 @@ options:
                 default: 0
                 choices: [0, 1, 2, 3]
         type: list
+        elements: dict
         aliases: [ "dcheck" ]
     delay:
         description:
             - Execution interval of the discovery rule.
-        required: false
         type: str
         default: "1h"
     proxy:
         description:
             - Name of the proxy used for discovery.
-        required: false
         type: str
     status:
         description:
@@ -181,7 +176,6 @@ options:
             - "Possible values:"
             - "0 - (default) enabled"
             - "1 - disabled"
-        required: false
         type: int
         default: 0
         choices: [0, 1]
@@ -570,7 +564,7 @@ def main():
             validate_certs=dict(type='bool', required=False, default=True),
             state=dict(type='str', default='present', choices=['present', 'absent']),
             name=dict(type='str', required=True),
-            iprange=dict(type='list', required=False),
+            iprange=dict(type='list', required=False, elements='str'),
             dchecks=dict(
                 type='list',
                 required=False,
@@ -593,10 +587,21 @@ def main():
                     name_source=dict(type='int', choices=[0, 1, 2, 3], default=0)
                 ),
                 required_if=[
-                    ['type', [0, 1, 2, 3, 4, 5, 6, 7, 8, 14, 15], ['ports']],
+                    ['type', 0, ['ports']],
+                    ['type', 1, ['ports']],
+                    ['type', 2, ['ports']],
+                    ['type', 3, ['ports']],
+                    ['type', 4, ['ports']],
+                    ['type', 5, ['ports']],
+                    ['type', 6, ['ports']],
+                    ['type', 7, ['ports']],
+                    ['type', 8, ['ports']],
                     ['type', 9, ['ports', 'key_']],
-                    ['type', [10, 11], ['ports', 'key_', 'snmp_community']],
+                    ['type', 10, ['ports', 'key_', 'snmp_community']],
+                    ['type', 11, ['ports', 'key_', 'snmp_community']],
                     ['type', 13, ['ports', 'key_']],
+                    ['type', 14, ['ports']],
+                    ['type', 15, ['ports']],
                     ['snmpv3_securitylevel', 2, ['snmpv3_privpassphrase']]
                 ]
             ),

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -225,6 +225,7 @@ except ImportError:
     ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
+from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
@@ -328,10 +329,13 @@ class Dchecks(object):
         for check in _dchecks:
             constructed_check = {
                 'type': check.get('type'),
-                'uniq': check.get('uniq'),
-                'host_source': check.get('host_source'),
-                'name_source': check.get('name_source')
+                'uniq': check.get('uniq')
             }
+            if LooseVersion(self._zbx_api_version) >= LooseVersion('4.4'):
+                constructed_check.update({
+                    'host_source': check.get('host_source'),
+                    'name_source': check.get('name_source')
+                })
             if constructed_check['type'] in (0, 1, 2, 3, 4, 5, 6, 7, 8, 14, 15):
                 constructed_check['ports'] = check.get('ports')
             if constructed_check['type'] == 9:

--- a/tests/integration/targets/test_zabbix_discovery_rule/meta/main.yml
+++ b/tests/integration/targets/test_zabbix_discovery_rule/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_zabbix

--- a/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
@@ -1,358 +1,233 @@
 ---
-- name: test - create new Zabbix discovery rule
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange: 192.168.1.1-255
-    dchecks:
-      - type: 12
-  register: drule_new
+- name: test - Zabbix discovery rule
+  module_defaults:
+    zabbix_discovery_rule:
+      server_url: "{{ zabbix_server_url }}"
+      login_user: "{{ zabbix_login_user }}"
+      login_password: "{{ zabbix_login_password }}"
+      name: ACME
+      state: present
+      iprange: 192.168.1.1-255
+      dchecks:
+        - type: 12
+      delay: "{{ 3600 if zabbix_version is version('3.4', '<=') else omit }}"
 
-- name: assert that drule was created
-  assert:
-    that: drule_new is changed
+  block:
+  - name: test - create new Zabbix discovery rule
+    zabbix_discovery_rule:
+    register: drule_new
 
-- name: test - create same Zabbix discovery rule
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange: 192.168.1.1-255
-    dchecks:
-      - type: 12
-  register: drule_exists
+  - name: assert that drule was created
+    assert:
+      that: drule_new is changed
 
-- name: assert that nothing has been changed
-  assert:
-    that: not drule_exists is changed
+  - name: test - create same Zabbix discovery rule
+    zabbix_discovery_rule:
+    register: drule_exists
 
-- name: test - update Zabbix discovery rule iprange
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange:
-      - 192.168.1.1-255
-      - 10.0.0.1-255
-    dchecks:
-      - type: 12
-  register: drule_iprange_update
+  - name: assert that nothing has been changed
+    assert:
+      that: not drule_exists is changed
 
-- name: assert that iprange has been changed
-  assert:
-    that: drule_iprange_update is changed
+  - name: test - update Zabbix discovery rule iprange
+    zabbix_discovery_rule:
+      iprange:
+        - 192.168.1.1-255
+        - 10.0.0.1-255
+    register: drule_iprange_update
 
-- name: test - update Zabbix discovery rule status
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange:
-      - 192.168.1.1-255
-      - 10.0.0.1-255
-    dchecks:
-      - type: 12
-    status: 1
-  register: drule_status_update
+  - name: assert that iprange has been changed
+    assert:
+      that: drule_iprange_update is changed
 
-- name: assert that iprange has been changed
-  assert:
-    that: drule_status_update is changed
+  - name: test - reset Zabbix discovery rule to default
+    zabbix_discovery_rule:
+    register: drule_reset
 
-- name: test - update Zabbix discovery rule status (again)
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange:
-      - 192.168.1.1-255
-      - 10.0.0.1-255
-    dchecks:
-      - type: 12
-    status: 0
-  register: drule_status_update_again
+  - name: assert that iprange has been changed
+    assert:
+      that: drule_reset is changed
 
-- name: assert that iprange has been changed
-  assert:
-    that: drule_status_update_again is changed
+  - name: test - update Zabbix discovery rule status
+    zabbix_discovery_rule:
+      status: 1
+    register: drule_status_update
 
-- name: test - update Zabbix discovery rule dchecks
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange:
-      - 192.168.1.1-255
-      - 10.0.0.1-255
-    dchecks:
-      - type: 12
-      - type: 9
-        key_: "system.hostname"
-        ports: "10050"
-        uniq: 1
-        host_source: 3
-  register: drule_dchecks_update
+  - name: assert that iprange has been changed
+    assert:
+      that: drule_status_update is changed
 
-- name: assert that dcheck has been changed
-  assert:
-    that: drule_dchecks_update is changed
+  - name: test - reset Zabbix discovery rule to default
+    zabbix_discovery_rule:
+    register: drule_reset
 
-- name: test - update Zabbix discovery rule dchecks ssh
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange:
-      - 192.168.1.1-255
-      - 10.0.0.1-255
-    dchecks:
-      - type: 12
-      - type: 0
-        ports: "22"
-  register: drule_dchecks_ssh_update
+  - name: assert that iprange has been changed
+    assert:
+      that: drule_reset is changed
 
-- name: assert that dcheck has been changed
-  assert:
-    that: drule_dchecks_ssh_update is changed
+  - name: test - update Zabbix discovery rule dchecks
+    zabbix_discovery_rule:
+      dchecks:
+        - type: 12
+        - type: 9
+          key_: "system.hostname"
+          ports: "10050"
+          uniq: 1
+          host_source: 3
+    register: drule_dchecks_update
 
-- name: test - update Zabbix discovery rule dchecks ldap
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange:
-      - 192.168.1.1-255
-      - 10.0.0.1-255
-    dchecks:
-      - type: 12
-      - type: 0
-        ports: "22"
-      - type: 1
-        ports: "389"
-  register: drule_dchecks_ldap_update
+  - name: assert that dcheck has been changed
+    assert:
+      that: drule_dchecks_update is changed
 
-- name: assert that dcheck has been changed
-  assert:
-    that: drule_dchecks_ldap_update is changed
+  - name: test - update Zabbix discovery rule dchecks ssh
+    zabbix_discovery_rule:
+      dchecks:
+        - type: 12
+        - type: 0
+          ports: "22"
+    register: drule_dchecks_ssh_update
 
-- name: test - update Zabbix discovery rule dchecks smtp
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange:
-      - 192.168.1.1-255
-      - 10.0.0.1-255
-    dchecks:
-      - type: 12
-      - type: 0
-        ports: "22"
-      - type: 1
-        ports: "389"
-      - type: 2
-        ports: 25,465,587
-  register: drule_dchecks_smtp_update
+  - name: assert that dcheck has been changed
+    assert:
+      that: drule_dchecks_ssh_update is changed
 
-- name: assert that dcheck has been changed
-  assert:
-    that: drule_dchecks_smtp_update is changed
+  - name: test - update Zabbix discovery rule dchecks ldap
+    zabbix_discovery_rule:
+      dchecks:
+        - type: 12
+        - type: 0
+          ports: "22"
+        - type: 1
+          ports: "389"
+    register: drule_dchecks_ldap_update
 
-- name: test - update Zabbix discovery rule dchecks http
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange:
-      - 192.168.1.1-255
-      - 10.0.0.1-255
-    dchecks:
-      - type: 12
-      - type: 0
-        ports: "22"
-      - type: 1
-        ports: "389"
-      - type: 2
-        ports: 25,465,587
-      - type: 4
-        ports: 80,8080
-  register: drule_dchecks_http_update
+  - name: assert that dcheck has been changed
+    assert:
+      that: drule_dchecks_ldap_update is changed
 
-- name: assert that dcheck has been changed
-  assert:
-    that: drule_dchecks_http_update is changed
+  - name: test - update Zabbix discovery rule dchecks smtp
+    zabbix_discovery_rule:
+      dchecks:
+        - type: 12
+        - type: 0
+          ports: "22"
+        - type: 1
+          ports: "389"
+        - type: 2
+          ports: 25,465,587
+    register: drule_dchecks_smtp_update
 
-- name: test - remove Zabbix discovery rule dchecks
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange:
-      - 192.168.1.1-255
-      - 10.0.0.1-255
-    dchecks:
-      - type: 12
-  register: drule_dchecks_remove_update
+  - name: assert that dcheck has been changed
+    assert:
+      that: drule_dchecks_smtp_update is changed
 
-- name: assert that dcheck has been changed
-  assert:
-    that: drule_dchecks_remove_update is changed
+  - name: test - update Zabbix discovery rule dchecks http
+    zabbix_discovery_rule:
+      dchecks:
+        - type: 12
+        - type: 0
+          ports: "22"
+        - type: 1
+          ports: "389"
+        - type: 2
+          ports: 25,465,587
+        - type: 4
+          ports: 80,8080
+    register: drule_dchecks_http_update
 
-- name: test - update Zabbix discovery rule snmp dcheck
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange:
-      - 192.168.1.1-255
-      - 10.0.0.1-255
-    dchecks:
-      - type: 11
-        snmp_community: CUSTOMER@snmp-readonly
-        ports: "161"
-        key_: iso.3.6.1.2.1.1.1.0
-        uniq: 0
-        host_source: 3
-        name_source: 3
-  register: drule_snmp_update
+  - name: assert that dcheck has been changed
+    assert:
+      that: drule_dchecks_http_update is changed
 
-- name: assert that snmp dcheck has been changed
-  assert:
-    that: drule_snmp_update is changed
+  - name: test - remove Zabbix discovery rule dchecks
+    zabbix_discovery_rule:
+      dchecks:
+        - type: 12
+    register: drule_dchecks_remove_update
 
-- name: test - update Zabbix discovery rule snmp3 dcheck
-  zabbix_discovery_rule:
-    server_url: "{{ zabbix_server_url }}"
-    login_user: "{{ zabbix_login_user }}"
-    login_password: "{{ zabbix_login_password }}"
-    name: ACME
-    state: present
-    iprange:
-      - 192.168.1.1-255
-      - 10.0.0.1-255
-    dchecks:
-      - type: 13
-        snmp_community: CUSTOMER@snmp3-readonly
-        ports: "161"
-        key_: iso.3.6.1.2.1.1.1.0
-        snmpv3_contextname: "ContextName"
-        snmpv3_securityname: "SecurityName"
-        snmpv3_securitylevel: 2
-        snmpv3_authprotocol: 1
-        snmpv3_authpassphrase: "SeCrEt"
-        snmpv3_privprotocol: 1
-        snmpv3_privpassphrase: "TopSecret"
-        uniq: 0
-        host_source: 1
-        name_source: 0
-  register: drule_snmp3_update
+  - name: assert that dcheck has been changed
+    assert:
+      that: drule_dchecks_remove_update is changed
 
-- name: assert that snmp3 dcheck has been changed
-  assert:
-    that: drule_snmp3_update is changed
+  - name: test - update Zabbix discovery rule snmp dcheck
+    zabbix_discovery_rule:
+      dchecks:
+        - type: 11
+          snmp_community: CUSTOMER@snmp-readonly
+          ports: "161"
+          key_: iso.3.6.1.2.1.1.1.0
+          uniq: 0
+          host_source: 3
+          name_source: 3
+    register: drule_snmp_update
 
-- block:
-    - name: test - create new active Zabbix proxy server
-      zabbix_proxy:
-        server_url: "{{ zabbix_server_url }}"
-        login_user: "{{ zabbix_login_user }}"
-        login_password: "{{ zabbix_login_password }}"
-        proxy_name: ACME_proxy
-        status: active
-        state: present
-      register: zbxproxy_active
+  - name: assert that snmp dcheck has been changed
+    assert:
+      that: drule_snmp_update is changed
 
-    - name: assert that proxy was created
-      assert:
-        that: zbxproxy_active is changed
+  - name: test - update Zabbix discovery rule snmp3 dcheck
+    zabbix_discovery_rule:
+      dchecks:
+        - type: 13
+          snmp_community: CUSTOMER@snmp3-readonly
+          ports: "161"
+          key_: iso.3.6.1.2.1.1.1.0
+          snmpv3_contextname: "ContextName"
+          snmpv3_securityname: "SecurityName"
+          snmpv3_securitylevel: 2
+          snmpv3_authprotocol: 1
+          snmpv3_authpassphrase: "SeCrEt"
+          snmpv3_privprotocol: 1
+          snmpv3_privpassphrase: "TopSecret"
+          uniq: 0
+          host_source: 1
+          name_source: 0
+    register: drule_snmp3_update
 
-    - name: test - update Zabbix discovery rule proxy
-      zabbix_discovery_rule:
-        server_url: "{{ zabbix_server_url }}"
-        login_user: "{{ zabbix_login_user }}"
-        login_password: "{{ zabbix_login_password }}"
-        name: ACME
-        state: present
-        iprange:
-          - 192.168.1.1-255
-          - 10.0.0.1-255
-        dchecks:
-          - type: 13
-            snmp_community: CUSTOMER@snmp3-readonly
-            ports: "161"
-            key_: iso.3.6.1.2.1.1.1.0
-            snmpv3_contextname: "ContextName"
-            snmpv3_securityname: "SecurityName"
-            snmpv3_securitylevel: 2
-            snmpv3_authprotocol: 1
-            snmpv3_authpassphrase: "SeCrEt"
-            snmpv3_privprotocol: 1
-            snmpv3_privpassphrase: "TopSecret"
-            uniq: 0
-            host_source: 1
-            name_source: 0
-        proxy: ACME_proxy
-      register: drule_proxy_update
+  - name: assert that snmp3 dcheck has been changed
+    assert:
+      that: drule_snmp3_update is changed
 
-    - name: assert that proxy has been changed
-      assert:
-        that: drule_proxy_update is changed
+  - name: test - reset Zabbix discovery rule to default
+    zabbix_discovery_rule:
+    register: drule_reset
 
-    - name: test - update Zabbix discovery rule proxy (again)
-      zabbix_discovery_rule:
-        server_url: "{{ zabbix_server_url }}"
-        login_user: "{{ zabbix_login_user }}"
-        login_password: "{{ zabbix_login_password }}"
-        name: ACME
-        state: present
-        iprange:
-          - 192.168.1.1-255
-          - 10.0.0.1-255
-        dchecks:
-          - type: 13
-            snmp_community: CUSTOMER@snmp3-readonly
-            ports: "161"
-            key_: iso.3.6.1.2.1.1.1.0
-            snmpv3_contextname: "ContextName"
-            snmpv3_securityname: "SecurityName"
-            snmpv3_securitylevel: 2
-            snmpv3_authprotocol: 1
-            snmpv3_authpassphrase: "SeCrEt"
-            snmpv3_privprotocol: 1
-            snmpv3_privpassphrase: "TopSecret"
-            uniq: 0
-            host_source: 1
-            name_source: 0
-        proxy: ACME_proxy
-      register: drule_proxy_update_again
+  - name: assert that iprange has been changed
+    assert:
+      that: drule_reset is changed
 
-    - name: assert that nothing has been changed
-      assert:
-        that: not drule_proxy_update_again is changed
+  - name: test - create new active Zabbix proxy server
+    zabbix_proxy:
+      server_url: "{{ zabbix_server_url }}"
+      login_user: "{{ zabbix_login_user }}"
+      login_password: "{{ zabbix_login_password }}"
+      proxy_name: ACME_proxy
+      status: active
+      state: present
+    register: zbxproxy_active
+
+  - name: assert that proxy was created
+    assert:
+      that: zbxproxy_active is changed
+
+  - name: test - update Zabbix discovery rule proxy
+    zabbix_discovery_rule:
+      proxy: ACME_proxy
+    register: drule_proxy_update
+
+  - name: assert that proxy has been changed
+    assert:
+      that: drule_proxy_update is changed
+
+  - name: test - update Zabbix discovery rule proxy (again)
+    zabbix_discovery_rule:
+      proxy: ACME_proxy
+    register: drule_proxy_update_again
+
+  - name: assert that nothing has been changed
+    assert:
+      that: not drule_proxy_update_again is changed
 
 - name: test - delete Zabbix discovery rule
   zabbix_discovery_rule:

--- a/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
@@ -13,7 +13,7 @@
       state: present
       iprange: 192.168.1.1-255
       dchecks:
-        - type: 12
+        - type: ICMP
       delay: "{{ 3600 if zabbix_version is version('3.4', '<=') else omit }}"
 
   block:
@@ -54,7 +54,7 @@
 
   - name: test - update Zabbix discovery rule status
     zabbix_discovery_rule:
-      status: 1
+      status: disabled
     register: drule_status_update
 
   - name: assert that iprange has been changed
@@ -72,12 +72,12 @@
   - name: test - update Zabbix discovery rule dchecks
     zabbix_discovery_rule:
       dchecks:
-        - type: 12
-        - type: 9
-          key_: "system.hostname"
+        - type: ICMP
+        - type: Zabbix
+          key: "system.hostname"
           ports: "10050"
-          uniq: 1
-          host_source: 3
+          uniq: yes
+          host_source: discovery
     register: drule_dchecks_update
 
   - name: assert that dcheck has been changed
@@ -87,8 +87,8 @@
   - name: test - update Zabbix discovery rule dchecks ssh
     zabbix_discovery_rule:
       dchecks:
-        - type: 12
-        - type: 0
+        - type: ICMP
+        - type: SSH
           ports: "22"
     register: drule_dchecks_ssh_update
 
@@ -99,10 +99,10 @@
   - name: test - update Zabbix discovery rule dchecks ldap
     zabbix_discovery_rule:
       dchecks:
-        - type: 12
-        - type: 0
+        - type: ICMP
+        - type: SSH
           ports: "22"
-        - type: 1
+        - type: LDAP
           ports: "389"
     register: drule_dchecks_ldap_update
 
@@ -113,12 +113,12 @@
   - name: test - update Zabbix discovery rule dchecks smtp
     zabbix_discovery_rule:
       dchecks:
-        - type: 12
-        - type: 0
+        - type: ICMP
+        - type: SSH
           ports: "22"
-        - type: 1
+        - type: LDAP
           ports: "389"
-        - type: 2
+        - type: SMTP
           ports: 25,465,587
     register: drule_dchecks_smtp_update
 
@@ -129,14 +129,14 @@
   - name: test - update Zabbix discovery rule dchecks http
     zabbix_discovery_rule:
       dchecks:
-        - type: 12
-        - type: 0
+        - type: ICMP
+        - type: SSH
           ports: "22"
-        - type: 1
+        - type: LDAP
           ports: "389"
-        - type: 2
+        - type: SMTP
           ports: 25,465,587
-        - type: 4
+        - type: HTTP
           ports: 80,8080
     register: drule_dchecks_http_update
 
@@ -147,7 +147,7 @@
   - name: test - remove Zabbix discovery rule dchecks
     zabbix_discovery_rule:
       dchecks:
-        - type: 12
+        - type: ICMP
     register: drule_dchecks_remove_update
 
   - name: assert that dcheck has been changed
@@ -157,13 +157,13 @@
   - name: test - update Zabbix discovery rule snmp dcheck
     zabbix_discovery_rule:
       dchecks:
-        - type: 11
+        - type: SNMPv2
           snmp_community: CUSTOMER@snmp-readonly
           ports: "161"
-          key_: iso.3.6.1.2.1.1.1.0
-          uniq: 0
-          host_source: 3
-          name_source: 3
+          key: iso.3.6.1.2.1.1.1.0
+          uniq: no
+          host_source: discovery
+          name_source: discovery
     register: drule_snmp_update
 
   - name: assert that snmp dcheck has been changed
@@ -173,20 +173,20 @@
   - name: test - update Zabbix discovery rule snmp3 dcheck
     zabbix_discovery_rule:
       dchecks:
-        - type: 13
+        - type: SNMPv3
           snmp_community: CUSTOMER@snmp3-readonly
           ports: "161"
-          key_: iso.3.6.1.2.1.1.1.0
+          key: iso.3.6.1.2.1.1.1.0
           snmpv3_contextname: "ContextName"
           snmpv3_securityname: "SecurityName"
-          snmpv3_securitylevel: 2
-          snmpv3_authprotocol: 1
+          snmpv3_securitylevel: authPriv
+          snmpv3_authprotocol: SHA
           snmpv3_authpassphrase: "SeCrEt"
-          snmpv3_privprotocol: 1
+          snmpv3_privprotocol: AES
           snmpv3_privpassphrase: "TopSecret"
-          uniq: 0
-          host_source: 1
-          name_source: 0
+          uniq: no
+          host_source: DNS
+          name_source: None
     register: drule_snmp3_update
 
   - name: assert that snmp3 dcheck has been changed

--- a/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
@@ -1,0 +1,215 @@
+---
+- name: test - create new Zabbix discovery rule
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange: 192.168.1.1-255
+    dchecks:
+        - type: 12
+  register: drule_new
+
+- name: assert that drule was created
+  assert:
+    that: drule_new is changed
+
+- name: test - create same Zabbix discovery rule
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange: 192.168.1.1-255
+    dchecks:
+        - type: 12
+  register: drule_exists
+
+- name: assert that nothing has been changed
+  assert:
+    that: not drule_exists is changed
+
+- name: test - update Zabbix discovery rule iprange
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange:
+      - 192.168.1.1-255
+      - 10.0.0.1-255
+    dchecks:
+        - type: 12
+  register: drule_iprange_update
+
+- name: assert that ipragne has been changed
+  assert:
+    that: drule_iprange_update is changed
+
+- name: test - update Zabbix discovery rule status
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange:
+      - 192.168.1.1-255
+      - 10.0.0.1-255
+    dchecks:
+        - type: 12
+    status: 1
+  register: drule_status_update
+
+- name: assert that ipragne has been changed
+  assert:
+    that: drule_status_update is changed
+
+- name: test - update Zabbix discovery rule status (again)
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange:
+      - 192.168.1.1-255
+      - 10.0.0.1-255
+    dchecks:
+        - type: 12
+    status: 0
+  register: drule_status_update_again
+
+- name: assert that ipragne has been changed
+  assert:
+    that: drule_status_update_again is changed
+
+- name: test - update Zabbix discovery rule dchecks
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange:
+      - 192.168.1.1-255
+      - 10.0.0.1-255
+    dchecks:
+        - type: 12
+        - type: 9
+          key_: "system.hostname"
+          ports: "10050"
+          uniq: 1
+          host_source: 3
+  register: drule_dchecks_update
+
+- name: assert that dcheck has been changed
+  assert:
+    that: drule_dchecks_update is changed
+
+- name: test - update Zabbix discovery rule snmp dcheck
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange:
+      - 192.168.1.1-255
+      - 10.0.0.1-255
+    dchecks:
+        - type: 11
+          snmp_community: CUSTOMER@snmp-readonly
+          ports: "161"
+          key_: iso.3.6.1.2.1.1.1.0
+          uniq: 0
+          host_source: 3
+          name_source: 3
+  register: drule_snmp_update
+
+- name: assert that snmp dcheck has been changed
+  assert:
+    that: drule_snmp_update is changed
+
+- block:
+    - name: test - create new active Zabbix proxy server
+      zabbix_proxy:
+        server_url: "{{ zabbix_server_url }}"
+        login_user: "{{ zabbix_login_user }}"
+        login_password: "{{ zabbix_login_password }}"
+        proxy_name: ACME_proxy
+        status: active
+        state: present
+      register: zbxproxy_active
+
+    - name: assert that proxy was created
+      assert:
+        that: zbxproxy_active is changed
+
+    - name: test - update Zabbix discovery rule proxy
+      zabbix_discovery_rule:
+        server_url: "{{ zabbix_server_url }}"
+        login_user: "{{ zabbix_login_user }}"
+        login_password: "{{ zabbix_login_password }}"
+        name: ACME
+        state: present
+        iprange:
+          - 192.168.1.1-255
+          - 10.0.0.1-255
+        dchecks:
+            - type: 11
+              snmp_community: CUSTOMER@snmp-readonly
+              ports: "161"
+              key_: iso.3.6.1.2.1.1.1.0
+              uniq: 0
+              host_source: 3
+              name_source: 3
+        proxy: ACME_proxy
+      register: drule_proxy_update
+
+    - name: assert that proxy has been changed
+      assert:
+        that: drule_proxy_update is changed
+
+- name: test - delete Zabbix discovery rule
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: absent
+  register: drule_delete
+
+- name: assert that proxy has been deleted
+  assert:
+    that: drule_delete is changed
+
+- name: test - delete Zabbix discovery rule (again)
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: absent
+  register: drule_delete_again
+
+- name: assert that nothing has been changed
+  assert:
+    that: not drule_delete_again is changed
+
+# Cleanup
+- name: delete active Zabbix proxy server
+  zabbix_proxy:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    proxy_name: ACME_proxy
+    state: absent
+  register: zbxproxy_delete
+
+- name: assert that proxy has been deleted
+  assert:
+    that: zbxproxy_delete is changed

--- a/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
@@ -8,7 +8,7 @@
     state: present
     iprange: 192.168.1.1-255
     dchecks:
-        - type: 12
+      - type: 12
   register: drule_new
 
 - name: assert that drule was created
@@ -24,7 +24,7 @@
     state: present
     iprange: 192.168.1.1-255
     dchecks:
-        - type: 12
+      - type: 12
   register: drule_exists
 
 - name: assert that nothing has been changed
@@ -42,7 +42,7 @@
       - 192.168.1.1-255
       - 10.0.0.1-255
     dchecks:
-        - type: 12
+      - type: 12
   register: drule_iprange_update
 
 - name: assert that iprange has been changed
@@ -60,7 +60,7 @@
       - 192.168.1.1-255
       - 10.0.0.1-255
     dchecks:
-        - type: 12
+      - type: 12
     status: 1
   register: drule_status_update
 
@@ -79,7 +79,7 @@
       - 192.168.1.1-255
       - 10.0.0.1-255
     dchecks:
-        - type: 12
+      - type: 12
     status: 0
   register: drule_status_update_again
 
@@ -98,12 +98,12 @@
       - 192.168.1.1-255
       - 10.0.0.1-255
     dchecks:
-        - type: 12
-        - type: 9
-          key_: "system.hostname"
-          ports: "10050"
-          uniq: 1
-          host_source: 3
+      - type: 12
+      - type: 9
+        key_: "system.hostname"
+        ports: "10050"
+        uniq: 1
+        host_source: 3
   register: drule_dchecks_update
 
 - name: assert that dcheck has been changed
@@ -121,9 +121,9 @@
       - 192.168.1.1-255
       - 10.0.0.1-255
     dchecks:
-        - type: 12
-        - type: 0
-          ports: "22"
+      - type: 12
+      - type: 0
+        ports: "22"
   register: drule_dchecks_ssh_update
 
 - name: assert that dcheck has been changed
@@ -141,11 +141,11 @@
       - 192.168.1.1-255
       - 10.0.0.1-255
     dchecks:
-        - type: 12
-        - type: 0
-          ports: "22"
-        - type: 1
-          ports: "389"
+      - type: 12
+      - type: 0
+        ports: "22"
+      - type: 1
+        ports: "389"
   register: drule_dchecks_ldap_update
 
 - name: assert that dcheck has been changed
@@ -163,13 +163,13 @@
       - 192.168.1.1-255
       - 10.0.0.1-255
     dchecks:
-        - type: 12
-        - type: 0
-          ports: "22"
-        - type: 1
-          ports: "389"
-        - type: 2
-          ports: 25,465,587
+      - type: 12
+      - type: 0
+        ports: "22"
+      - type: 1
+        ports: "389"
+      - type: 2
+        ports: 25,465,587
   register: drule_dchecks_smtp_update
 
 - name: assert that dcheck has been changed
@@ -187,15 +187,15 @@
       - 192.168.1.1-255
       - 10.0.0.1-255
     dchecks:
-        - type: 12
-        - type: 0
-          ports: "22"
-        - type: 1
-          ports: "389"
-        - type: 2
-          ports: 25,465,587
-        - type: 4
-          ports: 80,8080
+      - type: 12
+      - type: 0
+        ports: "22"
+      - type: 1
+        ports: "389"
+      - type: 2
+        ports: 25,465,587
+      - type: 4
+        ports: 80,8080
   register: drule_dchecks_http_update
 
 - name: assert that dcheck has been changed
@@ -213,7 +213,7 @@
       - 192.168.1.1-255
       - 10.0.0.1-255
     dchecks:
-        - type: 12
+      - type: 12
   register: drule_dchecks_remove_update
 
 - name: assert that dcheck has been changed
@@ -231,20 +231,20 @@
       - 192.168.1.1-255
       - 10.0.0.1-255
     dchecks:
-        - type: 11
-          snmp_community: CUSTOMER@snmp-readonly
-          ports: "161"
-          key_: iso.3.6.1.2.1.1.1.0
-          uniq: 0
-          host_source: 3
-          name_source: 3
+      - type: 11
+        snmp_community: CUSTOMER@snmp-readonly
+        ports: "161"
+        key_: iso.3.6.1.2.1.1.1.0
+        uniq: 0
+        host_source: 3
+        name_source: 3
   register: drule_snmp_update
 
 - name: assert that snmp dcheck has been changed
   assert:
     that: drule_snmp_update is changed
 
-- name: test - update Zabbix discovery rule add snmp3 dcheck
+- name: test - update Zabbix discovery rule snmp3 dcheck
   zabbix_discovery_rule:
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
@@ -255,30 +255,23 @@
       - 192.168.1.1-255
       - 10.0.0.1-255
     dchecks:
-        - type: 11
-          snmp_community: CUSTOMER@snmp-readonly
-          ports: "161"
-          key_: iso.3.6.1.2.1.1.1.0
-          uniq: 0
-          host_source: 3
-          name_source: 3
-        - type: 13
-          snmp_community: CUSTOMER@snmp3-readonly
-          ports: "161"
-          key_: iso.3.6.1.2.1.1.1.0
-          snmpv3_contextname: "ContextName"
-          snmpv3_securityname: "SecurityName"
-          snmpv3_securitylevel: 2
-          snmpv3_authprotocol: 1
-          snmpv3_authpassphrase: "SeCrEt"
-          snmpv3_privprotocol: 1
-          snmpv3_privpassphrase: "TopSecret"
-          uniq: 0
-          host_source: 3
-          name_source: 3
+      - type: 13
+        snmp_community: CUSTOMER@snmp3-readonly
+        ports: "161"
+        key_: iso.3.6.1.2.1.1.1.0
+        snmpv3_contextname: "ContextName"
+        snmpv3_securityname: "SecurityName"
+        snmpv3_securitylevel: 2
+        snmpv3_authprotocol: 1
+        snmpv3_authpassphrase: "SeCrEt"
+        snmpv3_privprotocol: 1
+        snmpv3_privpassphrase: "TopSecret"
+        uniq: 0
+        host_source: 1
+        name_source: 0
   register: drule_snmp3_update
 
-- name: assert that snmp dcheck has been changed
+- name: assert that snmp3 dcheck has been changed
   assert:
     that: drule_snmp3_update is changed
 
@@ -308,19 +301,58 @@
           - 192.168.1.1-255
           - 10.0.0.1-255
         dchecks:
-            - type: 11
-              snmp_community: CUSTOMER@snmp-readonly
-              ports: "161"
-              key_: iso.3.6.1.2.1.1.1.0
-              uniq: 0
-              host_source: 3
-              name_source: 3
+          - type: 13
+            snmp_community: CUSTOMER@snmp3-readonly
+            ports: "161"
+            key_: iso.3.6.1.2.1.1.1.0
+            snmpv3_contextname: "ContextName"
+            snmpv3_securityname: "SecurityName"
+            snmpv3_securitylevel: 2
+            snmpv3_authprotocol: 1
+            snmpv3_authpassphrase: "SeCrEt"
+            snmpv3_privprotocol: 1
+            snmpv3_privpassphrase: "TopSecret"
+            uniq: 0
+            host_source: 1
+            name_source: 0
         proxy: ACME_proxy
       register: drule_proxy_update
 
     - name: assert that proxy has been changed
       assert:
         that: drule_proxy_update is changed
+
+    - name: test - update Zabbix discovery rule proxy (again)
+      zabbix_discovery_rule:
+        server_url: "{{ zabbix_server_url }}"
+        login_user: "{{ zabbix_login_user }}"
+        login_password: "{{ zabbix_login_password }}"
+        name: ACME
+        state: present
+        iprange:
+          - 192.168.1.1-255
+          - 10.0.0.1-255
+        dchecks:
+          - type: 13
+            snmp_community: CUSTOMER@snmp3-readonly
+            ports: "161"
+            key_: iso.3.6.1.2.1.1.1.0
+            snmpv3_contextname: "ContextName"
+            snmpv3_securityname: "SecurityName"
+            snmpv3_securitylevel: 2
+            snmpv3_authprotocol: 1
+            snmpv3_authpassphrase: "SeCrEt"
+            snmpv3_privprotocol: 1
+            snmpv3_privpassphrase: "TopSecret"
+            uniq: 0
+            host_source: 1
+            name_source: 0
+        proxy: ACME_proxy
+      register: drule_proxy_update_again
+
+    - name: assert that nothing has been changed
+      assert:
+        that: not drule_proxy_update_again is changed
 
 - name: test - delete Zabbix discovery rule
   zabbix_discovery_rule:

--- a/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: test - do not run tests for Zabbix 3.0
+  meta: end_play
+  when: zabbix_version is version('3.0', '=')
+
 - name: test - Zabbix discovery rule
   module_defaults:
     zabbix_discovery_rule:

--- a/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
@@ -45,7 +45,7 @@
         - type: 12
   register: drule_iprange_update
 
-- name: assert that ipragne has been changed
+- name: assert that iprange has been changed
   assert:
     that: drule_iprange_update is changed
 
@@ -64,7 +64,7 @@
     status: 1
   register: drule_status_update
 
-- name: assert that ipragne has been changed
+- name: assert that iprange has been changed
   assert:
     that: drule_status_update is changed
 
@@ -83,7 +83,7 @@
     status: 0
   register: drule_status_update_again
 
-- name: assert that ipragne has been changed
+- name: assert that iprange has been changed
   assert:
     that: drule_status_update_again is changed
 
@@ -110,6 +110,116 @@
   assert:
     that: drule_dchecks_update is changed
 
+- name: test - update Zabbix discovery rule dchecks ssh
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange:
+      - 192.168.1.1-255
+      - 10.0.0.1-255
+    dchecks:
+        - type: 12
+        - type: 0
+          ports: "22"
+  register: drule_dchecks_ssh_update
+
+- name: assert that dcheck has been changed
+  assert:
+    that: drule_dchecks_ssh_update is changed
+
+- name: test - update Zabbix discovery rule dchecks ldap
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange:
+      - 192.168.1.1-255
+      - 10.0.0.1-255
+    dchecks:
+        - type: 12
+        - type: 0
+          ports: "22"
+        - type: 1
+          ports: "389"
+  register: drule_dchecks_ldap_update
+
+- name: assert that dcheck has been changed
+  assert:
+    that: drule_dchecks_ldap_update is changed
+
+- name: test - update Zabbix discovery rule dchecks smtp
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange:
+      - 192.168.1.1-255
+      - 10.0.0.1-255
+    dchecks:
+        - type: 12
+        - type: 0
+          ports: "22"
+        - type: 1
+          ports: "389"
+        - type: 2
+          ports: 25,465,587
+  register: drule_dchecks_smtp_update
+
+- name: assert that dcheck has been changed
+  assert:
+    that: drule_dchecks_smtp_update is changed
+
+- name: test - update Zabbix discovery rule dchecks http
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange:
+      - 192.168.1.1-255
+      - 10.0.0.1-255
+    dchecks:
+        - type: 12
+        - type: 0
+          ports: "22"
+        - type: 1
+          ports: "389"
+        - type: 2
+          ports: 25,465,587
+        - type: 4
+          ports: 80,8080
+  register: drule_dchecks_http_update
+
+- name: assert that dcheck has been changed
+  assert:
+    that: drule_dchecks_http_update is changed
+
+- name: test - remove Zabbix discovery rule dchecks
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange:
+      - 192.168.1.1-255
+      - 10.0.0.1-255
+    dchecks:
+        - type: 12
+  register: drule_dchecks_remove_update
+
+- name: assert that dcheck has been changed
+  assert:
+    that: drule_dchecks_remove_update is changed
+
 - name: test - update Zabbix discovery rule snmp dcheck
   zabbix_discovery_rule:
     server_url: "{{ zabbix_server_url }}"
@@ -133,6 +243,44 @@
 - name: assert that snmp dcheck has been changed
   assert:
     that: drule_snmp_update is changed
+
+- name: test - update Zabbix discovery rule add snmp3 dcheck
+  zabbix_discovery_rule:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ACME
+    state: present
+    iprange:
+      - 192.168.1.1-255
+      - 10.0.0.1-255
+    dchecks:
+        - type: 11
+          snmp_community: CUSTOMER@snmp-readonly
+          ports: "161"
+          key_: iso.3.6.1.2.1.1.1.0
+          uniq: 0
+          host_source: 3
+          name_source: 3
+        - type: 13
+          snmp_community: CUSTOMER@snmp3-readonly
+          ports: "161"
+          key_: iso.3.6.1.2.1.1.1.0
+          snmpv3_contextname: "ContextName"
+          snmpv3_securityname: "SecurityName"
+          snmpv3_securitylevel: 2
+          snmpv3_authprotocol: 1
+          snmpv3_authpassphrase: "SeCrEt"
+          snmpv3_privprotocol: 1
+          snmpv3_privpassphrase: "TopSecret"
+          uniq: 0
+          host_source: 3
+          name_source: 3
+  register: drule_snmp3_update
+
+- name: assert that snmp dcheck has been changed
+  assert:
+    that: drule_snmp3_update is changed
 
 - block:
     - name: test - create new active Zabbix proxy server


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add new module for create, delete and update Zabbix discovery rules.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_discovery_rule

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- Include all available API options in this module. Reference can be found here: https://www.zabbix.com/documentation/current/manual/api/reference/drule
- Tests for the new module are included.

Below is the documentation of the module:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
module: zabbix_discovery_rule
short_description: Create/delete/update Zabbix discovery rules
description:
   - Create discovery rule.
   - Delete existing discovery rule.
   - Update existing discovery rule with new options.
author:
    - "Tobias Birkefeld (@tcraxs)"
requirements:
    - zabbix-api
options:
    state:
        description:
            - Create or delete user group.
        required: false
        type: str
        default: "present"
        choices: [ "present", "absent" ]
    name:
        description:
            - Name of the discovery rule.
        required: true
        type: str
    iprange:
        description:
            - One or several IP ranges to check separated by commas.
        required: true
        type: list
        elements: str
    dchecks:
        description:
            - List of dictionaries of discovery check objects.
            - For more information, review discovery check object documentation at
              U(https://www.zabbix.com/documentation/current/manual/api/reference/dcheck/object)
        required: true
        suboptions:
            type:
                description:
                    - Type of check.
                    - "Possible values:"
                    - "0 - SSH"
                    - "1 - LDAP"
                    - "2 - SMTP"
                    - "3 - FTP"
                    - "4 - HTTP"
                    - "5 - POP"
                    - "6 - NNTP"
                    - "7 - IMAP"
                    - "8 - TCP"
                    - "9 - Zabbix agent"
                    - "10 - SNMPv1 agent"
                    - "11 - SNMPv2 agent"
                    - "12 - ICMP ping"
                    - "13 - SNMPv3 agent"
                    - "14 - HTTPS"
                    - "15 - Telnet"
                type: int
                choices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
                required: true
            ports:
                description:
                    - One or several port ranges to check separated by commas. Used for all checks except for ICMP.
                type: str
            key_:
                description:
                    - "The value of this property differs depending on the type of the check:"
                    - "- key to query for Zabbix agent checks"
                    - "- SNMP OID for SNMPv1, SNMPv2 and SNMPv3 checks"
                type: str
            snmp_community:
                description:
                    - SNMP community.
                    - Required for SNMPv1 and SNMPv2 agent checks.
                type: str
            snmpv3_authpassphrase:
                description:
                    - Authentication passphrase used for SNMPv3 agent checks with security level set to authNoPriv or authPriv.
                type: str
            snmpv3_authprotocol:
                description:
                    - Authentication protocol used for SNMPv3 agent checks with security level set to authNoPriv or authPriv.
                    - "Possible values:"
                    - "0 - (default) MD5"
                    - "1 - SHA"
                type: int
                choices: [0, 1]
            snmpv3_contextname:
                description:
                    - SNMPv3 context name. Used only by SNMPv3 checks.
                type: str
            snmpv3_privpassphrase:
                description:
                    - Privacy passphrase used for SNMPv3 agent checks with security level set to authPriv.
                type: str
            snmpv3_privprotocol:
                description:
                    - Privacy protocol used for SNMPv3 agent checks with security level set to authPriv.
                    - "Possible values:"
                    - "0 - (default) DES"
                    - "1 - AES"
                type: int
                choices: [0, 1]
            snmpv3_securitylevel:
                description:
                    - Security level used for SNMPv3 agent checks.
                    - "Possible values:"
                    - "0 - noAuthNoPriv"
                    - "1 - authNoPriv"
                    - "2 - authPriv"
                type: int
                choices: [0, 1, 2]
            snmpv3_securityname:
                description:
                    - Security name used for SNMPv3 agent checks.
                type: str
            uniq:
                description:
                    - Whether to use this check as a device uniqueness criteria.
                    - Only a single unique check can be configured for a discovery rule.
                    - Used for Zabbix agent, SNMPv1, SNMPv2 and SNMPv3 agent checks.
                    - "Possible values:"
                    - "0 - (default) do not use this check as a uniqueness criteria"
                    - "1 - use this check as a uniqueness criteria"
                type: int
                default: 0
                choices: [0, 1]
            host_source:
                description:
                    - Source for host name.
                    - "Possible values:"
                    - "1 - (default) DNS"
                    - "2 - IP"
                    - "3 - discovery value of this check"
                type: int
                default: 1
                choices: [1, 2, 3]
            name_source:
                description:
                    - Source for visible name.
                    - "Possible values:"
                    - "0 - (default) not specified"
                    - "1 - DNS"
                    - "2 - IP"
                    - "3 - discovery value of this check"
                type: int
                default: 0
                choices: [0, 1, 2, 3]
        type: list
        aliases: [ "dcheck" ]
    delay:
        description:
            - Execution interval of the discovery rule.
        required: false
        type: str
        default: "1h"
    proxy:
        description:
            - Name of the proxy used for discovery.
        required: false
        type: str
    status:
        description:
            - Whether the discovery rule is enabled.
            - "Possible values:"
            - "0 - (default) enabled"
            - "1 - disabled"
        required: false
        type: int
        default: 0
        choices: [0, 1]
```
