### PR TITLE
Fix bug for zabbix_service has no idempotency and add integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes:
 #### Modules:
   - zabbix_action - now correctly selects mediatype for the (normal|recovery|update) operations with Zabbix 4.4 and newer. (PR [#90](https://github.com/ansible-collections/community.zabbix/pull/90))
+  - zabbix_service - fixed the zabbix_service has no idempotency with Zabbix 5.0 (PR [#116](https://github.com/ansible-collections/community.zabbix/pull/116))
 
 ## 0.2.0
 

--- a/plugins/modules/zabbix_service.py
+++ b/plugins/modules/zabbix_service.py
@@ -182,6 +182,9 @@ class Service(object):
         item_to_check = ['name', 'showsla', 'algorithm', 'triggerid', 'sortorder', 'goodsla']
         change = False
         for item in item_to_check:
+            if item == 'goodsla':
+                live_config[item] = format(float(live_config[item]), '.4f')
+
             if str(generated_config[item]) != str(live_config[item]):
                 change = True
 

--- a/tests/integration/targets/test_zabbix_service/meta/main.yml
+++ b/tests/integration/targets/test_zabbix_service/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_zabbix

--- a/tests/integration/targets/test_zabbix_service/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_service/tasks/main.yml
@@ -1,0 +1,397 @@
+---
+- name: "test - Create a new service with check_mode"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.99
+    state: present
+  check_mode: yes
+  register: create_service_check_mode_result
+
+- assert:
+    that:
+      - create_service_check_mode_result.changed is sameas true
+
+- name: "test - Create a new service"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.99
+    state: present
+  register: create_service_result
+
+- assert:
+    that:
+      - create_service_result.changed is sameas true
+
+- name: "test - Create a new service (idempotency check)"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.99
+    state: present
+  register: create_service_idempotency_check_result
+
+- assert:
+    that:
+      - create_service_idempotency_check_result.changed is sameas false
+
+- name: "test - Update a sla with check_mode"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    state: present
+  check_mode: yes
+  register: update_sla_check_mode_result
+
+- assert:
+    that:
+      - update_sla_check_mode_result.changed is sameas true
+
+- name: "test - Update a sla"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    state: present
+  register: update_sla_result
+
+- assert:
+    that:
+      - update_sla_result.changed is sameas true
+
+- name: "test - Update a sla (idempotency check)"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    state: present
+  register: update_sla_idempotency_check_result
+
+- assert:
+    that:
+      - update_sla_idempotency_check_result.changed is sameas false
+
+- name: "test - Update a calculate_sla with check_mode"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    state: present
+  check_mode: yes
+  register: update_calculate_sla_check_mode_result
+
+- assert:
+    that:
+      - update_calculate_sla_check_mode_result.changed is sameas true
+
+- name: "test - Update a calculate_sla"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    state: present
+  register: update_calculate_sla_result
+
+- assert:
+    that:
+      - update_calculate_sla_result.changed is sameas true
+
+- name: "test - Update a calculate_sla (idempotency check)"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    state: present
+  register: update_calculate_sla_idempotency_check_result
+
+- assert:
+    that:
+      - update_calculate_sla_idempotency_check_result.changed is sameas false
+
+- name: "test - Update trigger_host and trigger_name with check_mode"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    trigger_host: "Zabbix server"
+    trigger_name: "Zabbix http poller processes more than 75% busy"
+    state: present
+  check_mode: yes
+  register: update_trigger_name_check_mode_result
+
+- assert:
+    that:
+      - update_trigger_name_check_mode_result.changed is sameas true
+
+- name: "test - Update trigger_host and trigger_name"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    trigger_host: "Zabbix server"
+    trigger_name: "Zabbix http poller processes more than 75% busy"
+    state: present
+  register: update_trigger_name_result
+
+- assert:
+    that:
+      - update_trigger_name_result.changed is sameas true
+
+- name: "test - Update trigger_host and trigger_name (idempotency check)"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    trigger_host: "Zabbix server"
+    trigger_name: "Zabbix http poller processes more than 75% busy"
+    state: present
+  register: update_trigger_name_idempotency_check_result
+
+- assert:
+    that:
+      - update_trigger_name_idempotency_check_result.changed is sameas false
+
+- name: "test - Update a algorithm of service with check_mode"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    trigger_host: "Zabbix server"
+    trigger_name: "Zabbix http poller processes more than 75% busy"
+    algorithm: all_children
+    state: present
+  check_mode: yes
+  register: update_algorithm_check_mode_result
+
+- assert:
+    that:
+      - update_algorithm_check_mode_result.changed is sameas true
+
+- name: "test - Update a algorithm of service"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    trigger_host: "Zabbix server"
+    trigger_name: "Zabbix http poller processes more than 75% busy"
+    algorithm: all_children
+    state: present
+  register: update_algorithm_result
+
+- assert:
+    that:
+      - update_algorithm_result.changed is sameas true
+
+- name: "test - Update a algorithm of service (idempotency check)"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    trigger_host: "Zabbix server"
+    trigger_name: "Zabbix http poller processes more than 75% busy"
+    algorithm: all_children
+    state: present
+  register: update_algorithm_idempotency_check_result
+
+- assert:
+    that:
+      - update_algorithm_idempotency_check_result.changed is sameas false
+
+- name: "test - Create a new root service for parent test"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModuleRoot
+    sla: 99.99
+    state: present
+  register: create_child_service_result
+
+- assert:
+    that:
+      - create_child_service_result.changed is sameas true
+
+- name: "test - Update a parent of child service with check_mode"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    trigger_host: "Zabbix server"
+    trigger_name: "Zabbix http poller processes more than 75% busy"
+    algorithm: all_children
+    parent: ExampleServiceForServiceModuleRoot
+    state: present
+  check_mode: yes
+  register: create_parent_child_service_check_mode_result
+
+- assert:
+    that:
+      - create_parent_child_service_check_mode_result.changed is sameas true
+
+- name: "test - Update a parent of child service"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    trigger_host: "Zabbix server"
+    trigger_name: "Zabbix http poller processes more than 75% busy"
+    algorithm: all_children
+    parent: ExampleServiceForServiceModuleRoot
+    state: present
+  register: create_parent_child_service_result
+
+- assert:
+    that:
+      - create_parent_child_service_result.changed is sameas true
+
+- name: "test - Update a parent of child service (idempotency check)"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    calculate_sla: yes
+    trigger_host: "Zabbix server"
+    trigger_name: "Zabbix http poller processes more than 75% busy"
+    algorithm: all_children
+    parent: ExampleServiceForServiceModuleRoot
+    state: present
+  register: create_parent_child_service_idempotency_check_result
+
+- assert:
+    that:
+      - create_parent_child_service_idempotency_check_result.changed is sameas false
+
+- name: "test - Remove ExampleServiceForServiceModule service with check_mode"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    state: absent
+  check_mode: yes
+  register: remove_service_with_check_mode_result
+
+- assert:
+    that:
+      - remove_service_with_check_mode_result.changed is sameas true
+
+- name: "test - Remove ExampleServiceForServiceModule service"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    state: absent
+  register: remove_service_result
+
+- assert:
+    that:
+      - remove_service_result.changed is sameas true
+
+- name: "test - Remove ExampleServiceForServiceModule service (idempotency check)"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModule
+    sla: 99.999
+    state: absent
+  register: remove_service_idempotency_check_result
+
+- assert:
+    that:
+      - remove_service_idempotency_check_result.changed is sameas false
+
+- name: "test - Remove ExampleServiceForServiceModuleRoot service with check_mode"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModuleRoot
+    sla: 99.999
+    state: absent
+  check_mode: yes
+  register: remove_root_service_with_check_mode_result
+
+- assert:
+    that:
+      - remove_root_service_with_check_mode_result.changed is sameas true
+
+- name: "test - Remove ExampleServiceForServiceModuleRoot service"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModuleRoot
+    sla: 99.999
+    state: absent
+  register: remove_root_service_result
+
+- assert:
+    that:
+      - remove_root_service_result.changed is sameas true
+
+- name: "test - Remove ExampleServiceForServiceModuleRoot service (idempotency check)"
+  zabbix_service:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: ExampleServiceForServiceModuleRoot
+    sla: 99.999
+    state: absent
+  register: remove_root_service_idempotency_check_result
+
+- assert:
+    that:
+      - remove_root_service_idempotency_check_result.changed is sameas false


### PR DESCRIPTION
This PR is fixes bug for zabbix_service has no idempotency with Zabbix 5.0.  
The cause is zero-padding was gone from `goodsla` in the got results from Zabbix 5.0.

**When Zabbix 4.4 or less**

```
            "goodsla": "99.9990",
```

**When Zabbix 5.0**

```
            "goodsla": "99.999",
```

So, fix to be in the same format when comparing.
And add integration tests for the zabbix_service module.

fixes: https://github.com/ansible-collections/community.zabbix/issues/112

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME

modules/zabbix_service.py

##### ADDITIONAL INFORMATION