### PR TITLE
Update bind port for Zabbix 3.0 container

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -58,7 +58,6 @@ jobs:
         working-directory: ./ansible_collections/community/zabbix
         env:
           zabbix_version: ${{ matrix.zabbix_container.version }}
-          zabbix_port: ${{ matrix.zabbix_container.port }}
 
       # Run the integration tests
       # As we need to connect to an existing docker container we can't use `--docker` here as the VMs would be on different

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -20,13 +20,9 @@ jobs:
       matrix:
         zabbix_container:
           - version: "3.0"
-            port: "8080"
           - version: "4.0"
-            port: "8080"
           - version: "4.4"
-            port: "8080"
           - version: "5.0"
-            port: "8080"
         ansible:
           # - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         zabbix_container:
           - version: "3.0"
-            port: "80"
+            port: "8080"
           - version: "4.0"
             port: "8080"
           - version: "4.4"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,4 +34,4 @@ services:
       - "zabbix-db"
       - "zabbix-server"
     ports:
-      - "8080:${zabbix_port}"
+      - "8080:8080"


### PR DESCRIPTION
##### SUMMARY

Zabbix 3.0 container listening port was changed from 80 to 8080 by Zabbix maintainer.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

.github/workflows/plugins-integration.yml

##### ADDITIONAL INFORMATION

