### PR TITLE
fix package name defaults in zabbix_agent role

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -22,8 +22,8 @@ selinux_allow_zabbix_run_sudo: False
 
 zabbix_agent_packages:
   - "{{ zabbix_agent_package }}"
-  - zabbix-sender
-  - zabbix-get
+  - "{{ zabbix_sender_package }}"
+  - "{{ zabbix_get_package }}"
 
 # Zabbix role related vars
 zabbix_install_pip_packages: true


### PR DESCRIPTION
##### SUMMARY
Add zabbix_get_package and zabbix_sender_package variables
to the list of packages being installed.

Those variables have been defined in role defaults but never used in the list of packages
actually being installed. This means overriding them (e.g. as a workaround to #212)
had no effect.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent

##### ADDITIONAL INFORMATION

Example: one of possible use cases -  to force uprade from zabbix client packages 4.2

```
ansible-playbook -i inventory \
  -e zabbix_agent_package="zabbix-agent=1:4.4.10-1+bionic" \
  -e zabbix_sender_package="zabbix-sender=1:4.4.10-1+bionic" \
  -e zabbix_get_package="zabbix-get=1:4.4.10-1+bionic" \
  someplaybook.yml
```
causes upgrade of zabbix-agent package but **not** `zabbix-sender` nor `zabbix-get`


Tested against a Ubuntu Bionic (18.04) host and:

```
$ ansible --version
ansible 2.10.2
  config file = /Users/waldekm/git/auto/ansible.cfg
  configured module search path = ['/Users/waldekm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/waldekm/git/auto/.venv/lib/python3.8/site-packages/ansible
  executable location = /Users/waldekm/git/auto/.venv/bin/ansible
  python version = 3.8.6 (default, Oct 27 2020, 08:57:44) [Clang 12.0.0 (clang-1200.0.32.21)]
```
