### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,9 @@
+FROM gitpod/workspace-full
+
+# Install custom tools, runtimes, etc.
+# For example "bastet", a command-line tetris clone:
+# RUN brew install bastet
+#
+# More information: https://www.gitpod.io/docs/config-docker/
+RUN pip install wheel && \
+  pip install ansible-base zabbix-api

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: 'echo "TODO: Replace with init/build command"'
+    command: 'echo "TODO: Replace with command to start project"'


### PR DESCRIPTION
Basic gitpod integration. Would enable to directly start an vscode like environment in gitpod for quick edits/PRs.
"Sadly" currently just for editing and maybe building/linting the code. Docker-Compose or starting other containers isn't supported currently so we can't start a zabbix-environment to test against.

- https://gitpod.io/
- https://www.gitpod.io/docs/config-gitpod-file/