### PR TITLE
Override mode for the configuration file

### DIFF
--- a/changelogs/fragments/roles-all-configure-conf-mode.yaml
+++ b/changelogs/fragments/roles-all-configure-conf-mode.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - "Added an ``zabbix_{agent,web,server,proxy,javagateway}_conf_mode`` to configure the mode for the configuration file."

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -136,6 +136,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_agent_become_on_localhost`: Default: `True`. Set to `False` if you don't need to elevate privileges on localhost to install packages locally with pip.
 * `zabbix_install_pip_packages`: Default: `True`. Set to `False` if you don't want to install the required pip packages. Useful when you control your environment completely.
 * `zabbix_agent_apt_priority`: Add a weight (`Pin-Priority`) for the APT repository.
+* `zabbix_agent_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 
 ### Zabbix Agent vs Zabbix Agent 2 configuration
 

--- a/docs/ZABBIX_JAVAGATEWAY_ROLE.md
+++ b/docs/ZABBIX_JAVAGATEWAY_ROLE.md
@@ -64,6 +64,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_repo_yum`: A list with Yum repository configuration.
 * `zabbix_repo_yum_schema`: Default: `https`. Option to change the web schema for the yum repository(http/https)
 * `zabbix_javagateway_package_state`: Default: `present`. Can be overridden to `latest` to update packages when needed.
+* `zabbix_javagateway_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 
 ### Java Gatewaty
 

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -96,6 +96,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_proxy_groupname`: Default: `zabbix`. The name of the group of the user on the host. Will only be used when `zabbix_repo: epel` is used.
 * `zabbix_proxy_groupid`: The GID of the group on the host. Will only be used when `zabbix_repo: epel` is used.
 * `zabbix_proxy_include_mode`: Default: `0755`. The "mode" for the directory configured with `zabbix_proxy_include`.
+* `zabbix_proxy_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 
 ### Database specific
 

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -109,6 +109,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_server_groupname`: Default: `zabbix`. The name of the group of the user on the host. Will only be used when `zabbix_repo: epel` is used.
 * `zabbix_server_groupid`: The GID of the group on the host. Will only be used when `zabbix_repo: epel` is used.
 * `zabbix_server_include_mode`: Default: `0755`. The "mode" for the directory configured with `zabbix_server_include`.
+* `zabbix_server_conf_mode`: Default: `0640`. The "mode" for the Zabbix configuration file.
 
 ### Database specific
 

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -89,6 +89,7 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_package_state`: Default: `present`. Can be overridden to `latest` to update packages when needed.
 * `zabbix_web_centos_release`: Default: False. When the `centos-release-scl` repository needs to be enabled. This is required when using Zabbix 5.0 due to installation of a recent version of `PHP`.
 * `zabbix_web_doubleprecision`: Default: `False`. For upgraded installations, please read database [upgrade notes](https://www.zabbix.com/documentation/current/manual/installation/upgrade_notes_500) (Paragraph "Enabling extended range of numeric (float) values") before enabling this option.
+* `zabbix_web_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 
 ### Zabbix Web specific
 

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -15,6 +15,7 @@ zabbix_agent_serveractive:
 zabbix_selinux: False
 zabbix_agent_src_reinstall: True
 zabbix_agent_apt_priority:
+zabbix_agent_conf_mode: "0644"
 
 # Selinux related vars 
 selinux_allow_zabbix_run_sudo: False

--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -138,7 +138,7 @@
     dest: "/etc/zabbix/{{ zabbix_agent_conf if not zabbix_agent2 else zabbix_agent2_conf }}"
     owner: root
     group: root
-    mode: 0644
+    mode: "{{ zabbix_agent_conf_mode }}"
   notify:
     - restart zabbix-agent
   become: yes

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -7,6 +7,7 @@ zabbix_javagateway_package_state: present
 zabbix_selinux: False
 zabbix_repo: zabbix
 zabbix_repo_yum_schema: https
+zabbix_java_gateway_conf_mode: "0644"
 
 zabbix_repo_yum:
   - name: zabbix

--- a/roles/zabbix_javagateway/tasks/main.yml
+++ b/roles/zabbix_javagateway/tasks/main.yml
@@ -30,7 +30,7 @@
     dest: /etc/zabbix/zabbix_java_gateway.conf
     owner: zabbix
     group: zabbix
-    mode: 0644
+    mode: "{{ zabbix_java_gateway_conf_mode }}"
   notify:
     - zabbix-java-gateway restarted
 

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -16,6 +16,7 @@ zabbix_proxy_package_state: present
 zabbix_proxy_install_database_client: True
 zabbix_install_pip_packages: true
 zabbix_repo_yum_schema: https
+zabbix_proxy_conf_mode: "0644"
 
 zabbix_repo_yum:
   - name: zabbix

--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -84,7 +84,7 @@
     dest: /etc/zabbix/zabbix_proxy.conf
     owner: zabbix
     group: zabbix
-    mode: 0644
+    mode: "{{ zabbix_proxy_conf_mode }}"
   notify: restart zabbix-proxy
 
 - name: "Installing the Zabbix-api package on localhost"

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -9,6 +9,7 @@ zabbix_repo: zabbix
 zabbix_server_package_state: present
 zabbix_server_install_recommends: True
 zabbix_server_install_database_client: True
+zabbix_server_conf_mode: 0640
 
 zabbix_service_state: started
 zabbix_service_enabled: True

--- a/roles/zabbix_server/tasks/main.yml
+++ b/roles/zabbix_server/tasks/main.yml
@@ -36,7 +36,7 @@
     dest: /etc/zabbix/zabbix_server.conf
     owner: zabbix
     group: zabbix
-    mode: 0640
+    mode: "{{ zabbix_server_conf_mode }}"
   notify:
     - zabbix-server restarted
   tags:

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -8,6 +8,7 @@ zabbix_web_package_state: present
 zabbix_web_centos_release: true
 zabbix_selinux: False
 zabbix_web_doubleprecision: False
+zabbix_web_conf_mode: "0640"
 
 zabbix_url: zabbix.example.com
 zabbix_websrv: apache

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -45,7 +45,7 @@
     dest: /etc/zabbix/web/zabbix.conf.php
     owner: "{{ apache_user }}"
     group: "{{ apache_group }}"
-    mode: 0640
+    mode: "{{ zabbix_web_conf_mode }}"
   notify:
     - restart apache
   tags:


### PR DESCRIPTION
Added the possibility to override the default value for the mode of the configuration file.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

role:
- agent
- server
- proxy
- web
- javagateway

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
