### PR TITLE
Add missing become: yes for AutoPSK

### DIFF
--- a/roles/zabbix_agent/tasks/tlspsk_auto.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto.yml
@@ -15,11 +15,13 @@
   stat:
     path: "{{ zabbix_agent_tlspskfile }}"
   register: zabbix_agent_tlspskcheck
+  become: yes
 
 - name: AutoPSK | read existing TLS PSK file
   slurp:
     src: "{{ zabbix_agent_tlspskfile }}"
   register: zabbix_agent_tlspsk_base64
+  become: yes
   when: zabbix_agent_tlspskcheck.stat.exists
 
 - name: AutoPSK | Save existing TLS PSK secret
@@ -41,11 +43,13 @@
   stat:
     path: "{{ zabbix_agent_tlspskidentity_file }}"
   register: zabbix_agent_tlspskidentity_check
+  become: yes
 
 - name: AutoPSK | Read existing TLS PSK identity file
   slurp:
     src: "{{ zabbix_agent_tlspskidentity_file }}"
   register: zabbix_agent_tlspskidentity_base64
+  become: yes
   when: zabbix_agent_tlspskidentity_check.stat.exists
 
 - name: AutoPSK | Use existing TLS PSK identity
@@ -65,6 +69,7 @@
     owner: zabbix
     group: zabbix
     mode: 0400
+  become: yes
   when:
     - zabbix_agent_tlspskidentity_file is defined
     - zabbix_agent_tlspskidentity is defined


### PR DESCRIPTION
##### SUMMARY
Discovered an issue when trying to remove a host from Zabbix. We would get errors trying to read the PSK files. Subsequently, after removing a host and trying to install it again we'd see the same error where `/etc/zabbix` is unreadable by the ansible user.



##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
role: zabbix_agent

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
