### PR TITLE
Integration tests for zabbix_action module with few adjusted fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@
 
 ### Improvements
 #### Modules:
-  - zabbix_action - fixed error on changed API fields for Zabbix 5.0 [GitHub Issue](https://github.com/rockaut/community.zabbix/edit/fix_92)
+  - zabbix_action - fixed error on changed API fields `*default_message` and `*default_subject` for Zabbix 5.0 (PR [#92](https://github.com/ansible-collections/community.zabbix/pull/92)).
+  - zabbix_action - parameter `ssh_auth_type` for SSH `remote_command` operation now correctly identifies which other parameters are required (PR [#113](https://github.com/ansible-collections/community.zabbix/pull/113)).
+  - zabbix_action - no longer requires `password` and `ssh_*key_file` parameters at the same time for `remote_command` operations of type SSH (PR [#113](https://github.com/ansible-collections/community.zabbix/pull/113)).
   - zabbix_mediatype - now supports new `webhook` media type (PR [#82](https://github.com/ansible-collections/community.zabbix/pull/82)).
   - zabbix_mediatype - new options `message_templates`, `description` and many more related to `type=webhook` (PR [#82](https://github.com/ansible-collections/community.zabbix/pull/82)).
 
 ### Bug Fixes:
 #### Modules:
   - zabbix_action - now correctly selects mediatype for the (normal|recovery|update) operations with Zabbix 4.4 and newer. (PR [#90](https://github.com/ansible-collections/community.zabbix/pull/90))
+  - zabbix_action - clarified choices for the `inventory` paramters in `*operations` sub option to `manual` and `automatic` (PR [#113](https://github.com/ansible-collections/community.zabbix/pull/113)).
+  - zabbix_action - module will no longer fail when searching for global script provided to `script_name` parameter (PR [#113](https://github.com/ansible-collections/community.zabbix/pull/113)).
   - zabbix_service - fixed the zabbix_service has no idempotency with Zabbix 5.0 (PR [#116](https://github.com/ansible-collections/community.zabbix/pull/116))
 
 ## 0.2.0

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -873,6 +873,9 @@ class Action(object):
             _params.pop('def_shortdata', None)
             _params.pop('r_longdata', None)
             _params.pop('r_shortdata', None)
+
+        if (LooseVersion(self._zbx_api_version) < LooseVersion('3.4') or
+            LooseVersion(self._zbx_api_version) >= LooseVersion('5.0')):
             _params.pop('ack_longdata', None)
             _params.pop('ack_shortdata', None)
 

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -875,7 +875,7 @@ class Action(object):
             _params.pop('r_shortdata', None)
 
         if (LooseVersion(self._zbx_api_version) < LooseVersion('3.4') or
-            LooseVersion(self._zbx_api_version) >= LooseVersion('5.0')):
+                LooseVersion(self._zbx_api_version) >= LooseVersion('5.0')):
             _params.pop('ack_longdata', None)
             _params.pop('ack_shortdata', None)
 

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -63,10 +63,11 @@ options:
         required: false
     conditions:
         type: list
+        elements: dict
         description:
-            - List of dictionaries of conditions to evaluate.
+            - List of conditions to use for filtering results.
             - For more information about suboptions of this option please
-              check out Zabbix API documentation U(https://www.zabbix.com/documentation/4.0/manual/api/reference/action/object#action_filter_condition)
+              check out Zabbix API documentation U(https://www.zabbix.com/documentation/5.0/manual/api/reference/action/object#action_filter_condition)
         suboptions:
             type:
                 description:
@@ -158,7 +159,7 @@ options:
                 description:
                     - Arbitrary unique ID that is used to reference the condition from a custom expression.
                     - Can only contain upper-case letters.
-                    - Required for custom expression filters.
+                    - Required for custom expression filters and ignored otherwise.
     eval_type:
         description:
             - Filter condition evaluation method.
@@ -172,11 +173,11 @@ options:
             - 'custom_expression'
     formula:
         description:
-            - User-defined expression to be used for evaluating conditions of filters with a custom expression.
-            - The expression must contain IDs that reference specific filter conditions by its formulaid.
+            - User-defined expression to be used for evaluating conditions with a custom expression.
+            - The expression must contain IDs that reference each condition by its formulaid.
             - The IDs used in the expression must exactly match the ones
-              defined in the filter conditions. No condition can remain unused or omitted.
-            - Required for custom expression filters.
+              defined in the I(conditions). No condition can remain unused or omitted.
+            - Required when I(eval_type=custom_expression).
             - Use sequential IDs that start at "A". If non-sequential IDs are used, Zabbix re-indexes them.
               This makes each module run notice the difference in IDs and update the action.
     default_message:
@@ -250,6 +251,7 @@ options:
             esc_step_to:
                 description:
                     - Step to end escalation at.
+                    - Specify 0 for infinitely.
                 default: 1
             send_to_groups:
                 type: list
@@ -270,6 +272,7 @@ options:
             media_type:
                 description:
                     - Media type that will be used to send the message.
+                    - Can be used with I(type=send_message) or I(type=notify_all_involved) inside I(acknowledge_operations).
                     - Set to C(all) for all media types
                 default: 'all'
             operation_condition:
@@ -293,6 +296,9 @@ options:
                 description:
                     - Host inventory mode.
                     - Required when I(type=set_host_inventory_mode).
+                choices:
+                    - manual
+                    - automatic
             command_type:
                 description:
                     - Type of operation command.
@@ -318,11 +324,11 @@ options:
             run_on_groups:
                 description:
                     - Host groups to run remote commands on.
-                    - Required when I(type=remote_command) if I(run_on_hosts) is not set.
+                    - Required when I(type=remote_command) and I(run_on_hosts) is not set.
             run_on_hosts:
                 description:
                     - Hosts to run remote commands on.
-                    - Required when I(type=remote_command) if I(run_on_groups) is not set.
+                    - Required when I(type=remote_command) and I(run_on_groups) is not set.
                     - If set to 0 the command will be run on the current host.
             ssh_auth_type:
                 description:
@@ -334,27 +340,32 @@ options:
             ssh_privatekey_file:
                 description:
                     - Name of the private key file used for SSH commands with public key authentication.
-                    - Required when I(type=remote_command) and I(command_type=ssh).
+                    - Required when I(ssh_auth_type=public_key).
+                    - Can be used when I(type=remote_command).
             ssh_publickey_file:
                 description:
                     - Name of the public key file used for SSH commands with public key authentication.
-                    - Required when I(type=remote_command) and I(command_type=ssh).
+                    - Required when I(ssh_auth_type=public_key).
+                    - Can be used when I(type=remote_command).
             username:
                 description:
                     - User name used for authentication.
-                    - Required when I(type=remote_command) and I(command_type in [ssh, telnet]).
+                    - Required when I(ssh_auth_type in [public_key, password]) or I(command_type=telnet).
+                    - Can be used when I(type=remote_command).
             password:
                 description:
                     - Password used for authentication.
-                    - Required when I(type=remote_command) and I(command_type in [ssh, telnet]).
+                    - Required when I(ssh_auth_type=password) or I(command_type=telnet).
+                    - Can be used when I(type=remote_command).
             port:
                 description:
                     - Port number used for authentication.
-                    - Required when I(type=remote_command) and I(command_type in [ssh, telnet]).
+                    - Can be used when I(command_type in [ssh, telnet]) and I(type=remote_command).
             script_name:
                 description:
                     - The name of script used for global script commands.
-                    - Required when I(type=remote_command) and I(command_type=global_script).
+                    - Required when I(command_type=global_script).
+                    - Can be used when I(type=remote_command).
     recovery_operations:
         type: list
         description:
@@ -521,7 +532,6 @@ class Zapi(object):
                 "selectRecoveryOperations": "extend",
                 "selectAcknowledgeOperations": "extend",
                 "selectFilter": "extend",
-                'selectInventory': 'extend',
                 'filter': {'name': [name]}
             })
             if len(_action) > 0:
@@ -544,7 +554,6 @@ class Zapi(object):
         try:
             action_list = self._zapi.action.get({
                 'output': 'extend',
-                'selectInventory': 'extend',
                 'filter': {'name': [name]}
             })
             if len(action_list) < 1:
@@ -590,7 +599,6 @@ class Zapi(object):
         try:
             hostgroup_list = self._zapi.hostgroup.get({
                 'output': 'extend',
-                'selectInventory': 'extend',
                 'filter': {'name': [hostgroup_name]}
             })
             if len(hostgroup_list) < 1:
@@ -613,7 +621,6 @@ class Zapi(object):
         try:
             template_list = self._zapi.template.get({
                 'output': 'extend',
-                'selectInventory': 'extend',
                 'filter': {'host': [template_name]}
             })
             if len(template_list) < 1:
@@ -636,7 +643,6 @@ class Zapi(object):
         try:
             trigger_list = self._zapi.trigger.get({
                 'output': 'extend',
-                'selectInventory': 'extend',
                 'filter': {'description': [trigger_name]}
             })
             if len(trigger_list) < 1:
@@ -659,7 +665,6 @@ class Zapi(object):
         try:
             discovery_rule_list = self._zapi.drule.get({
                 'output': 'extend',
-                'selectInventory': 'extend',
                 'filter': {'name': [discovery_rule_name]}
             })
             if len(discovery_rule_list) < 1:
@@ -682,7 +687,6 @@ class Zapi(object):
         try:
             discovery_check_list = self._zapi.dcheck.get({
                 'output': 'extend',
-                'selectInventory': 'extend',
                 'filter': {'name': [discovery_check_name]}
             })
             if len(discovery_check_list) < 1:
@@ -705,7 +709,6 @@ class Zapi(object):
         try:
             proxy_list = self._zapi.proxy.get({
                 'output': 'extend',
-                'selectInventory': 'extend',
                 'filter': {'host': [proxy_name]}
             })
             if len(proxy_list) < 1:
@@ -735,7 +738,6 @@ class Zapi(object):
                 return '0'
             mediatype_list = self._zapi.mediatype.get({
                 'output': 'extend',
-                'selectInventory': 'extend',
                 'filter': filter
             })
             if len(mediatype_list) < 1:
@@ -758,8 +760,7 @@ class Zapi(object):
         try:
             user_list = self._zapi.user.get({
                 'output': 'extend',
-                'selectInventory':
-                'extend', 'filter': {'alias': [user_name]}
+                'filter': {'alias': [user_name]}
             })
             if len(user_list) < 1:
                 self._module.fail_json(msg="User not found: %s" % user_name)
@@ -781,7 +782,6 @@ class Zapi(object):
         try:
             usergroup_list = self._zapi.usergroup.get({
                 'output': 'extend',
-                'selectInventory': 'extend',
                 'filter': {'name': [usergroup_name]}
             })
             if len(usergroup_list) < 1:
@@ -807,7 +807,6 @@ class Zapi(object):
                 return {}
             script_list = self._zapi.script.get({
                 'output': 'extend',
-                'selectInventory': 'extend',
                 'filter': {'name': [script_name]}
             })
             if len(script_list) < 1:
@@ -1059,8 +1058,8 @@ class Operations(object):
                 ).get('scriptid'),
                 'authtype': to_numeric_value([
                     'password',
-                    'private_key'
-                ], operation.get('ssh_auth_type', 'password')),
+                    'public_key'
+                ], operation.get('ssh_auth_type')),
                 'privatekey': operation.get('ssh_privatekey_file'),
                 'publickey': operation.get('ssh_publickey_file'),
                 'username': operation.get('username'),
@@ -1135,7 +1134,12 @@ class Operations(object):
         Returns:
             dict: constructed operation inventory
         """
-        return {'inventory_mode': operation.get('inventory')}
+        return {
+            'inventory_mode': to_numeric_value([
+                'manual',
+                'automatic'
+            ], operation.get('inventory'))
+        }
 
     def _construct_opconditions(self, operation):
         """Construct operation conditions.
@@ -1624,6 +1628,9 @@ def to_numeric_value(strs, value):
     Returns:
         int: converted integer
     """
+    if value is None:
+        return value
+
     strs = [s.lower() if isinstance(s, str) else s for s in strs]
     value = value.lower()
     tmp_dict = dict(zip(strs, list(range(len(strs)))))
@@ -1810,12 +1817,7 @@ def main():
                     run_on_groups=dict(type='list', required=False),
                     run_on_hosts=dict(type='list', required=False),
                     script_name=dict(type='str', required=False),
-                    ssh_auth_type=dict(
-                        type='str',
-                        required=False,
-                        default='password',
-                        choices=['password', 'public_key']
-                    ),
+                    ssh_auth_type=dict(type='str', required=False, choices=['password', 'public_key']),
                     ssh_privatekey_file=dict(type='str', required=False),
                     ssh_publickey_file=dict(type='str', required=False),
                     username=dict(type='str', required=False),
@@ -1828,33 +1830,19 @@ def main():
                     # when type is add_to_host_group or remove_from_host_group
                     host_groups=dict(type='list', required=False),
                     # when type is set_host_inventory_mode
-                    inventory=dict(type='str', required=False),
+                    inventory=dict(type='str', required=False, choices=['manual', 'automatic']),
                     # when type is link_to_template or unlink_from_template
                     templates=dict(type='list', required=False)
                 ),
                 required_if=[
                     ['type', 'remote_command', ['command_type']],
                     ['type', 'remote_command', ['run_on_groups', 'run_on_hosts'], True],
-                    ['command_type', 'custom_script', [
-                        'command',
-                        'execute_on'
-                    ]],
+                    ['command_type', 'custom_script', ['command', 'execute_on']],
                     ['command_type', 'ipmi', ['command']],
-                    ['command_type', 'ssh', [
-                        'command',
-                        'password',
-                        'username',
-                        'port',
-                        'ssh_auth_type',
-                        'ssh_privatekey_file',
-                        'ssh_publickey_file'
-                    ]],
-                    ['command_type', 'telnet', [
-                        'command',
-                        'password',
-                        'username',
-                        'port'
-                    ]],
+                    ['command_type', 'ssh', ['command', 'ssh_auth_type']],
+                    ['ssh_auth_type', 'password', ['username', 'password']],
+                    ['ssh_auth_type', 'public_key', ['username', 'ssh_privatekey_file', 'ssh_publickey_file']],
+                    ['command_type', 'telnet', ['command', 'username', 'password']],
                     ['command_type', 'global_script', ['script_name']],
                     ['type', 'add_to_host_group', ['host_groups']],
                     ['type', 'remove_from_host_group', ['host_groups']],
@@ -1902,12 +1890,7 @@ def main():
                     run_on_groups=dict(type='list', required=False),
                     run_on_hosts=dict(type='list', required=False),
                     script_name=dict(type='str', required=False),
-                    ssh_auth_type=dict(
-                        type='str',
-                        required=False,
-                        default='password',
-                        choices=['password', 'public_key']
-                    ),
+                    ssh_auth_type=dict(type='str', required=False, choices=['password', 'public_key']),
                     ssh_privatekey_file=dict(type='str', required=False),
                     ssh_publickey_file=dict(type='str', required=False),
                     username=dict(type='str', required=False),
@@ -1929,21 +1912,10 @@ def main():
                         'execute_on'
                     ]],
                     ['command_type', 'ipmi', ['command']],
-                    ['command_type', 'ssh', [
-                        'command',
-                        'password',
-                        'username',
-                        'port',
-                        'ssh_auth_type',
-                        'ssh_privatekey_file',
-                        'ssh_publickey_file'
-                    ]],
-                    ['command_type', 'telnet', [
-                        'command',
-                        'password',
-                        'username',
-                        'port'
-                    ]],
+                    ['command_type', 'ssh', ['command', 'ssh_auth_type']],
+                    ['ssh_auth_type', 'password', ['username', 'password']],
+                    ['ssh_auth_type', 'public_key', ['username', 'ssh_privatekey_file', 'ssh_publickey_file']],
+                    ['command_type', 'telnet', ['command', 'username', 'password']],
                     ['command_type', 'global_script', ['script_name']],
                     ['type', 'send_message', ['send_to_users', 'send_to_groups'], True]
                 ]
@@ -1987,12 +1959,7 @@ def main():
                     run_on_groups=dict(type='list', required=False),
                     run_on_hosts=dict(type='list', required=False),
                     script_name=dict(type='str', required=False),
-                    ssh_auth_type=dict(
-                        type='str',
-                        required=False,
-                        default='password',
-                        choices=['password', 'public_key']
-                    ),
+                    ssh_auth_type=dict(type='str', required=False, choices=['password', 'public_key']),
                     ssh_privatekey_file=dict(type='str', required=False),
                     ssh_publickey_file=dict(type='str', required=False),
                     username=dict(type='str', required=False),
@@ -2014,21 +1981,10 @@ def main():
                         'execute_on'
                     ]],
                     ['command_type', 'ipmi', ['command']],
-                    ['command_type', 'ssh', [
-                        'command',
-                        'password',
-                        'username',
-                        'port',
-                        'ssh_auth_type',
-                        'ssh_privatekey_file',
-                        'ssh_publickey_file'
-                    ]],
-                    ['command_type', 'telnet', [
-                        'command',
-                        'password',
-                        'username',
-                        'port'
-                    ]],
+                    ['command_type', 'ssh', ['command', 'ssh_auth_type']],
+                    ['ssh_auth_type', 'password', ['username', 'password']],
+                    ['ssh_auth_type', 'public_key', ['username', 'ssh_privatekey_file', 'ssh_publickey_file']],
+                    ['command_type', 'telnet', ['command', 'username', 'password']],
                     ['command_type', 'global_script', ['script_name']],
                     ['type', 'send_message', ['send_to_users', 'send_to_groups'], True]
                 ]

--- a/tests/integration/targets/test_zabbix_action/meta/main.yml
+++ b/tests/integration/targets/test_zabbix_action/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_zabbix

--- a/tests/integration/targets/test_zabbix_action/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_action/tasks/main.yml
@@ -1,0 +1,1165 @@
+---
+- name: test - prepare example template for zabbix_action module
+  zabbix_template:
+    server_url: "{{ zabbix_server_url }} "
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    template_name: ExampleTemplateForActionModule
+    template_groups:
+      - Templates
+    state: present
+  register: zbxaction_prep_template
+
+- name: test - prepare example mediatype for zabbix_action module
+  zabbix_mediatype:
+    server_url: "{{ zabbix_server_url }} "
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleMediaTypeForActionModule
+    smtp_email: zabbix@example.com
+    type: email
+    state: present
+  register: zbxaction_prep_mediatype
+
+- name: test - simple actions
+  module_defaults:
+    zabbix_action:
+      server_url: "{{ zabbix_server_url }}"
+      login_user: "{{ zabbix_login_user }}"
+      login_password: "{{ zabbix_login_password }}"
+      state: present
+      status: enabled
+      name: ExampleTriggerAction
+      event_source: trigger
+      esc_period: 60
+      conditions:
+        - type: trigger_severity
+          operator: '>='
+          value: Information
+      operations:
+        - type: send_message
+          subject: ExampleSubject
+          message: ExampleMessage
+          media_type: ExampleMediaTypeForActionModule
+          send_to_users:
+            - Admin
+
+  block:
+  - name: test - create new action
+    zabbix_action:
+    register: zbxaction_new
+
+  - assert:
+      that: zbxaction_new.changed is sameas True
+
+  - name: test - create new action (again)
+    zabbix_action:
+    register: zbxaction_new
+
+  - assert:
+      that: zbxaction_new.changed is sameas False
+
+  - when: zabbix_version is version('3.4', '>=')
+    block:
+    - name: test - update action with esc_period as string
+      zabbix_action:
+        esc_period: 2m
+      register: zbxaction_escperiod_str
+
+    - assert:
+        that: zbxaction_escperiod_str.changed is sameas True
+
+    - name: test - update action with esc_period as string (again)
+      zabbix_action:
+        esc_period: 2m
+      register: zbxaction_escperiod_str
+
+    - assert:
+        that: zbxaction_escperiod_str.changed is sameas False
+
+    - name: test - update action with esc_period as macro
+      zabbix_action:
+        esc_period: '{$MYMACRO}'
+      register: zbxaction_escperiod_macro
+
+    - assert:
+        that: zbxaction_escperiod_macro.changed is sameas True
+
+    - name: test - update action with esc_period as macro (again)
+      zabbix_action:
+        esc_period: '{$MYMACRO}'
+      register: zbxaction_escperiod_macro
+
+    - assert:
+        that: zbxaction_escperiod_macro.changed is sameas False
+
+  - name: test - update action with esc_period
+    zabbix_action:
+      esc_period: 120
+    register: zbxaction_escperiod
+
+  - assert:
+      that: zbxaction_escperiod.changed is sameas True
+
+  - name: test - update action with esc_period (again)
+    zabbix_action:
+      esc_period: 120
+    register: zbxaction_escperiod
+
+  - assert:
+      that: zbxaction_escperiod.changed is sameas False
+
+  - name: test - update action with pause_in_maintenance
+    zabbix_action:
+      esc_period: 120
+      pause_in_maintenance: False
+    register: zbxaction_maintpause
+
+  - assert:
+      that: zbxaction_maintpause.changed is sameas True
+
+  - name: test - update action with pause_in_maintenance (again)
+    zabbix_action:
+      esc_period: 120
+      pause_in_maintenance: False
+    register: zbxaction_maintpause
+
+  - assert:
+      that: zbxaction_maintpause.changed is sameas False
+
+  - name: test - reset action to default
+    zabbix_action:
+    register: zbxaction_reset
+
+  - assert:
+      that: zbxaction_reset.changed is sameas True
+
+  - when: zabbix_version is version('5.0', '<')
+    block:
+    - name: test - update action with default_subject and default_message
+      zabbix_action:
+        default_subject: Example default subject
+        default_message: Example default message
+      register: zbxaction_def_msgsubj
+
+    - assert:
+        that: zbxaction_def_msgsubj.changed is sameas True
+
+    - name: test - update action with default_subject and default_message (again)
+      zabbix_action:
+        default_subject: Example default subject
+        default_message: Example default message
+      register: zbxaction_def_msgsubj
+
+    - assert:
+        that: zbxaction_def_msgsubj.changed is sameas False
+
+  - when:
+      - zabbix_version is version('3.2', '>=')
+      - zabbix_version is version('5.0', '<')
+    block:
+    - name: test - update action with recovery_default_subject and recovery_default_message
+      zabbix_action:
+        default_subject: Example default subject
+        default_message: Example default message
+        recovery_default_subject: Example recovery subject
+        recovery_default_message: Example recovery message
+      register: zbxaction_rec_msgsubj
+
+    - assert:
+        that: zbxaction_rec_msgsubj.changed is sameas True
+
+    - name: test - update action with recovery_default_subject and recovery_default_message (again)
+      zabbix_action:
+        default_subject: Example default subject
+        default_message: Example default message
+        recovery_default_subject: Example recovery subject
+        recovery_default_message: Example recovery message
+      register: zbxaction_rec_msgsubj
+
+    - assert:
+        that: zbxaction_rec_msgsubj.changed is sameas False
+
+  - when:
+      - zabbix_version is version('3.4', '>=')
+      - zabbix_version is version('5.0', '<')
+    block:
+    - name: test - update action with acknowledge_default_subject and acknowledge_default_message
+      zabbix_action:
+        default_subject: Example default subject
+        default_message: Example default message
+        recovery_default_subject: Example recovery subject
+        recovery_default_message: Example recovery message
+        acknowledge_default_subject: Example acknowledge subject
+        acknowledge_default_message: Example acknowledge message
+      register: zbxaction_ack_msgsubj
+
+    - assert:
+        that: zbxaction_ack_msgsubj.changed is sameas True
+
+    - name: test - update action with acknowledge_default_subject and acknowledge_default_message (again)
+      zabbix_action:
+        default_subject: Example default subject
+        default_message: Example default message
+        recovery_default_subject: Example recovery subject
+        recovery_default_message: Example recovery message
+        acknowledge_default_subject: Example acknowledge subject
+        acknowledge_default_message: Example acknowledge message
+      register: zbxaction_ack_msgsubj
+
+    - assert:
+        that: zbxaction_ack_msgsubj.changed is sameas False
+
+  - name: test - reset action to default
+    zabbix_action:
+    register: zbxaction_reset
+
+  - assert:
+      that: zbxaction_reset.changed is sameas True
+
+  - name: test - disable action
+    zabbix_action:
+      status: disabled
+    register: zbxaction_disable
+
+  - assert:
+      that: zbxaction_disable.changed is sameas True
+
+  - name: test - disable action (again)
+    zabbix_action:
+      status: disabled
+    register: zbxaction_disable
+
+  - assert:
+      that: zbxaction_disable.changed is sameas False
+
+  - name: test - delete action
+    zabbix_action:
+      state: absent
+    register: zbxaction_delete
+
+  - assert:
+      that: zbxaction_delete.changed is sameas True
+
+  - name: test - delete action (again)
+    zabbix_action:
+      state: absent
+    register: zbxaction_delete
+
+  - assert:
+      that: zbxaction_delete.changed is sameas False
+
+- name: test - trigger actions with conditions
+  module_defaults:
+    zabbix_action:
+      server_url: "{{ zabbix_server_url }}"
+      login_user: "{{ zabbix_login_user }}"
+      login_password: "{{ zabbix_login_password }}"
+      state: present
+      status: enabled
+      name: ExampleTriggerActionConditions
+      event_source: trigger
+      esc_period: 60
+      operations:
+        - type: send_message
+          subject: ExampleSubject
+          message: ExampleMessage
+          media_type: ExampleMediaTypeForActionModule
+          send_to_users:
+            - Admin
+
+  block:
+  - name: test - create new action with multiple conditions
+    zabbix_action:
+      conditions:
+        - type: host_group
+          operator: '='
+          value: Linux servers
+        - type: trigger_severity
+          operator: '>='
+          value: Average
+        - type: application
+          operator: like
+          value: AnsibleTest
+        - type: event_tag_value
+          value: MyTag
+          operator: '='
+          value2: MyTagValue
+        - type: time_period
+          operator: not in
+          value: 6-7,00:00-24:00
+    register: zbxaction_conditions
+
+  - assert:
+      that: zbxaction_conditions.changed is sameas True
+
+  - name: test - create new action with multiple conditions (again)
+    zabbix_action:
+      conditions:
+        - type: host_group
+          operator: '='
+          value: Linux servers
+        - type: trigger_severity
+          operator: '>='
+          value: Average
+        - type: application
+          operator: like
+          value: AnsibleTest
+        - type: event_tag_value
+          value: MyTag
+          operator: '='
+          value2: MyTagValue
+        - type: time_period
+          operator: not in
+          value: 6-7,00:00-24:00
+    register: zbxaction_conditions
+
+  - assert:
+      that: zbxaction_conditions.changed is sameas False
+
+  - name: test - create new action with multiple conditions (reorder)
+    zabbix_action:
+      conditions:
+        - type: host_group
+          operator: '='
+          value: Linux servers
+        - type: application
+          operator: like
+          value: AnsibleTest
+        - type: event_tag_value
+          value: MyTag
+          operator: '='
+          value2: MyTagValue
+        - type: trigger_severity
+          operator: '>='
+          value: Average
+        - type: time_period
+          operator: not in
+          value: 6-7,00:00-24:00
+    register: zbxaction_conditions_reorder
+
+  - assert:
+      that: zbxaction_conditions_reorder.changed is sameas True
+
+  - name: test - update action with multiple conditions by removing one condition
+    zabbix_action:
+      conditions:
+        - type: host_group
+          operator: '='
+          value: Linux servers
+        - type: application
+          operator: like
+          value: AnsibleTest
+        - type: event_tag_value
+          value: MyTag
+          operator: '='
+          value2: MyTagValue
+        - type: trigger_severity
+          operator: '>='
+          value: Average
+    register: zbxaction_conditions_delone
+
+  - assert:
+      that: zbxaction_conditions_delone.changed is sameas True
+
+  - name: test - update action with multiple conditions by changing operators
+    zabbix_action:
+      conditions:
+        - type: host_group
+          operator: '<>'
+          value: Linux servers
+        - type: application
+          operator: not like
+          value: AnsibleTest
+        - type: event_tag_value
+          value: MyTag
+          operator: '<>'
+          value2: MyTagValue
+        - type: trigger_severity
+          operator: '<='
+          value: Average
+    register: zbxaction_conditions_operators
+
+  - assert:
+      that: zbxaction_conditions_operators.changed is sameas True
+
+  - name: test - update action with multiple conditions and evaltype
+    zabbix_action:
+      conditions:
+        - type: host_group
+          operator: '<>'
+          value: Linux servers
+        - type: application
+          operator: not like
+          value: AnsibleTest
+        - type: event_tag_value
+          value: MyTag
+          operator: '<>'
+          value2: MyTagValue
+        - type: trigger_severity
+          operator: '<='
+          value: Average
+      eval_type: and
+    register: zbxaction_conditions_eval
+
+  - assert:
+      that: zbxaction_conditions_eval.changed is sameas True
+
+  - name: test - update action with multiple conditions and evaltype (again)
+    zabbix_action:
+      conditions:
+        - type: host_group
+          operator: '<>'
+          value: Linux servers
+        - type: application
+          operator: not like
+          value: AnsibleTest
+        - type: event_tag_value
+          value: MyTag
+          operator: '<>'
+          value2: MyTagValue
+        - type: trigger_severity
+          operator: '<='
+          value: Average
+      eval_type: and
+    register: zbxaction_conditions_eval
+
+  - assert:
+      that: zbxaction_conditions_eval.changed is sameas False
+
+  - name: test - update action with reduced conditions and formula
+    zabbix_action:
+      conditions:
+        - type: host_group
+          operator: '='
+          value: Linux servers
+          formulaid: A
+        - type: trigger_severity
+          operator: '>='
+          value: Average
+          formulaid: B
+        - type: event_tag_value
+          value: MyTag
+          operator: '<>'
+          value2: MyTagValue
+          formulaid: C
+      formula: A and (B or C)
+    register: zbxaction_conditions_formula
+
+  - assert:
+      that: zbxaction_conditions_formula.changed is sameas True
+
+  - name: test - update formula used in action with reduced conditions
+    zabbix_action:
+      conditions:
+        - type: host_group
+          operator: '='
+          value: Linux servers
+          formulaid: A
+        - type: trigger_severity
+          operator: '>='
+          value: Average
+          formulaid: B
+        - type: event_tag_value
+          value: MyTag
+          operator: '<>'
+          value2: MyTagValue
+          formulaid: C
+      formula: (A or B) or C
+    register: zbxaction_conditions_formula
+
+  - assert:
+      that: zbxaction_conditions_formula.changed is sameas True
+
+  - name: test - update formula used in action with reduced conditions (again)
+    zabbix_action:
+      conditions:
+        - type: host_group
+          operator: '='
+          value: Linux servers
+          formulaid: A
+        - type: trigger_severity
+          operator: '>='
+          value: Average
+          formulaid: B
+        - type: event_tag_value
+          value: MyTag
+          operator: '<>'
+          value2: MyTagValue
+          formulaid: C
+      formula: (A or B) or C
+    register: zbxaction_conditions_formula
+
+  - assert:
+      that: zbxaction_conditions_formula.changed is sameas False
+
+  - name: test - delete action
+    zabbix_action:
+      state: absent
+    register: zbxaction_delete
+
+  - assert:
+      that: zbxaction_delete.changed is sameas True
+
+- name: test - trigger actions with operations
+  module_defaults:
+    zabbix_action:
+      server_url: "{{ zabbix_server_url }}"
+      login_user: "{{ zabbix_login_user }}"
+      login_password: "{{ zabbix_login_password }}"
+      state: present
+      status: enabled
+      name: ExampleTriggerActionOperations
+      event_source: trigger
+      esc_period: 60
+      conditions:
+        - type: trigger_severity
+          operator: '>='
+          value: Average
+
+  block:
+  - name: test - create new action with send_message operations
+    zabbix_action:
+      operations:
+        - type: send_message
+          send_to_users:
+            - Admin
+          subject: test_subject
+          message: test_message
+          media_type: ExampleMediaTypeForActionModule
+          operation_condition: not_acknowledged
+          esc_step_from: 1
+          esc_step_to: 2
+        - type: send_message
+          send_to_users:
+            - Admin
+          subject: test_subject
+          message: test_message
+          media_type: SMS
+          operation_condition: not_acknowledged
+          esc_step_from: 2
+          esc_step_to: 0
+          esc_period: 300
+    register: zbxaction_ops
+
+  - assert:
+      that: zbxaction_ops.changed is sameas True
+
+  - name: test - create new action with send_message operations (again)
+    zabbix_action:
+      operations:
+        - type: send_message
+          send_to_users:
+            - Admin
+          subject: test_subject
+          message: test_message
+          media_type: ExampleMediaTypeForActionModule
+          operation_condition: not_acknowledged
+          esc_step_from: 1
+          esc_step_to: 2
+        - type: send_message
+          send_to_users:
+            - Admin
+          subject: test_subject
+          message: test_message
+          media_type: SMS
+          operation_condition: not_acknowledged
+          esc_step_from: 2
+          esc_step_to: 0
+          esc_period: 300
+    register: zbxaction_ops
+
+  - assert:
+      that: zbxaction_ops.changed is sameas False
+
+  - name: test - create new action with remote_command operations
+    zabbix_action:
+      operations:
+        - type: remote_command
+          command_type: custom_script
+          command: /usr/local/bin/do_something.sh
+          execute_on: agent
+          run_on_hosts: 0
+        - type: remote_command
+          command_type: ssh
+          command: /usr/local/bin/do_something.sh
+          run_on_hosts: 0
+          ssh_auth_type: password
+          username: root
+          password: zabbix
+        - type: remote_command
+          command_type: global_script
+          script_name: Ping
+          run_on_hosts: 0
+    register: zbxaction_rmtcmd
+
+  - assert:
+      that: zbxaction_rmtcmd.changed is sameas True
+
+  - name: test - create new action with remote_command operations (again)
+    zabbix_action:
+      operations:
+        - type: remote_command
+          command_type: custom_script
+          command: /usr/local/bin/do_something.sh
+          execute_on: agent
+          run_on_hosts: 0
+        - type: remote_command
+          command_type: ssh
+          command: /usr/local/bin/do_something.sh
+          run_on_hosts: 0
+          ssh_auth_type: password
+          username: root
+          password: zabbix
+        - type: remote_command
+          command_type: global_script
+          script_name: Ping
+          run_on_hosts: 0
+    register: zbxaction_rmtcmd
+
+  - assert:
+      that: zbxaction_rmtcmd.changed is sameas False
+
+  - name: test - update ssh remote_command auth in action with remote_command operations
+    zabbix_action:
+      operations:
+        - type: remote_command
+          command_type: custom_script
+          command: /usr/local/bin/do_something.sh
+          execute_on: agent
+          run_on_hosts: 0
+        - type: remote_command
+          command_type: ssh
+          command: /usr/local/bin/do_something.sh
+          run_on_hosts: 0
+          ssh_auth_type: public_key
+          username: root
+          ssh_privatekey_file: /etc/zabbix/.ssh/id_test
+          ssh_publickey_file: /etc/zabbix/.ssh/id_test.pub
+        - type: remote_command
+          command_type: global_script
+          script_name: Ping
+          run_on_hosts: 0
+    register: zbxaction_rmtcmd
+
+  - assert:
+      that: zbxaction_rmtcmd.changed is sameas True
+
+  - name: test - delete action
+    zabbix_action:
+      state: absent
+    register: zbxaction_delete
+
+  - assert:
+      that: zbxaction_delete.changed is sameas True
+
+- name: test - discovery actions
+  module_defaults:
+    zabbix_action:
+      server_url: "{{ zabbix_server_url }}"
+      login_user: "{{ zabbix_login_user }}"
+      login_password: "{{ zabbix_login_password }}"
+      state: present
+      status: enabled
+      name: ExampleDiscoveryActionOperations
+      event_source: discovery
+      esc_period: 60
+
+  block:
+  - name: test - create new discovery action
+    zabbix_action:
+      conditions:
+        - type: host_IP
+          operator: '='
+          value: '192.168.0.1-127'
+        - type: discovery_object
+          operator: '='
+          value: host
+        - type: discovery_status
+          operator: '='
+          value: 'discovered'
+        - type: uptime_or_downtime_duration
+          operator: '>='
+          value: 1800
+      operations:
+        - type: add_host
+        - type: add_to_host_group
+          host_groups:
+            - Linux servers
+        - type: link_to_template
+          templates:
+            - ExampleTemplateForActionModule
+        - type: enable_host
+        - type: set_host_inventory_mode
+          inventory: automatic
+    register: zbxaction_discovery
+
+  - assert:
+      that: zbxaction_discovery.changed is sameas True
+
+  - name: test - create new discovery action (again)
+    zabbix_action:
+      conditions:
+        - type: host_IP
+          operator: '='
+          value: '192.168.0.1-127'
+        - type: discovery_object
+          operator: '='
+          value: host
+        - type: discovery_status
+          operator: '='
+          value: 'discovered'
+        - type: uptime_or_downtime_duration
+          operator: '>='
+          value: 1800
+      operations:
+        - type: add_host
+        - type: add_to_host_group
+          host_groups:
+            - Linux servers
+        - type: link_to_template
+          templates:
+            - ExampleTemplateForActionModule
+        - type: enable_host
+        - type: set_host_inventory_mode
+          inventory: automatic
+    register: zbxaction_discovery
+
+  - assert:
+      that: zbxaction_discovery.changed is sameas False
+
+  - name: test - update discovery action conditions and operations
+    zabbix_action:
+      conditions:
+        - type: host_IP
+          operator: '='
+          value: '192.168.1.1-127'
+        - type: discovery_object
+          operator: '='
+          value: host
+        - type: discovery_status
+          operator: '='
+          value: 'discovered'
+        - type: uptime_or_downtime_duration
+          operator: '>='
+          value: 2200
+      operations:
+        - type: add_host
+        - type: add_to_host_group
+          host_groups:
+            - Linux servers
+            - Discovered hosts
+        - type: link_to_template
+          templates:
+            - ExampleTemplateForActionModule
+        - type: enable_host
+        - type: send_message
+          send_to_users:
+            - Admin
+          subject: test_subject
+          message: test_message
+          media_type: ExampleMediaTypeForActionModule
+          operation_condition: not_acknowledged
+          esc_step_from: 1
+          esc_step_to: 2
+    register: zbxaction_discovery_update
+
+  - assert:
+      that: zbxaction_discovery_update.changed is sameas True
+
+  - name: test - update discovery action conditions and operations (again)
+    zabbix_action:
+      conditions:
+        - type: host_IP
+          operator: '='
+          value: '192.168.1.1-127'
+        - type: discovery_object
+          operator: '='
+          value: host
+        - type: discovery_status
+          operator: '='
+          value: 'discovered'
+        - type: uptime_or_downtime_duration
+          operator: '>='
+          value: 2200
+      operations:
+        - type: add_host
+        - type: add_to_host_group
+          host_groups:
+            - Linux servers
+            - Discovered hosts
+        - type: link_to_template
+          templates:
+            - ExampleTemplateForActionModule
+        - type: enable_host
+        - type: send_message
+          send_to_users:
+            - Admin
+          subject: test_subject
+          message: test_message
+          media_type: ExampleMediaTypeForActionModule
+          operation_condition: not_acknowledged
+          esc_step_from: 1
+          esc_step_to: 2
+    register: zbxaction_discovery_update
+
+  - assert:
+      that: zbxaction_discovery_update.changed is sameas False
+
+  - name: test - delete action
+    zabbix_action:
+      state: absent
+    register: zbxaction_delete
+
+  - assert:
+      that: zbxaction_delete.changed is sameas True
+
+- name: test - auto registration actions
+  module_defaults:
+    zabbix_action:
+      server_url: "{{ zabbix_server_url }}"
+      login_user: "{{ zabbix_login_user }}"
+      login_password: "{{ zabbix_login_password }}"
+      state: present
+      status: enabled
+      name: ExampleAutoRegActionOperations
+      event_source: auto_registration
+      esc_period: 60
+
+  block:
+  - name: test - create new auto registration action
+    zabbix_action:
+      conditions:
+        - type: host_name
+          operator: like
+          value: zabbix
+        - type: host_metadata
+          operator: not like
+          value: somemetadata
+      operations:
+        - type: add_host
+    register: zbxaction_autoreg
+
+  - assert:
+      that: zbxaction_autoreg.changed is sameas True
+
+  - name: test - create new auto registration action (again)
+    zabbix_action:
+      conditions:
+        - type: host_name
+          operator: like
+          value: zabbix
+        - type: host_metadata
+          operator: not like
+          value: somemetadata
+      operations:
+        - type: add_host
+    register: zbxaction_autoreg
+
+  - assert:
+      that: zbxaction_autoreg.changed is sameas False
+
+  - name: test - update auto registration action
+    zabbix_action:
+      conditions:
+        - type: host_name
+          operator: like
+          value: zabbix
+        - type: host_metadata
+          operator: not like
+          value: somemetadata
+        - type: host_metadata
+          operator: like
+          value: somemetadata2
+      operations:
+        - type: add_host
+    register: zbxaction_autoreg_update
+
+  - assert:
+      that: zbxaction_autoreg_update.changed is sameas True
+
+  - name: test - update auto registration action (again)
+    zabbix_action:
+      conditions:
+        - type: host_name
+          operator: like
+          value: zabbix
+        - type: host_metadata
+          operator: not like
+          value: somemetadata
+        - type: host_metadata
+          operator: like
+          value: somemetadata2
+      operations:
+        - type: add_host
+    register: zbxaction_autoreg_update
+
+  - assert:
+      that: zbxaction_autoreg_update.changed is sameas False
+
+  - name: test - delete action
+    zabbix_action:
+      state: absent
+    register: zbxaction_delete
+
+  - assert:
+      that: zbxaction_delete.changed is sameas True
+
+- name: test - internal actions
+  module_defaults:
+    zabbix_action:
+      server_url: "{{ zabbix_server_url }}"
+      login_user: "{{ zabbix_login_user }}"
+      login_password: "{{ zabbix_login_password }}"
+      state: present
+      status: enabled
+      name: ExampleInternalActionOperations
+      event_source: internal
+      esc_period: 60
+      operations:
+        - type: send_message
+          send_to_users:
+            - Admin
+          subject: test_subject
+          message: test_message
+          media_type: ExampleMediaTypeForActionModule
+
+  block:
+  - name: test - create new internal action
+    zabbix_action:
+      conditions:
+        - type: application
+          operator: like
+          value: zabbix
+        - type: host_template
+          operator: '='
+          value: ExampleTemplateForActionModule
+        - type: event_type
+          operator: '='
+          value: item in not supported state
+    register: zbxaction_internal
+
+  - assert:
+      that: zbxaction_internal.changed is sameas True
+
+  - name: test - create new internal action (again)
+    zabbix_action:
+      conditions:
+        - type: application
+          operator: like
+          value: zabbix
+        - type: host_template
+          operator: '='
+          value: ExampleTemplateForActionModule
+        - type: event_type
+          operator: '='
+          value: item in not supported state
+    register: zbxaction_internal
+
+  - assert:
+      that: zbxaction_internal.changed is sameas False
+
+  - name: test - update internal action conditions
+    zabbix_action:
+      conditions:
+        - type: application
+          operator: like
+          value: zabbix
+        - type: host_template
+          operator: '='
+          value: ExampleTemplateForActionModule
+        - type: event_type
+          operator: '='
+          value: item in not supported state
+        - type: event_type
+          operator: '='
+          value: trigger in unknown state
+    register: zbxaction_internal_update
+
+  - assert:
+      that: zbxaction_internal_update.changed is sameas True
+
+  - name: test - update internal action conditions (again)
+    zabbix_action:
+      conditions:
+        - type: application
+          operator: like
+          value: zabbix
+        - type: host_template
+          operator: '='
+          value: ExampleTemplateForActionModule
+        - type: event_type
+          operator: '='
+          value: item in not supported state
+        - type: event_type
+          operator: '='
+          value: trigger in unknown state
+    register: zbxaction_internal_update
+
+  - assert:
+      that: zbxaction_internal_update.changed is sameas False
+
+  - name: test - delete action
+    zabbix_action:
+      state: absent
+    register: zbxaction_delete
+
+  - assert:
+      that: zbxaction_delete.changed is sameas True
+
+- name: test - actions with recovery and acknowledge operations
+  when:
+    - zabbix_version is version('3.4', '>=')
+  module_defaults:
+    zabbix_action:
+      server_url: "{{ zabbix_server_url }}"
+      login_user: "{{ zabbix_login_user }}"
+      login_password: "{{ zabbix_login_password }}"
+      state: present
+      status: enabled
+      name: ExampleTriggerActionRecAckOps
+      event_source: trigger
+      esc_period: 60
+      conditions:
+        - type: trigger_severity
+          operator: '>='
+          value: Information
+      operations:
+        - type: send_message
+          subject: ExampleSubject
+          message: ExampleMessage
+          media_type: ExampleMediaTypeForActionModule
+          send_to_users:
+            - Admin
+
+  block:
+  - name: test - create new action with recovery and acknowledge operations
+    zabbix_action:
+      recovery_operations:
+        - type: send_message
+          subject: ExampleSubject
+          message: ExampleMessage
+          media_type: ExampleMediaTypeForActionModule
+          send_to_users:
+            - Admin
+        - type: remote_command
+          command_type: custom_script
+          command: /usr/local/bin/do_something.sh
+          execute_on: agent
+          run_on_hosts: 0
+        - type: remote_command
+          command_type: ssh
+          command: /usr/local/bin/do_something.sh
+          run_on_hosts: 0
+          ssh_auth_type: password
+          username: root
+          password: zabbix
+        - type: notify_all_involved
+          subject: RecoverySubject
+          message: RecoveryMessage
+      acknowledge_operations:
+        - type: send_message
+          subject: ExampleSubject
+          message: ExampleMessage
+          media_type: ExampleMediaTypeForActionModule
+          send_to_users:
+            - Admin
+        - type: remote_command
+          command_type: ssh
+          command: /usr/local/bin/do_something.sh
+          run_on_hosts: 0
+          ssh_auth_type: public_key
+          username: root
+          ssh_privatekey_file: /etc/zabbix/.ssh/id_test
+          ssh_publickey_file: /etc/zabbix/.ssh/id_test.pub
+        - type: remote_command
+          command_type: global_script
+          script_name: Ping
+          run_on_hosts: 0
+        - type: notify_all_involved
+          subject: RecoverySubject
+          message: RecoveryMessage
+          media_type: ExampleMediaTypeForActionModule
+    register: zbxaction_recack_new
+
+  - assert:
+      that: zbxaction_recack_new.changed is sameas True
+
+  - name: test - create new action with recovery and acknowledge operations (again)
+    zabbix_action:
+      recovery_operations:
+        - type: send_message
+          subject: ExampleSubject
+          message: ExampleMessage
+          media_type: ExampleMediaTypeForActionModule
+          send_to_users:
+            - Admin
+        - type: remote_command
+          command_type: custom_script
+          command: /usr/local/bin/do_something.sh
+          execute_on: agent
+          run_on_hosts: 0
+        - type: remote_command
+          command_type: ssh
+          command: /usr/local/bin/do_something.sh
+          run_on_hosts: 0
+          ssh_auth_type: password
+          username: root
+          password: zabbix
+        - type: notify_all_involved
+          subject: RecoverySubject
+          message: RecoveryMessage
+      acknowledge_operations:
+        - type: send_message
+          subject: ExampleSubject
+          message: ExampleMessage
+          media_type: ExampleMediaTypeForActionModule
+          send_to_users:
+            - Admin
+        - type: remote_command
+          command_type: ssh
+          command: /usr/local/bin/do_something.sh
+          run_on_hosts: 0
+          ssh_auth_type: public_key
+          username: root
+          ssh_privatekey_file: /etc/zabbix/.ssh/id_test
+          ssh_publickey_file: /etc/zabbix/.ssh/id_test.pub
+        - type: remote_command
+          command_type: global_script
+          script_name: Ping
+          run_on_hosts: 0
+        - type: notify_all_involved
+          subject: RecoverySubject
+          message: RecoveryMessage
+          media_type: ExampleMediaTypeForActionModule
+    register: zbxaction_recack_new
+
+  - assert:
+      that: zbxaction_recack_new.changed is sameas False
+
+  - name: test - delete action
+    zabbix_action:
+      state: absent
+    register: zbxaction_delete
+
+  - assert:
+      that: zbxaction_delete.changed is sameas True
+
+- name: test - cleanup example template for zabbix_action module
+  zabbix_template:
+    server_url: "{{ zabbix_server_url }} "
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    template_name: ExampleTemplateForActionModule
+    state: absent
+  register: zbxaction_prep_template
+
+- name: test - cleanup example mediatype for zabbix_action module
+  zabbix_mediatype:
+    server_url: "{{ zabbix_server_url }} "
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleMediaTypeForActionModule
+    type: email
+    state: absent
+  register: zbxaction_prep_mediatype

--- a/tests/integration/targets/test_zabbix_action/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_action/tasks/main.yml
@@ -210,12 +210,12 @@
     - assert:
         that: zbxaction_ack_msgsubj.changed is sameas False
 
-  - name: test - reset action to default
-    zabbix_action:
-    register: zbxaction_reset
+    - name: test - reset action to default
+      zabbix_action:
+      register: zbxaction_reset
 
-  - assert:
-      that: zbxaction_reset.changed is sameas True
+    - assert:
+        that: zbxaction_reset.changed is sameas True
 
   - name: test - disable action
     zabbix_action:

--- a/tests/integration/targets/test_zabbix_action/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_action/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: test - do not run tests for Zabbix 3.0
+  meta: end_play
+  when: zabbix_version is version('3.0', '=')
+
 - name: test - prepare example template for zabbix_action module
   zabbix_template:
     server_url: "{{ zabbix_server_url }} "


### PR DESCRIPTION
…bix_action module

##### SUMMARY
- adds integration tests for `zabbix_action` module
- `remote_command` of type SSH always required all of the options (username, pass, ssh_*_file and so on) regardless of auth method set in `ssh_auth_type`
- removed `selectInventory: extend` from API calls where it is silently ignored (or fails like with `zbx.script.get`)
- documentation adjustements
- it was unclear what options are available for `inventory` parameter in `*operations` so unified that to `manual` and `automatic`
- Edit: I've decided to skip 3.0 testing completly since the module states it only supports 3.4+ version and 3.4 is already unsupported, 4.0 is covered by these tests

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/modules/zabbix_action
tests/integration/targets/test_zabbix_action
