### PR TITLE
DB TLS variables and StartPreprocessors

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -315,6 +315,8 @@ Keep in mind that using the Zabbix Agent in a Container requires changes to the 
 
 * `zabbix_agent_inventory_zabbix`: Adds Facts for a zabbix inventory
 
+* `zabbix_repo_yum_schema`: Option to change the web schema for the yum repository(http/https)
+
 ## IPMI variables
 
 * `zabbix_agent_ipmi_authtype`: IPMI authentication algorithm. Possible values are 1 (callback), 2 (user), 3 (operator), 4 (admin), 5 (OEM), with 2 being the API default.

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -77,6 +77,8 @@ There are some variables in de default/main.yml which can (Or needs to) be chang
 
 * `zabbix_install_pip_packages`: Set to `False` if you don't want to install the required pip packages. Useful when you control your environment completely. Default: True
 
+* `zabbix_proxy_startpreprocessors`: Number of pre-forked instances of preprocessing workers. The preprocessing manager process is automatically started when a preprocessor worker is started.This parameter is supported since Zabbix 4.2.0.
+
 There are some zabbix-proxy specific variables which will be used for the zabbix-proxy configuration file, these can be found in the default/main.yml file. There are 2 which needs some explanation:
 
 ```yaml
@@ -131,6 +133,24 @@ These variables are specific for Zabbix 3.0 and higher:
 * `*zabbix_proxy_tlskeyfile`: Full pathname of a file containing the agent private key.
 
 * `*zabbix_proxy_tlspskidentity`: Unique, case sensitive string used to identify the pre-shared key.
+
+* `zabbix_proxy_dbtlsconnect`: Setting this option enforces to use TLS connection to database:
+required - connect using TLS
+verify_ca - connect using TLS and verify certificate
+verify_full - connect using TLS, verify certificate and verify that database identity specified by DBHost matches its certificate
+On MySQL starting from 5.7.11 and PostgreSQL the following values are supported: "required", "verify", "verify_full". On MariaDB starting from version 10.2.6 "required" and "verify_full" values are supported.
+By default not set to any option and the behaviour depends on database configuration.
+This parameter is supported since Zabbix 5.0.0.
+
+* `zabbix_proxy_dbtlscafile`: Full pathname of a file containing the top-level CA(s) certificates for database certificate verification.This parameter is supported since Zabbix 5.0.0.
+
+* `zabbix_proxy_dbtlscertfile`: Full pathname of file containing Zabbix server certificate for authenticating to database.This parameter is supported since Zabbix 5.0.0.
+
+* `zabbix_proxy_dbtlskeyfile`: Full pathname of file containing the private key for authenticating to database.This parameter is supported since Zabbix 5.0.0.
+
+* `zabbix_proxy_dbtlscipher`: The list of encryption ciphers that Zabbix server permits for TLS protocols up through TLSv1.2.Supported only for MySQL.This parameter is supported since Zabbix 5.0.0.
+
+* `zabbix_proxy_dbtlscipher13`: The list of encryption ciphersuites that Zabbix server permits for TLSv1.3 protocol.Supported only for MySQL, starting from version 8.0.16. This parameter is supported since Zabbix 5.0.0.
 
 ## Zabbix API variables
 

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -111,6 +111,9 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_server_dbencoding`: The encoding for the MySQL database. Default set to `utf8`
 * `zabbix_server_dbcollation`: The collation for the MySQL database. Default set to `utf8_bin`
 * `zabbix_server_manage_service`: True / False. When you run multiple Zabbix servers in a High Available cluster setup (e.g. pacemaker), you don't want Ansible to manage the zabbix-server service, because Pacemaker is in control of zabbix-server service.
+* `zabbix_repo_yum_schema`: Option to change the web schema for the yum repository(http/https)
+* `zabbix_proxy_startpreprocessors`: Number of pre-forked instances of preprocessing workers. The preprocessing manager process is automatically started when a preprocessor worker is started.This parameter is supported since Zabbix 4.2.0.
+
 
 ### Custom Zabbix Scripts
 
@@ -147,6 +150,18 @@ These variables are specific for Zabbix 3.0 and higher:
 * `zabbix_server_tlsservercertsubject`: Allowed server certificate subject.
 * `zabbix_server_tlscertfile`: Full pathname of a file containing the agent certificate or certificate chain.
 * `zabbix_server_tlskeyfile`: Full pathname of a file containing the agent private key.
+* `zabbix_server_dbtlsconnect`: Setting this option enforces to use TLS connection to database:
+required - connect using TLS
+verify_ca - connect using TLS and verify certificate
+verify_full - connect using TLS, verify certificate and verify that database identity specified by DBHost matches its certificate
+On MySQL starting from 5.7.11 and PostgreSQL the following values are supported: "required", "verify", "verify_full". On MariaDB starting from version 10.2.6 "required" and "verify_full" values are supported.
+By default not set to any option and the behaviour depends on database configuration.
+This parameter is supported since Zabbix 5.0.0.
+* `zabbix_server_dbtlscafile`: Full pathname of a file containing the top-level CA(s) certificates for database certificate verification.This parameter is supported since Zabbix 5.0.0.
+* `zabbix_server_dbtlscertfile`: Full pathname of file containing Zabbix server certificate for authenticating to database.This parameter is supported since Zabbix 5.0.0.
+* `zabbix_server_dbtlskeyfile`: Full pathname of file containing the private key for authenticating to database.This parameter is supported since Zabbix 5.0.0.
+* `zabbix_server_dbtlscipher`: The list of encryption ciphers that Zabbix server permits for TLS protocols up through TLSv1.2.Supported only for MySQL.This parameter is supported since Zabbix 5.0.0.
+* `zabbix_server_dbtlscipher13`: The list of encryption ciphersuites that Zabbix server permits for TLSv1.3 protocol.Supported only for MySQL, starting from version 8.0.16. This parameter is supported since Zabbix 5.0.0.
 
 ## Database
 

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -82,6 +82,7 @@ The following is an overview of all available configuration defaults for this ro
 
 * `zabbix_web_version`: This is the version of zabbix. Default: 5.0, Can be overridden to 4.4, 4.0, 3.4, 3.2, 3.0, 2.4, or 2.2. Previously the variable `zabbix_version` was used directly but it could cause [some inconvenience](https://github.com/dj-wasabi/ansible-zabbix-agent/pull/303). That variable is maintained by retrocompativility.
 * `zabbix_repo_yum`: A list with Yum repository configuration.
+* `zabbix_repo_yum_schema`: Option to change the web schema for the yum repository(http/https)
 * `zabbix_web_package_state`: Default: _present_. Can be overridden to "latest" to update packages when needed.
 * `zabbix_web_centos_release`: Default: False. When the `centos-release-scl` repository needs to be enabled. This is required when using Zabbix 5.0 due to installation of a recent version of `PHP`.
 

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -32,7 +32,7 @@ zabbix_apt_install_recommends: no
 zabbix_agent_distribution_major_version: "{{ ansible_distribution_major_version }}"
 zabbix_agent_distribution_release: "{{ ansible_distribution_release }}"
 zabbix_agent_os_family: "{{ ansible_os_family }}"
-zabbix_repo_yum_schema: http
+zabbix_repo_yum_schema: https
 
 zabbix_repo_yum:
   - name: zabbix

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -32,19 +32,18 @@ zabbix_apt_install_recommends: no
 zabbix_agent_distribution_major_version: "{{ ansible_distribution_major_version }}"
 zabbix_agent_distribution_release: "{{ ansible_distribution_release }}"
 zabbix_agent_os_family: "{{ ansible_os_family }}"
+zabbix_repo_yum_schema: http
 
 zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch
-    baseurl: http://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ zabbix_agent_distribution_major_version }}/$basearch/
-    priority: 1
+    baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ zabbix_agent_distribution_major_version }}/$basearch/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
   - name: zabbix-non-supported
     description: Zabbix Official Repository non-supported - $basearch
-    baseurl: http://repo.zabbix.com/non-supported/rhel/{{ zabbix_agent_distribution_major_version }}/$basearch/
-    priority: 1
+    baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/non-supported/rhel/{{ zabbix_agent_distribution_major_version }}/$basearch/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -5,17 +5,18 @@ zabbix_version: 5.0
 zabbix_repo: zabbix
 zabbix_package_state: present
 zabbix_selinux: False
+zabbix_repo_yum_schema: http
 
 zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch
-    baseurl: http://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/
+    baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
   - name: zabbix-supported
     description: Zabbix Official Repository non-supported - $basearch
-    baseurl: http://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/
+    baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -5,7 +5,7 @@ zabbix_version: 5.0
 zabbix_repo: zabbix
 zabbix_package_state: present
 zabbix_selinux: False
-zabbix_repo_yum_schema: http
+zabbix_repo_yum_schema: https
 
 zabbix_repo_yum:
   - name: zabbix

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -14,7 +14,7 @@ zabbix_repo: zabbix
 zabbix_proxy_package_state: present
 zabbix_proxy_install_database_client: True
 zabbix_install_pip_packages: true
-zabbix_repo_yum_schema: http
+zabbix_repo_yum_schema: https
 
 zabbix_repo_yum:
   - name: zabbix

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -14,7 +14,7 @@ zabbix_repo: zabbix
 zabbix_proxy_package_state: present
 zabbix_proxy_install_database_client: True
 zabbix_install_pip_packages: true
-zabbix_repo_yum_schema: https
+zabbix_repo_yum_schema: http
 
 zabbix_repo_yum:
   - name: zabbix

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -14,17 +14,18 @@ zabbix_repo: zabbix
 zabbix_proxy_package_state: present
 zabbix_proxy_install_database_client: True
 zabbix_install_pip_packages: true
+zabbix_repo_yum_schema: https
 
 zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch
-    baseurl: http://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/
+    baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
   - name: zabbix-non-supported
     description: Zabbix Official Repository non-supported - $basearch
-    baseurl: http://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/
+    baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
@@ -33,6 +34,12 @@ zabbix_server_host: 192.168.1.1
 zabbix_server_port: 10051
 zabbix_database_creation: True
 zabbix_database_sqlload: True
+zabbix_proxy_dbtlsconnect:
+zabbix_proxy_dbtlscafile:
+zabbix_proxy_dbtlscertfile:
+zabbix_proxy_dbtlskeyfile:
+zabbix_proxy_dbtlscipher:
+zabbix_proxy_dbtlscipher13:
 
 # Some role specific vars
 zabbix_proxy_database: mysql
@@ -74,6 +81,7 @@ zabbix_proxy_starttrappers: 5
 zabbix_proxy_startpingers: 1
 zabbix_proxy_startdiscoverers: 1
 zabbix_proxy_starthttppollers: 1
+zabbix_proxy_startpreprocessors: 3
 zabbix_proxy_javagateway:
 zabbix_proxy_javagatewayport: 10052
 zabbix_proxy_startjavapollers: 5

--- a/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
+++ b/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
@@ -597,6 +597,6 @@ DBTLSCipher={{ zabbix_proxy_dbtlscipher }}
 # Mandatory no
 # Default:
 # DBTLSCipher13=
-{% if zabbix_proxy_dbtlscipher13 is defined and zabbix_proxy_dbtlscipher13r is not none %}
+{% if zabbix_proxy_dbtlscipher13 is defined and zabbix_proxy_dbtlscipher13 is not none %}
 DBTLSCipher13={{ zabbix_proxy_dbtlscipher13 }}
 {% endif %}

--- a/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
+++ b/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
@@ -181,6 +181,16 @@ StartPollers={{ zabbix_proxy_startpollers }}
 #
 StartIPMIPollers={{ zabbix_proxy_startipmipollers }}
 
+### Option: StartPreprocessors
+#       Number of pre-forked instances of preprocessing workers.
+#               The preprocessing manager process is automatically started when preprocessor worker is started.
+#
+# Mandatory: no
+# Range: 1-1000
+# Default:
+# StartPreprocessors=3
+StartPreprocessors={{ zabbix_proxy_startpreprocessors }}
+
 ### Option: StartPollersUnreachable
 #	Number of pre-forked instances of pollers for unreachable hosts (including IPMI).
 #
@@ -515,4 +525,78 @@ TLSPSKIdentity={{ zabbix_proxy_tlspskidentity }}
 {% if zabbix_proxy_tlspskfile is defined and zabbix_proxy_tlspskfile %}
 TLSPSKFile={{ zabbix_proxy_tlspskfile }}
 {% endif %}
+{% endif %}
+
+### Option: DBTLSConnect
+#	Setting this option enforces to use TLS connection to database.
+#	required    - connect using TLS
+#	verify_ca   - connect using TLS and verify certificate
+#	verify_full - connect using TLS, verify certificate and verify that database identity specified by DBHost
+#	              matches its certificate
+#	On MySQL starting from 5.7.11 and PostgreSQL following values are supported: "required", "verify_ca" and
+#	"verify_full".
+#	On MariaDB starting from version 10.2.6 "required" and "verify_full" values are supported.
+#	Default is not to set any option and behavior depends on database configuration
+#
+# Mandatory: no
+# Default:
+# DBTLSConnect=
+{% if zabbix_proxy_dbtlsconnect is defined and zabbix_proxy_dbtlsconnect is not none %}
+DBTLSConnect={{ zabbix_proxy_dbtlsconnect }}
+{% endif %}
+
+### Option: DBTLSCAFile
+#	Full pathname of a file containing the top-level CA(s) certificates for database certificate verification.
+#	Supported only for MySQL and PostgreSQL
+#
+# Mandatory: no
+#	(yes, if DBTLSConnect set to one of: verify_ca, verify_full)
+# Default:
+# DBTLSCAFile=
+{% if zabbix_proxy_dbtlscafile is defined and zabbix_proxy_dbtlscafile is not none %}
+DBTLSCAFile={{ zabbix_proxy_dbtlscafile }}
+{% endif %}
+
+### Option: DBTLSCertFile
+#	Full pathname of file containing Zabbix proxy certificate for authenticating to database.
+#	Supported only for MySQL and PostgreSQL
+#
+# Mandatory: no
+# Default:
+# DBTLSCertFile=
+{% if zabbix_proxy_dbtlscertfile is defined and zabbix_proxy_dbtlscertfile is not none %}
+DBTLSCertFile={{ zabbix_proxy_dbtlscertfile }}
+{% endif %}
+
+### Option: DBTLSKeyFile
+#	Full pathname of file containing the private key for authenticating to database.
+#	Supported only for MySQL and PostgreSQL
+#
+# Mandatory: no
+# Default:
+# DBTLSKeyFile=
+{% if zabbix_proxy_dbtlskeyfile is defined and zabbix_proxy_dbtlskeyfile is not none %}
+DBTLSKeyFile={{ zabbix_proxy_dbtlskeyfile }}
+{% endif %}
+
+### Option: DBTLSCipher
+#	The list of encryption ciphers that Zabbix proxy permits for TLS protocols up through TLSv1.2
+#	Supported only for MySQL
+#
+# Mandatory no
+# Default:
+# DBTLSCipher=
+{% if zabbix_proxy_dbtlscipher is defined and zabbix_proxy_dbtlscipher is not none %}
+DBTLSCipher={{ zabbix_proxy_dbtlscipher }}
+{% endif %}
+
+### Option: DBTLSCipher13
+#	The list of encryption ciphersuites that Zabbix proxy permits for TLSv1.3 protocol
+#	Supported only for MySQL, starting from version 8.0.16
+#
+# Mandatory no
+# Default:
+# DBTLSCipher13=
+{% if zabbix_proxy_dbtlscipher13 is defined and zabbix_proxy_dbtlscipher13r is not none %}
+DBTLSCipher13={{ zabbix_proxy_dbtlscipher13 }}
 {% endif %}

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -12,17 +12,18 @@ zabbix_server_install_database_client: True
 
 zabbix_service_state: started
 zabbix_service_enabled: True
+zabbix_repo_yum_schema: http
 
 zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch
-    baseurl: http://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/
+    baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
   - name: zabbix-non-supported
     description: Zabbix Official Repository non-supported - $basearch
-    baseurl: http://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/
+    baseurl: "{{ zabbix_repo_yum_schema }}http://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -23,7 +23,7 @@ zabbix_repo_yum:
     state: present
   - name: zabbix-non-supported
     description: Zabbix Official Repository non-supported - $basearch
-    baseurl: "{{ zabbix_repo_yum_schema }}http://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/"
+    baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -32,6 +32,15 @@ zabbix_server_database: pgsql
 zabbix_server_database_long: postgresql
 zabbix_database_creation: True
 zabbix_database_sqlload: True
+zabbix_server_dbtlsconnect:
+zabbix_server_dbtlscafile:
+zabbix_server_dbtlscertfile:
+zabbix_server_dbtlskeyfile:
+zabbix_server_dbtlscipher:
+zabbix_server_dbtlscipher13:
+
+
+
 
 # zabbix-server specific vars
 zabbix_server_listenport: 10051
@@ -66,6 +75,7 @@ zabbix_server_starttrappers: 5
 zabbix_server_startpingers: 1
 zabbix_server_startdiscoverers: 1
 zabbix_server_starthttppollers: 1
+zabbix_server_startpreprocessors: 3
 zabbix_server_starttimers: 1
 zabbix_server_javagateway:
 zabbix_server_javagatewayport: 10052

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -40,9 +40,6 @@ zabbix_server_dbtlskeyfile:
 zabbix_server_dbtlscipher:
 zabbix_server_dbtlscipher13:
 
-
-
-
 # zabbix-server specific vars
 zabbix_server_listenport: 10051
 zabbix_server_sourceip:

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -12,7 +12,7 @@ zabbix_server_install_database_client: True
 
 zabbix_service_state: started
 zabbix_service_enabled: True
-zabbix_repo_yum_schema: http
+zabbix_repo_yum_schema: https
 
 zabbix_repo_yum:
   - name: zabbix

--- a/roles/zabbix_server/templates/zabbix_server.conf.j2
+++ b/roles/zabbix_server/templates/zabbix_server.conf.j2
@@ -173,6 +173,16 @@ StartPollers={{ zabbix_server_startpollers }}
 #
 StartIPMIPollers={{ zabbix_server_startipmipollers }}
 
+### Option: StartPreprocessors
+#       Number of pre-forked instances of preprocessing workers.
+#               The preprocessing manager process is automatically started when preprocessor worker is started.
+#
+# Mandatory: no
+# Range: 1-1000
+# Default:
+# StartPreprocessors=3
+StartPreprocessors={{ zabbix_server_startpreprocessors }}
+
 ### option: startpollersunreachable
 #	number of pre-forked instances of pollers for unreachable hosts (including ipmi).
 #
@@ -574,4 +584,78 @@ TLSCertFile={{ zabbix_server_tlscertfile }}
 {% if zabbix_server_tlskeyfile is defined and zabbix_server_tlskeyfile is not none %}
 TLSKeyFile={{ zabbix_server_tlskeyfile }}
 {% endif %}
+{% endif %}
+
+### Option: DBTLSConnect
+#	Setting this option enforces to use TLS connection to database.
+#	required    - connect using TLS
+#	verify_ca   - connect using TLS and verify certificate
+#	verify_full - connect using TLS, verify certificate and verify that database identity specified by DBHost
+#	              matches its certificate
+#	On MySQL starting from 5.7.11 and PostgreSQL following values are supported: "required", "verify_ca" and
+#	"verify_full".
+#	On MariaDB starting from version 10.2.6 "required" and "verify_full" values are supported.
+#	Default is not to set any option and behavior depends on database configuration
+#
+# Mandatory: no
+# Default:
+# DBTLSConnect=
+{% if zabbix_server_dbtlsconnect is defined and zabbix_server_dbtlsconnect is not none %}
+DBTLSConnect={{ zabbix_server_dbtlsconnect }}
+{% endif %}
+
+### Option: DBTLSCAFile
+#	Full pathname of a file containing the top-level CA(s) certificates for database certificate verification.
+#	Supported only for MySQL and PostgreSQL
+#
+# Mandatory: no
+#	(yes, if DBTLSConnect set to one of: verify_ca, verify_full)
+# Default:
+# DBTLSCAFile=
+{% if zabbix_server_dbtlscafile is defined and zabbix_server_dbtlscafile is not none %}
+DBTLSCAFile={{ zabbix_server_dbtlscafile }}
+{% endif %}
+
+### Option: DBTLSCertFile
+#	Full pathname of file containing Zabbix proxy certificate for authenticating to database.
+#	Supported only for MySQL and PostgreSQL
+#
+# Mandatory: no
+# Default:
+# DBTLSCertFile=
+{% if zabbix_server_dbtlscertfile is defined and zabbix_server_dbtlscertfile is not none %}
+DBTLSCertFile={{ zabbix_server_dbtlscertfile }}
+{% endif %}
+
+### Option: DBTLSKeyFile
+#	Full pathname of file containing the private key for authenticating to database.
+#	Supported only for MySQL and PostgreSQL
+#
+# Mandatory: no
+# Default:
+# DBTLSKeyFile=
+{% if zabbix_server_dbtlskeyfile is defined and zabbix_server_dbtlskeyfile is not none %}
+DBTLSKeyFile={{ zabbix_server_dbtlskeyfile }}
+{% endif %}
+
+### Option: DBTLSCipher
+#	The list of encryption ciphers that Zabbix proxy permits for TLS protocols up through TLSv1.2
+#	Supported only for MySQL
+#
+# Mandatory no
+# Default:
+# DBTLSCipher=
+{% if zabbix_server_dbtlscipher is defined and zabbix_server_dbtlscipher is not none %}
+DBTLSCipher={{ zabbix_server_dbtlscipher }}
+{% endif %}
+
+### Option: DBTLSCipher13
+#	The list of encryption ciphersuites that Zabbix proxy permits for TLSv1.3 protocol
+#	Supported only for MySQL, starting from version 8.0.16
+#
+# Mandatory no
+# Default:
+# DBTLSCipher13=
+{% if zabbix_server_dbtlscipher13 is defined and zabbix_server_dbtlscipher13r is not none %}
+DBTLSCipher13={{ zabbix_server_dbtlscipher13 }}
 {% endif %}

--- a/roles/zabbix_server/templates/zabbix_server.conf.j2
+++ b/roles/zabbix_server/templates/zabbix_server.conf.j2
@@ -656,6 +656,6 @@ DBTLSCipher={{ zabbix_server_dbtlscipher }}
 # Mandatory no
 # Default:
 # DBTLSCipher13=
-{% if zabbix_server_dbtlscipher13 is defined and zabbix_server_dbtlscipher13r is not none %}
+{% if zabbix_server_dbtlscipher13 is defined and zabbix_server_dbtlscipher13 is not none %}
 DBTLSCipher13={{ zabbix_server_dbtlscipher13 }}
 {% endif %}

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -26,17 +26,18 @@ zabbix_apache_tls_crt: /etc/pki/server.crt
 zabbix_apache_tls_key: /etc/pki/server.key
 zabbix_apache_tls_chain:
 zabbix_apache_can_connect_ldap: False
+zabbix_repo_yum_schema: http
 
 zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch
-    baseurl: http://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/
+    baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
   - name: zabbix-non-supported
     description: Zabbix Official Repository non-supported - $basearch
-    baseurl: http://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/
+    baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -45,7 +45,7 @@ zabbix_repo_yum:
 zabbix_5_repo_yum:
   - name: zabbix-frontend
     description: Zabbix Official Repository - $basearch
-    baseurl: http://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/frontend/
+    baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/frontend/"
     gpgcheck: 0
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -26,7 +26,7 @@ zabbix_apache_tls_crt: /etc/pki/server.crt
 zabbix_apache_tls_key: /etc/pki/server.key
 zabbix_apache_tls_chain:
 zabbix_apache_can_connect_ldap: False
-zabbix_repo_yum_schema: http
+zabbix_repo_yum_schema: https
 
 zabbix_repo_yum:
   - name: zabbix


### PR DESCRIPTION
There are no following variables in the current roles in templates for Zabbix server/proxy:
DBTLSconnect
DBTLScafile
DBTLScertfile
DBTLSkeyfile
DBTLScipher
DBTLScipher13
StartPreprocessors

and added the zabbix_repo_yum_schema variable so that the web schema can be selected.
