### PR TITLE
apt packages cache_valid_time 1h

### DIFF
--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -168,7 +168,7 @@
     pkg: "zabbix-agent"
     state: "{{ zabbix_agent_package_state }}"
     update_cache: yes
-    cache_valid_time: 0
+    cache_valid_time: 3600
     force_apt_get: "{{ zabbix_apt_force_apt_get }}"
     install_recommends: "{{ zabbix_apt_install_recommends }}"
   environment:
@@ -187,7 +187,7 @@
     pkg: policycoreutils-python-utils
     state: present
     update_cache: yes
-    cache_valid_time: 0
+    cache_valid_time: 3600
     force_apt_get: "{{ zabbix_apt_force_apt_get }}"
     install_recommends: "{{ zabbix_apt_install_recommends }}"
   environment:

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -148,7 +148,7 @@
     pkg: "{{ zabbix_agent_packages }}"
     state: "{{ zabbix_agent_package_state }}"
     update_cache: yes
-    cache_valid_time: 0
+    cache_valid_time: 3600
     force_apt_get: "{{ zabbix_apt_force_apt_get }}"
     install_recommends: "{{ zabbix_apt_install_recommends }}"
   environment:


### PR DESCRIPTION
##### SUMMARY
This pr sets apt cache to 3600 seconds as it is very annoying to wait every time playbook is being run.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
role/zabbix_agent

##### ADDITIONAL INFORMATION
None
