### PR TITLE
Remove geerlingguy.apache dependency from zabbix_web

### DIFF
--- a/roles/zabbix_web/meta/main.yml
+++ b/roles/zabbix_web/meta/main.yml
@@ -25,8 +25,4 @@ galaxy_info:
     - monitoring
     - zabbix
 
-dependencies:
-  - name: geerlingguy.apache
-    src: geerlingguy.apache
-    tags: apache
-    when: zabbix_websrv == 'apache'
+dependencies: []


### PR DESCRIPTION
##### SUMMARY
Removes the dependency on `geerlingguy.apache` that zabbix_web has defined.

Setting `zabbix_websrv: nginx` doesn't work unless you also require `geerlingguy.apache` on your own.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_web

