### PR TITLE
Disable no_log warning for override_password in module zabbix_user

### DIFF
--- a/changelogs/fragments/254-disable-no-log-warning.yml
+++ b/changelogs/fragments/254-disable-no-log-warning.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - zabbix_user - disable no_log warning for option override_password.

--- a/plugins/modules/zabbix_user.py
+++ b/plugins/modules/zabbix_user.py
@@ -515,7 +515,7 @@ def main():
         surname=dict(type='str', default=''),
         usrgrps=dict(type='list'),
         passwd=dict(type='str', required=False, no_log=True),
-        override_passwd=dict(type='bool', required=False, default=False),
+        override_passwd=dict(type='bool', required=False, default=False, no_log=False),
         lang=dict(type='str', default='en_GB', choices=['en_GB', 'en_US', 'zh_CN', 'cs_CZ', 'fr_FR',
                                                         'he_IL', 'it_IT', 'ko_KR', 'ja_JP', 'nb_NO',
                                                         'pl_PL', 'pt_BR', 'pt_PT', 'ru_RU', 'sk_SK',


### PR DESCRIPTION
##### SUMMARY
The user module generates the warning: `Module did not set no_log for override_password` because part of the options name is `password`. Ansible has a built in checker for fields like this to prevent you from leaking passwords into log files or things like that.
But here the field is just a boolean and therefore no danger of leaking any sensitive information. So the checking mechanism can be turned off to get rid of this warning.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_user.py

##### ADDITIONAL INFORMATION

