### PR TITLE
Fix template importing in zabbix >= 5.2

### DIFF
--- a/changelogs/fragments/templatescreens-fix.yml
+++ b/changelogs/fragments/templatescreens-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - "zabbix_template - fixed issue when importing templates to zabbix version. >= 5.2"

--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -610,6 +610,11 @@ class Template(ZabbixBase):
             if LooseVersion(self._zbx_api_version) >= LooseVersion('4.4.4'):
                 update_rules['templateLinkage']['deleteMissing'] = True
 
+            #templateScreens is named templateDashboards in zabbix >= 5.2  
+            #https://support.zabbix.com/browse/ZBX-18677
+            if LooseVersion(self._zbx_api_version) >= LooseVersion('5.2'):
+               update_rules["templateDashboards"] = update_rules.pop("templateScreens")
+
             import_data = {'format': template_type, 'source': template_content, 'rules': update_rules}
             self._zapi.configuration.import_(import_data)
         except Exception as e:


### PR DESCRIPTION
##### SUMMARY
In zabbix 5.2 "templateScreens" has been replaced by "templateDashboards" when importing config (config.import): https://support.zabbix.com/browse/ZBX-18677

This fix will check whether the Zabbix API version is >= 5.2, if true, the templateScreens object will be renamed to "templateDashboards" in the json params object when calling the Zabbix API.

##### ISSUE TYPE
- Bugfix Pull Request
