### PR TITLE
zabbix_user: Fix unable create a user since Zabbix 5.2

### DIFF
--- a/changelogs/fragments/260-zabbix_user.yml
+++ b/changelogs/fragments/260-zabbix_user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_user - fixed it couldn't create a user since Zabbix 5.2 (https://github.com/ansible-collections/community.zabbix/pull/260).

--- a/changelogs/fragments/260-zabbix_user.yml
+++ b/changelogs/fragments/260-zabbix_user.yml
@@ -1,2 +1,4 @@
 bugfixes:
   - zabbix_user - fixed it couldn't create a user since Zabbix 5.2 (https://github.com/ansible-collections/community.zabbix/pull/260).
+minor_changes:
+  - zabbix_user - added a new parameter to set timezone for users (https://github.com/ansible-collections/community.zabbix/pull/260).

--- a/changelogs/fragments/260-zabbix_user.yml
+++ b/changelogs/fragments/260-zabbix_user.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - zabbix_user - fixed it couldn't create a user since Zabbix 5.2 (https://github.com/ansible-collections/community.zabbix/pull/260).
 minor_changes:
-  - zabbix_user - added a new parameter to set timezone for users (https://github.com/ansible-collections/community.zabbix/pull/260).
+  - zabbix_user - added new parameters to set timezone and role_name for users (https://github.com/ansible-collections/community.zabbix/pull/260).

--- a/changelogs/fragments/260-zabbix_user.yml
+++ b/changelogs/fragments/260-zabbix_user.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - zabbix_user - fixed it couldn't create a user since Zabbix 5.2 (https://github.com/ansible-collections/community.zabbix/pull/260).
+  - zabbix_user - fixed issue where module couldn't create a user since Zabbix 5.2 (https://github.com/ansible-collections/community.zabbix/pull/260).
 minor_changes:
   - zabbix_user - added new parameters to set timezone and role_name for users (https://github.com/ansible-collections/community.zabbix/pull/260).

--- a/plugins/modules/zabbix_user.py
+++ b/plugins/modules/zabbix_user.py
@@ -58,7 +58,7 @@ options:
     lang:
         description:
             - Language code of the user's language.
-            - C(default) can use if Zabbix 5.2 or more.
+            - C(default) can be used with Zabbix version 5.2 or higher.
         default: 'en_GB'
         choices:
             - 'en_GB'
@@ -190,7 +190,7 @@ options:
     type:
         description:
             - Type of the user.
-            - I(type) is necessary if Zabbix 5.0 and less.
+            - I(type) is necessary if Zabbix version is 5.0 or lower.
         default: 'Zabbix user'
         choices:
             - 'Zabbix user'
@@ -200,7 +200,7 @@ options:
     timezone:
         description:
             - User's time zone.
-            - I(timezone) can use if since Zabbix 5.2.
+            - I(timezone) can be used with Zabbix version 5.2 or higher.
             - For the full list of supported time zones please refer to U(https://www.php.net/manual/en/timezones.php)
         default: default
         type: str
@@ -208,7 +208,7 @@ options:
     role_name:
         description:
             - User's role.
-            - I(role_name) is necessary if Zabbix 5.2 or more.
+            - I(role_name) is required when Zabbix version is 5.2 or higher.
         default: 'User role'
         type: str
         version_added: 1.2.0

--- a/plugins/modules/zabbix_user.py
+++ b/plugins/modules/zabbix_user.py
@@ -209,6 +209,7 @@ options:
         description:
             - User's role.
             - I(role_name) is necessary if Zabbix 5.2 or more.
+        default: 'User role'
         type: str
         version_added: 1.2.0
     state:
@@ -590,7 +591,7 @@ def main():
                                                         disaster=True)),
                                       active=dict(type='bool', default=True))),
         timezone=dict(type='str', default='default'),
-        role_name=dict(type='str'),
+        role_name=dict(type='str', default='User role'),
         type=dict(type='str', default='Zabbix user', choices=['Zabbix user', 'Zabbix admin', 'Zabbix super admin']),
         state=dict(type='str', default="present", choices=['present', 'absent'])
     ))


### PR DESCRIPTION
##### SUMMARY

This PR is to fix that the zabbix_user module can't create a user since Zabbix 5.2.  
fixes: https://github.com/ansible-collections/community.zabbix/issues/256

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/zabbix_user.py

##### ADDITIONAL INFORMATION

tested on Zabbix 5.2