### PR TITLE
Fix: Remove unnecessary variables and fix a variable typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - zabbix_mediatype - now supports new `webhook` media type (PR [#82](https://github.com/ansible-collections/community.zabbix/pull/82)).
   - zabbix_mediatype - new options `message_templates`, `description` and many more related to `type=webhook` (PR [#82](https://github.com/ansible-collections/community.zabbix/pull/82)).
   - zabbix_discovery_rule - refactoring module to use `module_utils` classes and functions, adjust return values on success, add documentation for return values (PR [#120](https://github.com/ansible-collections/community.zabbix/pull/120)).
+  - zabbix_discovery_rule - refactoring the module to remove unnecessary variables and fix a variable typo (PR [#129](https://github.com/ansible-collections/community.zabbix/pull/129))
 
 ### Bug Fixes:
 #### Modules:

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -255,21 +255,9 @@ msg:
     sample: 'Discovery rule created: ACME, ID: 42'
 '''
 
-
-import traceback
-
-try:
-    from zabbix_api import ZabbixAPI
-    from zabbix_api import Already_Exists
-
-    HAS_ZABBIX_API = True
-except ImportError:
-    ZBX_IMP_ERR = traceback.format_exc()
-    HAS_ZABBIX_API = False
-
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
 import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from distutils.version import LooseVersion
 
 
@@ -658,9 +646,6 @@ def main():
     delay = module.params['delay']
     proxy = module.params['proxy']
     status = module.params['status']
-
-    if not HAS_ZABBIX_API:
-        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
 
     zbx = None
 

--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -651,13 +651,6 @@ def main():
         supports_check_mode=True
     )
 
-    server_url = module.params['server_url']
-    login_user = module.params['login_user']
-    login_password = module.params['login_password']
-    http_login_user = module.params['http_login_user']
-    http_login_password = module.params['http_login_password']
-    validate_certs = module.params['validate_certs']
-    timeout = module.params['timeout']
     state = module.params['state']
     name = module.params['name']
     iprange = module.params['iprange']
@@ -698,7 +691,7 @@ def main():
             if difference == {}:
                 module.exit_json(changed=False, state=state, drule=name, druleid=drule_id, msg="Discovery Rule is up to date: %s" % name)
             else:
-                result = drule.update_drule(
+                drule_id = drule.update_drule(
                     drule_id=drule_id,
                     **difference
                 )


### PR DESCRIPTION
##### SUMMARY

This PR fixes the following.

* Remove option variables don't use in code
* The `result` variable typo
    * result(mistake) -> drule_id
    * The result variable isn't referenced in code

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

zabbix_discovery_rule

##### ADDITIONAL INFORMATION