### PR TITLE
Added missed 'become: yes' for the root operations

### DIFF
--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -18,6 +18,7 @@
     state: present
   register: gnupg_installed
   until: gnupg_installed is succeeded
+  become: yes
 
 - name: "Debian | Install gpg key"
   apt_key:
@@ -124,6 +125,7 @@
     state: directory
   when:
     - zabbix_agent_apt_priority | int
+  become: yes
 
 - name: "Debian | Configuring the weight for APT"
   copy:
@@ -135,6 +137,7 @@
     owner: root
   when:
     - zabbix_agent_apt_priority | int
+  become: yes
 
 # Note: set cache_valid_time=0 to ensure that an apt-get update after the added repo-key
 # else you often get 'WARNING: The following packages cannot be authenticated!


### PR DESCRIPTION
##### SUMMARY
Added missed `become: yes` for the root operations

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zabbix-agent

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
