### PR TITLE
GitHub Actions fails because set-env is disabled

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build the collection
         run: |
           collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
-          echo "::set-env name=COLLECTION_FILE::$collection_file"
+          echo "COLLECTION_FILE=$collection_file" >> $GITHUB_ENV
 
       - name: Install the collection
         run: ansible-galaxy collection install $COLLECTION_FILE

--- a/.github/workflows/javagateway.yml
+++ b/.github/workflows/javagateway.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build the collection
         run: |
           collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
-          echo "::set-env name=COLLECTION_FILE::$collection_file"
+          echo "COLLECTION_FILE=$collection_file" >> $GITHUB_ENV
 
       - name: Install the collection
         run: ansible-galaxy collection install $COLLECTION_FILE

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build the collection
         run: |
           collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
-          echo "::set-env name=COLLECTION_FILE::$collection_file"
+          echo "COLLECTION_FILE=$collection_file" >> $GITHUB_ENV
 
       - name: Install the collection
         run: ansible-galaxy collection install $COLLECTION_FILE

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build the collection
         run: |
           collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
-          echo "::set-env name=COLLECTION_FILE::$collection_file"
+          echo "COLLECTION_FILE=$collection_file" >> $GITHUB_ENV
 
       - name: Install the collection
         run: ansible-galaxy collection install $COLLECTION_FILE

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build the collection
         run: |
           collection_file=$( basename $(ansible-galaxy collection build -f | awk -F" " '{print $NF}'))
-          echo "::set-env name=COLLECTION_FILE::$collection_file"
+          echo "COLLECTION_FILE=$collection_file" >> $GITHUB_ENV
 
       - name: Install the collection
         run: ansible-galaxy collection install $COLLECTION_FILE


### PR DESCRIPTION
##### SUMMARY
`set-env` command is disabled on November 16th.
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/  
https://github.com/ansible-collections/community.zabbix/actions/runs/363231263  

I've upgraded to a new writing style. 
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/workflows/agent.yml
.github/workflows/javagateway.yml
.github/workflows/proxy.yml
.github/workflows/server.yml
.github/workflows/web.yml

##### ADDITIONAL INFORMATION

