### PR TITLE
Fix to decode Unicode Escape of multibyte strings

### DIFF
--- a/changelogs/fragments/226-zabbix_template.yaml
+++ b/changelogs/fragments/226-zabbix_template.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_template - Fixed to decode Unicode Escape of multibyte strings in an importing template data(https://github.com/ansible-collections/community.zabbix/pull/226).

--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -308,6 +308,7 @@ template_xml:
 
 import json
 import traceback
+import codecs
 import xml.etree.ElementTree as ET
 
 from distutils.version import LooseVersion
@@ -616,11 +617,7 @@ class Template(ZabbixBase):
             if LooseVersion(self._zbx_api_version) >= LooseVersion('4.4.4'):
                 update_rules['templateLinkage']['deleteMissing'] = True
 
-            # templateScreens is named templateDashboards in zabbix >= 5.2
-            # https://support.zabbix.com/browse/ZBX-18677
-            if LooseVersion(self._zbx_api_version) >= LooseVersion('5.2'):
-                update_rules["templateDashboards"] = update_rules.pop("templateScreens")
-
+            template_content = codecs.decode(template_content, 'unicode-escape')
             import_data = {'format': template_type, 'source': template_content, 'rules': update_rules}
             self._zapi.configuration.import_(import_data)
         except Exception as e:

--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -617,6 +617,11 @@ class Template(ZabbixBase):
             if LooseVersion(self._zbx_api_version) >= LooseVersion('4.4.4'):
                 update_rules['templateLinkage']['deleteMissing'] = True
 
+            # templateScreens is named templateDashboards in zabbix >= 5.2
+            # https://support.zabbix.com/browse/ZBX-18677
+            if LooseVersion(self._zbx_api_version) >= LooseVersion('5.2'):
+                update_rules["templateDashboards"] = update_rules.pop("templateScreens")
+
             template_content = codecs.decode(template_content, 'unicode-escape')
             import_data = {'format': template_type, 'source': template_content, 'rules': update_rules}
             self._zapi.configuration.import_(import_data)


### PR DESCRIPTION
##### SUMMARY

This PR is to fix to decode Unicode Escape of multibyte strings in an importing template content.  
If using Python2, this module hasn't decoded Unicode Escape until now.  
Exporting template data with this module (or zabbix_template_info) and a copy module creates a file with multibyte strings encoded as a byte string (Unicode Escape).  
So, a garbled text occurs(byte strings) on Zabbix after to import using that.  
This issue only occurs in Python2.

fixes: https://github.com/ansible-collections/community.zabbix/issues/225

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/zabbix_template.py

##### ADDITIONAL INFORMATION