### PR TITLE
WIP: implement zabbix_credentials

### DIFF
--- a/plugins/doc_fragments/zabbix.py
+++ b/plugins/doc_fragments/zabbix.py
@@ -9,41 +9,96 @@ class ModuleDocFragment(object):
     # Standard documentation fragment
     DOCUMENTATION = r'''
 options:
+    zabbix_credentials:
+        description:
+            - Zabbix connection details. A dictionary which can be used to store the connection details.
+            - direct module parameters overriding zabbix_credential parameters
+        suboptions:
+            server_url:
+                description:
+                    - URL of Zabbix server, with protocol (http or https).
+                required: true
+                type: str
+            login_user:
+                description:
+                    - Zabbix user name.
+                required: true
+                type: str
+            login_password:
+                description:
+                    - Zabbix user password.
+                required: true
+                type: str
+            http_login_user:
+                description:
+                    - Basic Auth login
+                type: str
+            http_login_password:
+                description:
+                    - Basic Auth password
+                type: str
+            timeout:
+                description:
+                    - The timeout of API request (seconds).
+                type: int
+                default: 10
+            validate_certs:
+                description:
+                    - If set to False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+                type: bool
+                default: yes
+        type: dict
+        version_added: "0.3"
+        aliases: [ connection, zabbix_connection, credentials ]
     server_url:
         description:
             - URL of Zabbix server, with protocol (http or https).
               C(url) is an alias for C(server_url).
+            - since v0.3 can be defined centraly in zabbix_credentials
+            - overrides zabbix_credentials.server_url
         required: true
         type: str
         aliases: [ url ]
     login_user:
         description:
             - Zabbix user name.
+            - since v0.3 can be defined centraly in zabbix_credentials
+            - overrides zabbix_credentials.login_user
         type: str
         required: true
     login_password:
         description:
             - Zabbix user password.
+            - since v0.3 can be defined centraly in zabbix_credentials
+            - overrides zabbix_credentials.login_password
         type: str
         required: true
     http_login_user:
         description:
             - Basic Auth login
+            - since v0.3 can be defined centraly in zabbix_credentials
+            - overrides zabbix_credentials.http_login_user
         type: str
     http_login_password:
         description:
             - Basic Auth password
+            - since v0.3 can be defined centraly in zabbix_credentials
+            - overrides zabbix_credentials.http_login_password
         type: str
     timeout:
         description:
             - The timeout of API request (seconds).
+            - since v0.3 can be defined centraly in zabbix_credentials
+            - overrides zabbix_credentials.timeout
         type: int
         default: 10
     validate_certs:
-      description:
-       - If set to False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-      type: bool
-      default: yes
+        description:
+            - If set to False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+            - since v0.3 can be defined centraly in zabbix_credentials
+            - overrides zabbix_credentials.validate_certs
+        type: bool
+        default: yes
 notes:
     - If you use I(login_password=zabbix), the word "zabbix" is replaced by "********" in all module output, because I(login_password) uses C(no_log).
       See L(this FAQ,https://docs.ansible.com/ansible/latest/network/user_guide/faq.html#why-is-my-output-sometimes-replaced-with) for more information.

--- a/plugins/doc_fragments/zabbix.py
+++ b/plugins/doc_fragments/zabbix.py
@@ -9,96 +9,41 @@ class ModuleDocFragment(object):
     # Standard documentation fragment
     DOCUMENTATION = r'''
 options:
-    zabbix_credentials:
-        description:
-            - Zabbix connection details. A dictionary which can be used to store the connection details.
-            - direct module parameters overriding zabbix_credential parameters
-        suboptions:
-            server_url:
-                description:
-                    - URL of Zabbix server, with protocol (http or https).
-                required: true
-                type: str
-            login_user:
-                description:
-                    - Zabbix user name.
-                required: true
-                type: str
-            login_password:
-                description:
-                    - Zabbix user password.
-                required: true
-                type: str
-            http_login_user:
-                description:
-                    - Basic Auth login
-                type: str
-            http_login_password:
-                description:
-                    - Basic Auth password
-                type: str
-            timeout:
-                description:
-                    - The timeout of API request (seconds).
-                type: int
-                default: 10
-            validate_certs:
-                description:
-                    - If set to False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-                type: bool
-                default: yes
-        type: dict
-        version_added: "0.3"
-        aliases: [ connection, zabbix_connection, credentials ]
     server_url:
         description:
             - URL of Zabbix server, with protocol (http or https).
               C(url) is an alias for C(server_url).
-            - since v0.3 can be defined centraly in zabbix_credentials
-            - overrides zabbix_credentials.server_url
         required: true
         type: str
         aliases: [ url ]
     login_user:
         description:
             - Zabbix user name.
-            - since v0.3 can be defined centraly in zabbix_credentials
-            - overrides zabbix_credentials.login_user
         type: str
         required: true
     login_password:
         description:
             - Zabbix user password.
-            - since v0.3 can be defined centraly in zabbix_credentials
-            - overrides zabbix_credentials.login_password
         type: str
         required: true
     http_login_user:
         description:
             - Basic Auth login
-            - since v0.3 can be defined centraly in zabbix_credentials
-            - overrides zabbix_credentials.http_login_user
         type: str
     http_login_password:
         description:
             - Basic Auth password
-            - since v0.3 can be defined centraly in zabbix_credentials
-            - overrides zabbix_credentials.http_login_password
         type: str
     timeout:
         description:
             - The timeout of API request (seconds).
-            - since v0.3 can be defined centraly in zabbix_credentials
-            - overrides zabbix_credentials.timeout
         type: int
         default: 10
     validate_certs:
-        description:
-            - If set to False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-            - since v0.3 can be defined centraly in zabbix_credentials
-            - overrides zabbix_credentials.validate_certs
-        type: bool
-        default: yes
+      description:
+       - If set to False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+      type: bool
+      default: yes
 notes:
     - If you use I(login_password=zabbix), the word "zabbix" is replaced by "********" in all module output, because I(login_password) uses C(no_log).
       See L(this FAQ,https://docs.ansible.com/ansible/latest/network/user_guide/faq.html#why-is-my-output-sometimes-replaced-with) for more information.

--- a/plugins/module_utils/helpers.py
+++ b/plugins/module_utils/helpers.py
@@ -16,10 +16,20 @@ def zabbix_common_argument_spec():
     Return a dictionary with connection options.
     The options are commonly used by most of Zabbix modules.
     """
-    return dict(
-        server_url=dict(type='str', required=True, aliases=['url']),
+    credentials_spec = dict(
+        server_url=dict(type='str', required=True),
         login_user=dict(type='str', required=True),
         login_password=dict(type='str', required=True, no_log=True),
+        http_login_user=dict(type='str', required=False, default=None),
+        http_login_password=dict(type='str', required=False, default=None, no_log=True),
+        timeout=dict(type='int', default=10),
+        validate_certs=dict(type='bool', required=False, default=True),
+    )
+    return dict(
+        zabbi_credentials=dict(default=None, type='dict', options=credentials_spec),
+        server_url=dict(type='str', required=False, aliases=['url']),
+        login_user=dict(type='str', required=False),
+        login_password=dict(type='str', required=False, no_log=True),
         http_login_user=dict(type='str', required=False, default=None),
         http_login_password=dict(type='str', required=False, default=None, no_log=True),
         timeout=dict(type='int', default=10),

--- a/plugins/module_utils/helpers.py
+++ b/plugins/module_utils/helpers.py
@@ -26,7 +26,7 @@ def zabbix_common_argument_spec():
         validate_certs=dict(type='bool', required=False, default=True),
     )
     return dict(
-        zabbi_credentials=dict(default=None, type='dict', options=credentials_spec),
+        zabbix_credentials=dict(default=None, type='dict', options=credentials_spec),
         server_url=dict(type='str', required=False, aliases=['url']),
         login_user=dict(type='str', required=False),
         login_password=dict(type='str', required=False, no_log=True),


### PR DESCRIPTION
##### SUMMARY
See #126 for more information
Fixes #126

##### ISSUE TYPE
- Feature Pull Request

##### ADDITIONAL INFORMATION
With this implementation you could for example:

```yaml
---

- hosts: localhost
  gather_facts: false
  collections:
    - community.zabbix
  vars:
    zabbix_creds:
      server_url: http://localhost:8080
      login_user: Admin
      login_password: zabbix
  tasks:
    - name: Create host groups - old style
      local_action:
        module: zabbix_group
        server_url: http://localhost:8080
        login_user: Admin
        login_password: zabbix
        state: "{{ state | default('present') }}"
        host_groups:
          - _JUSTATEST_

    - name: Create host groups - new style
      local_action:
        module: zabbix_group
        zabbix_credentials: "{{ zabbix_creds }}"
        server_url: http://someother:8080 # <- overrides zabbix_creds.server_url
        state: "{{ state | default('present') }}"
        host_groups:
          - _JUSTATEST2_

```
