### PR TITLE
Add lint test with tox flake8

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Run lint test
         run: tox -elinters -vv
+        working-directory: ./ansible_collections/community/zabbix
 
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -9,6 +9,32 @@ on:
       - 'roles/**'
 
 jobs:
+  tox-linters:
+    name: Tox-Lint ${{ matrix.python }}
+    strategy:
+      matrix:
+        python:
+          - 2.7
+          - 3.7
+          - 3.8
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          path: ansible_collections/community/zabbix
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install dependencies
+        run: pip install flake8 tox
+
+      - name: Run lint test
+        run: tox -elinters -vv
+
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tox-linters:
-    name: Tox-Lint ${{ matrix.python }}
+    name: Tox-Lint (py${{ matrix.python }})
     strategy:
       matrix:
         python:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# unit test
+.tox/

--- a/plugins/module_utils/base.py
+++ b/plugins/module_utils/base.py
@@ -7,11 +7,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from distutils.version import LooseVersion
-
 from ansible_collections.community.zabbix.plugins.module_utils.wrappers import ZapiWrapper
 
 

--- a/plugins/module_utils/helpers.py
+++ b/plugins/module_utils/helpers.py
@@ -7,9 +7,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from distutils.version import LooseVersion
-
 
 def zabbix_common_argument_spec():
     """

--- a/plugins/module_utils/wrappers.py
+++ b/plugins/module_utils/wrappers.py
@@ -9,8 +9,7 @@ __metaclass__ = type
 import atexit
 import traceback
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from distutils.version import LooseVersion
+from ansible.module_utils.basic import missing_required_lib
 
 try:
     from zabbix_api import ZabbixAPI

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -874,8 +874,8 @@ class Action(object):
             _params.pop('r_longdata', None)
             _params.pop('r_shortdata', None)
 
-        if (LooseVersion(self._zbx_api_version) < LooseVersion('3.4') or
-                LooseVersion(self._zbx_api_version) >= LooseVersion('5.0')):
+        if (LooseVersion(self._zbx_api_version) < LooseVersion('3.4')
+                or LooseVersion(self._zbx_api_version) >= LooseVersion('5.0')):
             _params.pop('ack_longdata', None)
             _params.pop('ack_shortdata', None)
 
@@ -980,7 +980,7 @@ class Operations(object):
                 "disable_host",
                 "set_host_inventory_mode"], operation['type']
             )
-        except Exception as e:
+        except Exception:
             self._module.fail_json(msg="Unsupported value '%s' for operation type." % operation['type'])
 
     def _construct_opmessage(self, operation):
@@ -1243,7 +1243,7 @@ class RecoveryOperations(Operations):
                 None,
                 "notify_all_involved"], operation['type']
             )
-        except Exception as e:
+        except Exception:
             self._module.fail_json(msg="Unsupported value '%s' for recovery operation type." % operation['type'])
 
     def construct_the_data(self, operations):
@@ -1308,7 +1308,7 @@ class AcknowledgeOperations(Operations):
                 None,
                 "notify_all_involved"], operation['type']
             )
-        except Exception as e:
+        except Exception:
             self._module.fail_json(msg="Unsupported value '%s' for acknowledge operation type." % operation['type'])
 
     def construct_the_data(self, operations):
@@ -1440,7 +1440,7 @@ class Filter(object):
                 "event_tag",
                 "event_tag_value"], _condition['type']
             )
-        except Exception as e:
+        except Exception:
             self._module.fail_json(msg="Unsupported value '%s' for condition type." % _condition['type'])
 
     def _construct_operator(self, _condition):
@@ -1467,7 +1467,7 @@ class Filter(object):
                 "Yes",
                 "No"], _condition['operator']
             )
-        except Exception as e:
+        except Exception:
             self._module.fail_json(msg="Unsupported value '%s' for operator." % _condition['operator'])
 
     def _construct_value(self, conditiontype, value):
@@ -1563,7 +1563,7 @@ class Filter(object):
                     "trigger in normal state"], value
                 )
             return value
-        except Exception as e:
+        except Exception:
             self._module.fail_json(
                 msg="""Unsupported value '%s' for specified condition type.
                        Check out Zabbix API documentation for supported values for

--- a/plugins/modules/zabbix_group.py
+++ b/plugins/modules/zabbix_group.py
@@ -73,11 +73,10 @@ EXAMPLES = r'''
 '''
 
 
-import atexit
 import traceback
 
 try:
-    from zabbix_api import ZabbixAPI, Already_Exists
+    from zabbix_api import Already_Exists
 
     HAS_ZABBIX_API = True
 except ImportError:

--- a/plugins/modules/zabbix_group_info.py
+++ b/plugins/modules/zabbix_group_info.py
@@ -54,11 +54,7 @@ EXAMPLES = r'''
     timeout: 10
 '''
 
-
-import atexit
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
 import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils

--- a/plugins/modules/zabbix_maintenance.py
+++ b/plugins/modules/zabbix_maintenance.py
@@ -350,12 +350,12 @@ def main():
             module.fail_json(msg="Failed to check maintenance %s existence: %s" % (name, error))
 
         if maintenance and (
-            sorted(group_ids) != sorted(maintenance["groupids"]) or
-            sorted(host_ids) != sorted(maintenance["hostids"]) or
-            str(maintenance_type) != maintenance["maintenance_type"] or
-            str(int(start_time)) != maintenance["active_since"] or
-            str(int(start_time + period)) != maintenance["active_till"] or
-            str(desc) != maintenance['description']
+            sorted(group_ids) != sorted(maintenance["groupids"])
+            or sorted(host_ids) != sorted(maintenance["hostids"])
+            or str(maintenance_type) != maintenance["maintenance_type"]
+            or str(int(start_time)) != maintenance["active_since"]
+            or str(int(start_time + period)) != maintenance["active_till"]
+            or str(desc) != maintenance['description']
         ):
             if module.check_mode:
                 changed = True

--- a/plugins/modules/zabbix_mediatype.py
+++ b/plugins/modules/zabbix_mediatype.py
@@ -635,14 +635,14 @@ def delete_mediatype(module, zbx, mediatype_id):
 
 def update_mediatype(module, zbx, **kwargs):
     try:
-        mediatype_id = zbx.mediatype.update(kwargs)
+        zbx.mediatype.update(kwargs)
     except Exception as e:
         module.fail_json(msg="Failed to update mediatype '{_id}': {e}".format(_id=kwargs['mediatypeid'], e=e))
 
 
 def create_mediatype(module, zbx, **kwargs):
     try:
-        mediatype_id = zbx.mediatype.create(kwargs)
+        zbx.mediatype.create(kwargs)
     except Exception as e:
         module.fail_json(msg="Failed to create mediatype '{name}': {e}".format(name=kwargs['name'], e=e))
 

--- a/plugins/modules/zabbix_service.py
+++ b/plugins/modules/zabbix_service.py
@@ -228,7 +228,7 @@ def main():
     service = Service(module)
     service_ids = service.get_service_ids(name)
     if service_ids:
-        service_json = service.dump_services(service_ids)
+        service.dump_services(service_ids)
 
     # Delete service
     if state == "absent":

--- a/plugins/modules/zabbix_template_info.py
+++ b/plugins/modules/zabbix_template_info.py
@@ -147,6 +147,7 @@ import traceback
 import json
 import xml.etree.ElementTree as ET
 
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase

--- a/plugins/modules/zabbix_template_info.py
+++ b/plugins/modules/zabbix_template_info.py
@@ -147,7 +147,6 @@ import traceback
 import json
 import xml.etree.ElementTree as ET
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase

--- a/plugins/modules/zabbix_valuemap.py
+++ b/plugins/modules/zabbix_valuemap.py
@@ -178,13 +178,13 @@ class ValuemapModule(ZabbixBase):
 
     def update(self, **kwargs):
         try:
-            valuemap_id = self._zapi.valuemap.update(kwargs)
+            self._zapi.valuemap.update(kwargs)
         except Exception as e:
             self._module.fail_json(msg="Failed to update valuemap '{_id}': {e}".format(_id=kwargs['valuemapid'], e=e))
 
     def create(self, **kwargs):
         try:
-            valuemap_id = self._zapi.valuemap.create(kwargs)
+            self._zapi.valuemap.create(kwargs)
         except Exception as e:
             self._module.fail_json(msg="Failed to create valuemap '{name}': {e}".format(name=kwargs['description'], e=e))
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+[tox]
+minversion = 1.4.2
+envlist = linters
+skipsdist = True
+
+[testenv]
+#deps = -r{toxinidir}/requirements.txt
+#       -r{toxinidir}/test-requirements.txt
+
+[testenv:linters]
+install_command = pip install {opts} {packages}
+deps =
+  flake8
+commands =
+  flake8 plugins {posargs}
+[testenv:venv]
+# This env is used to push new release on Galaxy
+install_command = pip install {opts} {packages}
+deps = ansible
+commands = {posargs}
+
+[flake8]
+# E123, E125 skipped as they are invalid PEP-8.
+
+show-source = True
+ignore = E123,E125,E402,E501,E741,W503
+max-line-length = 160
+builtins = _
+exclude = .git,.tox,tests/unit/compat/


### PR DESCRIPTION
##### SUMMARY

The current CI hasn't been able to the detection of unused variables and imported unused libraries.  
This PR is to add to able to the detection of unused variables and imported unused libraries with tox and flake8.  
Also, fix to syntax errors some modules and libraries.

fixes: https://github.com/ansible-collections/community.zabbix/issues/130

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/base.py
plugins/module_utils/helpers.py
plugins/module_utils/wrappers.py
plugins/modules/zabbix_action.py
plugins/modules/zabbix_group.py
plugins/modules/zabbix_group_info.py
plugins/modules/zabbix_maintenance.py
plugins/modules/zabbix_mediatype.py
plugins/modules/zabbix_template_info.py
plugins/modules/zabbix_user.py
plugins/modules/zabbix_valuemap.py
plugins/modules/zabbix_service.py
.github/workflows/plugins.yml
tox.ini

##### ADDITIONAL INFORMATION