### PR TITLE
Removed duplicate zabbix_apache_vhost_port

### DIFF
--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -98,7 +98,6 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_vhost`: Default: `true`. When you don't want to create an Apache Virtual Host configuration, you can set it to False.
 * `zabbix_apache_vhost_port`: The port on which Zabbix HTTP vhost is running.
 * `zabbix_apache_vhost_tls_port`: The port on which Zabbix HTTPS vhost is running.
-* `zabbix_apache_vhost_port`: On which port the Apache Virtual Host is available.
 * `zabbix_apache_vhost_listen_ip`: On which interface the Apache Virtual Host is available.
 * `zabbix_apache_can_connect_ldap`: Default: `false`. Set SELinux boolean to allow httpd to connect to LDAP.
 * `zabbix_php_install`: Default: `true`. True / False. Switch for extra install of packages for PHP, currently on for Debian/Ubuntu.


### PR DESCRIPTION
The variable 'zabbix_apache_vhost_port' was listed twice in the README.

##### SUMMARY
The list of variables for the zabbix_web role listed 'zabbix_apache_vhost_port' twice with small variation in their description.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zabbix_web

