### PR TITLE
Configured the acl_users with a variable containing apache or nginx

### DIFF
--- a/roles/zabbix_web/templates/php-fpm.conf.j2
+++ b/roles/zabbix_web/templates/php-fpm.conf.j2
@@ -3,7 +3,11 @@ user = apache
 group = apache
 
 listen = {{ php_fpm_listen }}/zabbix.sock
-listen.acl_users = apache,nginx
+{% if zabbix_websrv == "apache" %}
+listen.acl_users = {{ apache_user }}
+{% else %}
+listen.acl_users = {{ zabbix_websrv }}
+{% endif %}
 listen.allowed_clients = 127.0.0.1
 
 pm = dynamic


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When `zabbix_websrv` is set to `apache`, then the user on which Apache is running will be added, otherwise the `zabbix_websrv` output (In case for Nginx).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #203 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

role: zabbix_web

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
