### PR TITLE
Fix: win_cmd on register service when path has spaces

### DIFF
--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -123,7 +123,7 @@
   notify: restart win zabbix agent
 
 - name: "Windows | Register Service"
-  win_command: '{{ zabbix_win_exe_path }} --config {{ zabbix_win_install_dir }}\zabbix_agentd.conf --install'
+  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agentd.conf" --install'
   register: zabbix_windows_install
   args:
     creates: '{{ zabbix_win_install_dir }}\.installed'

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -81,7 +81,7 @@
     - agent_file_info.stat.exists
 
 - name: "Windows | Uninstall Zabbix (Update)"
-  win_command: '"{{ zabbix_win_exe_path }}" -config "{{ zabbix_win_install_dir }}\zabbix_agentd.conf" --uninstall'
+  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agentd.conf" --uninstall'
   register: zabbix_windows_install
   when:
     - update_zabbix_agent | default(false)

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -81,7 +81,7 @@
     - agent_file_info.stat.exists
 
 - name: "Windows | Uninstall Zabbix (Update)"
-  win_command: '{{ zabbix_win_exe_path }} --config {{ zabbix_win_install_dir }}\zabbix_agentd.conf --uninstall'
+  win_command: '"{{ zabbix_win_exe_path }}" -config "{{ zabbix_win_install_dir }}\zabbix_agentd.conf" --uninstall'
   register: zabbix_windows_install
   when:
     - update_zabbix_agent | default(false)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When you set the `zabbix_win_install_dir` variable with folder that has spaces, the `win_command` brokes as reported on #132 

With small change on the line of `win_command` using double quotes, it fixes the way is the command is executed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #132 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- role: zabbix_agent
- task: Window.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
