### PR TITLE
Fixed getenforce binary path

### DIFF
--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -88,7 +88,7 @@
   become: yes
 
 - name: "Collect getenforce output"
-  command: getenforce
+  command: /usr/sbin/getenforce
   register: sestatus
   when: 'getenforce_bin.stat.exists'
   changed_when: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_agent/tasks/Linux.yml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Running by default role code is checking for getenforce binary using full path "/usr/sbin/getnforce". But, in case the binary exists Ansible tries to launch command using binary basename 'getenforce'.
So, it's better use full path.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
