### PR TITLE
Zabbix 5.0

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -61,14 +61,14 @@ See the following list of supported Operating systems with the Zabbix releases:
 | Red Hat Fam 6       |     |     |           | V         |
 | Red Hat Fam 5       |     |     |           | V         |
 | Fedora              |     | V   | V         |           |
-| Ubuntu 20.04 focal  |     |     |           |           |
+| Ubuntu 20.04 focal  | V   |     |           |           |
 | Ubuntu 19.10 eoan   |     |     |           |           |
-| Ubuntu 18.04 bionic |     | V   | V         |           |
-| Ubuntu 16.04 xenial |     | V   | V         |           |
-| Ubuntu 14.04 trusty |     | V   | V         | V         |
-| Debian 10 buster    |     | V   |           |           |
-| Debian 9 stretch    |     | V   | V         |           |
-| Debian 8 jessie     |     | V   | V         | V         |
+| Ubuntu 18.04 bionic | V   | V   | V         |           |
+| Ubuntu 16.04 xenial | V   | V   | V         |           |
+| Ubuntu 14.04 trusty | V   | V   | V         | V         |
+| Debian 10 buster    | V   | V   |           |           |
+| Debian 9 stretch    | V   | V   | V         |           |
+| Debian 8 jessie     | V   | V   | V         | V         |
 | Debian 7 wheezy     |     |     | V         | V         |
 | macOS 10.15         |     | V   | V         |           |
 | macOS 10.14         |     | V   | V         |           |

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -54,22 +54,24 @@ To successfully complete the install the role requires `python-netaddr` on the c
 
 See the following list of supported Operating systems with the Zabbix releases:
 
-| Zabbix  | 4.4 | 4.0 (LTS) | 3.0 (LTS)|
-|---|---|---|---|
-|Red Hat Fam 8| V |   |   |
-|Red Hat Fam 7| V  | V  | V |
-|Red Hat Fam 6|   |   | V |
-|Red Hat Fam 5|   |   | V |
-|Fedora| V  |  V |   |
-|Ubuntu 18.04| V  | V  |   |
-|Ubuntu 16.04| V  | V |   |
-|Ubuntu 14.04| V  | V | V |
-|Debian 10| V  |   |   |
-|Debian 9|  V | V |   |
-|Debian 8| V  | V | V |
-|Debian 7|    | V | V  |
-|macOS 10.15|  V | V |   |
-|macOS 10.14|  V | V |   |
+| Zabbix              | 5.0 | 4.4 | 4.0 (LTS) | 3.0 (LTS) |
+|---------------------|-----|-----|-----------|-----------|
+| Red Hat Fam 8       |     | V   |           |           |
+| Red Hat Fam 7       |     | V   | V         | V         |
+| Red Hat Fam 6       |     |     |           | V         |
+| Red Hat Fam 5       |     |     |           | V         |
+| Fedora              |     | V   | V         |           |
+| Ubuntu 20.04 focal  |     |     |           |           |
+| Ubuntu 19.10 eoan   |     |     |           |           |
+| Ubuntu 18.04 bionic |     | V   | V         |           |
+| Ubuntu 16.04 xenial |     | V   | V         |           |
+| Ubuntu 14.04 trusty |     | V   | V         | V         |
+| Debian 10 buster    |     | V   |           |           |
+| Debian 9 stretch    |     | V   | V         |           |
+| Debian 8 jessie     |     | V   | V         | V         |
+| Debian 7 wheezy     |     |     | V         | V         |
+| macOS 10.15         |     | V   | V         |           |
+| macOS 10.14         |     | V   | V         |           |
 
 # Getting started
 

--- a/docs/ZABBIX_JAVAGATEWAY_ROLE.md
+++ b/docs/ZABBIX_JAVAGATEWAY_ROLE.md
@@ -29,20 +29,24 @@ Please sent Pull Requests or suggestions when you want to use this role for othe
 
 See the following list of supported Operating systems with the Zabbix releases.
 
-| Zabbix  | 4.4 | 4.0 (LTS) | 3.0 (LTS)|
-|---|---|---|---|
-|Red Hat Fam 8| V |   |   |
-|Red Hat Fam 7| V  | V  | V |
-|Red Hat Fam 6|   |   | V |
-|Red Hat Fam 5|   |   | V |
-|Fedora| V  |  V |   |
-|Ubuntu 18.04| V  | V  |   |
-|Ubuntu 16.04| V  | V |   |
-|Ubuntu 14.04| V  | V | V |
-|Debian 10| V  |   |   |
-|Debian 9|  V | V |   |
-|Debian 8| V  | V | V |
-|Debian 7|    | V | V  |
+| Zabbix              | 5.0 | 4.4 | 4.0 (LTS) | 3.0 (LTS) |
+|---------------------|-----|-----|-----------|-----------|
+| Red Hat Fam 8       |     | V   |           |           |
+| Red Hat Fam 7       |     | V   | V         | V         |
+| Red Hat Fam 6       |     |     |           | V         |
+| Red Hat Fam 5       |     |     |           | V         |
+| Fedora              |     | V   | V         |           |
+| Ubuntu 20.04 focal  |     |     |           |           |
+| Ubuntu 19.10 eoan   |     |     |           |           |
+| Ubuntu 18.04 bionic |     | V   | V         |           |
+| Ubuntu 16.04 xenial |     | V   | V         |           |
+| Ubuntu 14.04 trusty |     | V   | V         | V         |
+| Debian 10 buster    |     | V   |           |           |
+| Debian 9 stretch    |     | V   | V         |           |
+| Debian 8 jessie     |     | V   | V         | V         |
+| Debian 7 wheezy     |     |     | V         | V         |
+| macOS 10.15         |     | V   | V         |           |
+| macOS 10.14         |     | V   | V         |           |
 
 # Role Variables
 

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -32,20 +32,24 @@ Please sent Pull Requests or suggestions when you want to use this role for othe
 
 See the following list of supported Operating systems with the Zabbix releases.
 
-| Zabbix  | 4.4 | 4.0 (LTS) | 3.0 (LTS)|
-|---|---|---|---|
-|Red Hat Fam 8| V |   |   |
-|Red Hat Fam 7| V  | V  | V |
-|Red Hat Fam 6|   |   | V |
-|Red Hat Fam 5|   |   | V |
-|Fedora| V  |  V |   |
-|Ubuntu 18.04| V  | V  |   |
-|Ubuntu 16.04| V  | V |   |
-|Ubuntu 14.04| V  | V | V |
-|Debian 10| V  |   |   |
-|Debian 9|  V | V |   |
-|Debian 8| V  | V | V |
-|Debian 7|    | V | V  |
+| Zabbix              | 5.0 | 4.4 | 4.0 (LTS) | 3.0 (LTS) |
+|---------------------|-----|-----|-----------|-----------|
+| Red Hat Fam 8       |     | V   |           |           |
+| Red Hat Fam 7       |     | V   | V         | V         |
+| Red Hat Fam 6       |     |     |           | V         |
+| Red Hat Fam 5       |     |     |           | V         |
+| Fedora              |     | V   | V         |           |
+| Ubuntu 20.04 focal  |     |     |           |           |
+| Ubuntu 19.10 eoan   |     |     |           |           |
+| Ubuntu 18.04 bionic |     | V   | V         |           |
+| Ubuntu 16.04 xenial |     | V   | V         |           |
+| Ubuntu 14.04 trusty |     | V   | V         | V         |
+| Debian 10 buster    |     | V   |           |           |
+| Debian 9 stretch    |     | V   | V         |           |
+| Debian 8 jessie     |     | V   | V         | V         |
+| Debian 7 wheezy     |     |     | V         | V         |
+| macOS 10.15         |     | V   | V         |           |
+| macOS 10.14         |     | V   | V         |           |
 
 # Role Variables
 

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -41,20 +41,24 @@ Please send Pull Requests or suggestions when you want to use this role for othe
 
 See the following list of supported Operating systems with the Zabbix releases:
 
-| Zabbix  | 4.4 | 4.0 (LTS) | 3.0 (LTS)|
-|---|---|---|---|
-|Red Hat Fam 8| V |   |   |
-|Red Hat Fam 7| V  | V  | V |
-|Red Hat Fam 6|   |   | V |
-|Red Hat Fam 5|   |   | V |
-|Fedora| V  |  V |   |
-|Ubuntu 18.04| V  | V  |   |
-|Ubuntu 16.04| V  | V |   |
-|Ubuntu 14.04| V  | V | V |
-|Debian 10| V  |   |   |
-|Debian 9|  V | V |   |
-|Debian 8| V  | V | V |
-|Debian 7|    | V | V  |
+| Zabbix              | 5.0 | 4.4 | 4.0 (LTS) | 3.0 (LTS) |
+|---------------------|-----|-----|-----------|-----------|
+| Red Hat Fam 8       |     | V   |           |           |
+| Red Hat Fam 7       |     | V   | V         | V         |
+| Red Hat Fam 6       |     |     |           | V         |
+| Red Hat Fam 5       |     |     |           | V         |
+| Fedora              |     | V   | V         |           |
+| Ubuntu 20.04 focal  |     |     |           |           |
+| Ubuntu 19.10 eoan   |     |     |           |           |
+| Ubuntu 18.04 bionic |     | V   | V         |           |
+| Ubuntu 16.04 xenial |     | V   | V         |           |
+| Ubuntu 14.04 trusty |     | V   | V         | V         |
+| Debian 10 buster    |     | V   |           |           |
+| Debian 9 stretch    |     | V   | V         |           |
+| Debian 8 jessie     |     | V   | V         | V         |
+| Debian 7 wheezy     |     |     | V         | V         |
+| macOS 10.15         |     | V   | V         |           |
+| macOS 10.14         |     | V   | V         |           |
 
 # Installation
 

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -42,20 +42,24 @@ Please sent Pull Requests or suggestions when you want to use this role for othe
 
 See the following list of supported Operating Systems with the Zabbix releases.
 
-| Zabbix  | 4.4 | 4.0 (LTS) | 3.0 (LTS)|
-|---|---|---|---|
-|Red Hat Fam 8| V |   |   |
-|Red Hat Fam 7| V  | V  | V |
-|Red Hat Fam 6|   |   | V |
-|Red Hat Fam 5|   |   | V |
-|Fedora| V  |  V |   |
-|Ubuntu 18.04| V  | V  |   |
-|Ubuntu 16.04| V  | V |   |
-|Ubuntu 14.04| V  | V | V |
-|Debian 10| V  |   |   |
-|Debian 9|  V | V |   |
-|Debian 8| V  | V | V |
-|Debian 7|    | V | V  |
+| Zabbix              | 5.0 | 4.4 | 4.0 (LTS) | 3.0 (LTS) |
+|---------------------|-----|-----|-----------|-----------|
+| Red Hat Fam 8       |     | V   |           |           |
+| Red Hat Fam 7       |     | V   | V         | V         |
+| Red Hat Fam 6       |     |     |           | V         |
+| Red Hat Fam 5       |     |     |           | V         |
+| Fedora              |     | V   | V         |           |
+| Ubuntu 20.04 focal  |     |     |           |           |
+| Ubuntu 19.10 eoan   |     |     |           |           |
+| Ubuntu 18.04 bionic |     | V   | V         |           |
+| Ubuntu 16.04 xenial |     | V   | V         |           |
+| Ubuntu 14.04 trusty |     | V   | V         | V         |
+| Debian 10 buster    |     | V   |           |           |
+| Debian 9 stretch    |     | V   | V         |           |
+| Debian 8 jessie     |     | V   | V         | V         |
+| Debian 7 wheezy     |     |     | V         | V         |
+| macOS 10.15         |     | V   | V         |           |
+| macOS 10.14         |     | V   | V         |           |
 
 # Installation
 

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for zabbix-agent
 
-zabbix_agent_version: 4.4
+zabbix_agent_version: 5.0
 zabbix_version: "{{ zabbix_agent_version }}"
 zabbix_version_patch: 0
 zabbix_repo: zabbix

--- a/roles/zabbix_agent/vars/zabbix.yml
+++ b/roles/zabbix_agent/vars/zabbix.yml
@@ -1,6 +1,20 @@
 ---
-
 sign_keys:
+  "50":
+    focal:
+      sign_key: E709712C
+    bionic:
+      sign_key: E709712C
+    buster:
+      sign_key: E709712C
+    stretch:
+      sign_key: E709712C
+    jessie:
+      sign_key: E709712C
+    trusty:
+      sign_key: E709712C
+    xenial:
+      sign_key: E709712C
   "44":
     focal:
       sign_key: A14FE591

--- a/roles/zabbix_agent/vars/zabbix.yml
+++ b/roles/zabbix_agent/vars/zabbix.yml
@@ -1,19 +1,19 @@
 ---
 sign_keys:
   "50":
-    focal:
-      sign_key: E709712C
-    bionic:
-      sign_key: E709712C
     buster:
       sign_key: E709712C
     stretch:
       sign_key: E709712C
     jessie:
       sign_key: E709712C
-    trusty:
+    focal:
+      sign_key: E709712C
+    bionic:
       sign_key: E709712C
     xenial:
+      sign_key: E709712C
+    trusty:
       sign_key: E709712C
   "44":
     focal:

--- a/roles/zabbix_proxy/vars/zabbix.yml
+++ b/roles/zabbix_proxy/vars/zabbix.yml
@@ -1,6 +1,20 @@
 ---
-
 sign_keys:
+  "50":
+    focal:
+      sign_key: E709712C
+    bionic:
+      sign_key: E709712C
+    buster:
+      sign_key: E709712C
+    stretch:
+      sign_key: E709712C
+    jessie:
+      sign_key: E709712C
+    trusty:
+      sign_key: E709712C
+    xenial:
+      sign_key: E709712C
   "44":
     bionic:
       sign_key: A14FE591

--- a/roles/zabbix_proxy/vars/zabbix.yml
+++ b/roles/zabbix_proxy/vars/zabbix.yml
@@ -1,19 +1,19 @@
 ---
 sign_keys:
   "50":
-    focal:
-      sign_key: E709712C
-    bionic:
-      sign_key: E709712C
     buster:
       sign_key: E709712C
     stretch:
       sign_key: E709712C
     jessie:
       sign_key: E709712C
-    trusty:
+    focal:
+      sign_key: E709712C
+    bionic:
       sign_key: E709712C
     xenial:
+      sign_key: E709712C
+    trusty:
       sign_key: E709712C
   "44":
     bionic:

--- a/roles/zabbix_server/vars/zabbix.yml
+++ b/roles/zabbix_server/vars/zabbix.yml
@@ -1,6 +1,20 @@
 ---
-
 sign_keys:
+  "50":
+    focal:
+      sign_key: E709712C
+    bionic:
+      sign_key: E709712C
+    buster:
+      sign_key: E709712C
+    stretch:
+      sign_key: E709712C
+    jessie:
+      sign_key: E709712C
+    trusty:
+      sign_key: E709712C
+    xenial:
+      sign_key: E709712C
   "44":
     bionic:
       sign_key: A14FE591

--- a/roles/zabbix_server/vars/zabbix.yml
+++ b/roles/zabbix_server/vars/zabbix.yml
@@ -1,19 +1,19 @@
 ---
 sign_keys:
   "50":
-    focal:
-      sign_key: E709712C
-    bionic:
-      sign_key: E709712C
     buster:
       sign_key: E709712C
     stretch:
       sign_key: E709712C
     jessie:
       sign_key: E709712C
-    trusty:
+    focal:
+      sign_key: E709712C
+    bionic:
       sign_key: E709712C
     xenial:
+      sign_key: E709712C
+    trusty:
       sign_key: E709712C
   "44":
     bionic:

--- a/roles/zabbix_web/vars/zabbix.yml
+++ b/roles/zabbix_web/vars/zabbix.yml
@@ -1,6 +1,20 @@
 ---
-
 sign_keys:
+  "50":
+    focal:
+      sign_key: E709712C
+    bionic:
+      sign_key: E709712C
+    buster:
+      sign_key: E709712C
+    stretch:
+      sign_key: E709712C
+    jessie:
+      sign_key: E709712C
+    trusty:
+      sign_key: E709712C
+    xenial:
+      sign_key: E709712C
   "44":
     buster:
       sign_key: A14FE591

--- a/roles/zabbix_web/vars/zabbix.yml
+++ b/roles/zabbix_web/vars/zabbix.yml
@@ -1,19 +1,19 @@
 ---
 sign_keys:
   "50":
-    focal:
-      sign_key: E709712C
-    bionic:
-      sign_key: E709712C
     buster:
       sign_key: E709712C
     stretch:
       sign_key: E709712C
     jessie:
       sign_key: E709712C
-    trusty:
+    focal:
+      sign_key: E709712C
+    bionic:
       sign_key: E709712C
     xenial:
+      sign_key: E709712C
+    trusty:
       sign_key: E709712C
   "44":
     buster:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add signing keys for Zabbix 5.0 on Debian & Ubuntu. (Signing key for Ubuntu 19.10 eoan is missing.)
Confirm this is working for `community.zabbix.zabbix_agent`.
Update the docs, validating support only for `community.zabbix.zabbix_agent`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Works towards fixing #45.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`community.zabbix.zabbix_agent`
Docs for all roles.
