### PR TITLE
Fix support for macro context

### DIFF
--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -924,6 +924,7 @@ class Host(object):
         except Exception as e:
             self._module.fail_json(msg="Failed to set inventory to host: %s" % e)
 
+            
 def normalize_macro_name(macro_name):
     # Zabbix handles macro names in upper case characters
     if ':' in macro_name:
@@ -938,6 +939,7 @@ def normalize_macro_name(macro_name):
         macro_name = macro_name + '}'
 
     return macro_name
+
 
 def main():
     module = AnsibleModule(

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -924,6 +924,20 @@ class Host(object):
         except Exception as e:
             self._module.fail_json(msg="Failed to set inventory to host: %s" % e)
 
+def normalize_macro_name(macro_name):
+    # Zabbix handles macro names in upper case characters
+    if ':' in macro_name:
+        macro_name = ':'.join([macro_name.split(':')[0].upper(), ':'.join(macro_name.split(':')[1:])])
+    else:
+        macro_name = macro_name.upper()
+
+    # Valid format for macro is {$MACRO}
+    if not macro_name.startswith('{$'):
+        macro_name = '{$' + macro_name
+    if not macro_name.endswith('}'):
+        macro_name = macro_name + '}'
+
+    return macro_name
 
 def main():
     module = AnsibleModule(
@@ -1079,11 +1093,8 @@ def main():
     if macros:
         # convert macros to zabbix native format - {$MACRO}
         for macro in macros:
-            macro['macro'] = macro['macro'].upper()
-            if not macro['macro'].startswith('{$'):
-                macro['macro'] = '{$' + macro['macro']
-            if not macro['macro'].endswith('}'):
-                macro['macro'] = macro['macro'] + '}'
+            macro['macro'] = normalize_macro_name(macro['macro'])
+
             if LooseVersion(zbx_api_version) <= LooseVersion('4.4.0'):
                 if 'description' in macro:
                     macro.pop('description', False)

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -924,7 +924,7 @@ class Host(object):
         except Exception as e:
             self._module.fail_json(msg="Failed to set inventory to host: %s" % e)
 
-            
+
 def normalize_macro_name(macro_name):
     # Zabbix handles macro names in upper case characters
     if ':' in macro_name:


### PR DESCRIPTION
normalize_macro_name() lifted from zabbix_hostmacro

Fixes macro context part of #114.