### PR TITLE
fix KeyErrors which occur during exceptions in discovery_rule

### DIFF
--- a/plugins/modules/zabbix_discovery_rule.py
+++ b/plugins/modules/zabbix_discovery_rule.py
@@ -462,11 +462,11 @@ class DiscoveryRule(object):
         """
         try:
             if self._module.check_mode:
-                self._module.exit_json(msg="Discovery rule would be updated if check mode was not specified: %s" % kwargs['name'], changed=True)
+                self._module.exit_json(msg="Discovery rule would be updated if check mode was not specified: ID %s" % kwargs['drule_id'], changed=True)
             kwargs['druleid'] = kwargs.pop('drule_id')
             return self._zapi.drule.update(kwargs)
         except Exception as e:
-            self._module.fail_json(msg="Failed to update discovery rule '%s': %s" % (kwargs['druleid'], e))
+            self._module.fail_json(msg="Failed to update discovery rule ID '%s': %s" % (kwargs['drule_id'], e))
 
     def add_drule(self, **kwargs):
         """Add discovery rule

--- a/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_discovery_rule/tasks/main.yml
@@ -17,6 +17,15 @@
       delay: "{{ 3600 if zabbix_version is version('3.4', '<=') else omit }}"
 
   block:
+  - name: test - create new Zabbix discovery rule (checkmode)
+    zabbix_discovery_rule:
+    check_mode: True
+    register: drule_new_checkmode
+
+  - name: assert that drule will be created (checkmode)
+    assert:
+      that: drule_new_checkmode is changed
+
   - name: test - create new Zabbix discovery rule
     zabbix_discovery_rule:
     register: drule_new
@@ -32,6 +41,18 @@
   - name: assert that nothing has been changed
     assert:
       that: not drule_exists is changed
+
+  - name: test - update Zabbix discovery rule iprange (checkmode)
+    zabbix_discovery_rule:
+      iprange:
+        - 192.168.1.1-255
+        - 10.0.0.1-255
+    check_mode: True
+    register: drule_iprange_update_checkmode
+
+  - name: assert that iprange will be changed
+    assert:
+      that: drule_iprange_update_checkmode is changed
 
   - name: test - update Zabbix discovery rule iprange
     zabbix_discovery_rule:


### PR DESCRIPTION
##### SUMMARY
If the call of `update_drule` throws an exceptions, the referenced `kwargs['druleid']` does not exists and therefore we got an KeyError: 'druleid' Traceback.
Also the `kwargs['name']` could probably not exists in the parameters, if the name of drule was not changed, it will not exist in the `difference` dict. So it cannot be used here as a reliable variable.
This PR will solve these two problems. I also add 2 more integration test to cover this fix.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_discovery_rule