### PR TITLE
Update apache_vhost.conf.j2

### DIFF
--- a/roles/zabbix_web/templates/apache_vhost.conf.j2
+++ b/roles/zabbix_web/templates/apache_vhost.conf.j2
@@ -59,7 +59,7 @@
   RewriteEngine On
   RewriteRule ^$ /index.php [L]
 
-{% if zabbix_version is version('4.4', '<=') %}
+{% if zabbix_version is version('5.0', '<=') %}
 {% if zabbix_apache_include_custom_fragment | default(true) %}
   ## Custom fragment
   {% if zabbix_php_fpm %}
@@ -156,7 +156,7 @@ SSLCryptoDevice {{ zabbix_apache_SSLCryptoDevice }}
   RewriteEngine On
   RewriteRule ^$ /index.php [L]
 
-{% if zabbix_version is version('4.4', '<=') %}
+{% if zabbix_version is version('5.0', '<=') %}
 {% if zabbix_apache_include_custom_fragment | default(true) %}
   ## Custom fragment
   {% if zabbix_php_fpm %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Zabbix 5.0 works well under Ubuntu 18.04 except this issue with PHP parameters, they should be processed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apache_vhost.conf.j2
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
