### PR TITLE
update userparameter.yml for agent2 using

### DIFF
--- a/roles/zabbix_agent/tasks/userparameter.yml
+++ b/roles/zabbix_agent/tasks/userparameter.yml
@@ -48,4 +48,38 @@
     with_items: "{{ zabbix_agent_userparameters }}"
     when: item.scripts_dir is defined
 
-  when: zabbix_agent_os_family != "Windows"
+  when:
+    - zabbix_agent_os_family != "Windows"
+    - not zabbix_agent2
+
+- block:
+  - name: "Installing user-defined userparameters"
+    template:
+      src: "{{ zabbix_agent_userparameters_templates_src }}/{{ item.name }}.j2"
+      dest: "{{ zabbix_agent2_include }}/userparameter_{{ item.name }}.conf"
+      owner: zabbix
+      group: zabbix
+      mode: 0644
+    notify:
+      - restart zabbix-agent
+      - restart mac zabbix agent
+    become: yes
+    with_items: "{{ zabbix_agent_userparameters }}"
+  
+  - name: "Installing user-defined scripts"
+    copy:
+      src: "{{ zabbix_agent_userparameters_scripts_src }}/{{ item.scripts_dir }}"
+      dest: "/etc/zabbix/scripts/"
+      owner: zabbix
+      group: zabbix
+      mode: 0755
+    notify:
+      - restart zabbix-agent
+      - restart mac zabbix agent
+    become: yes
+    with_items: "{{ zabbix_agent_userparameters }}"
+    when: item.scripts_dir is defined
+
+  when:
+    - zabbix_agent_os_family != "Windows"
+    - zabbix_agent2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Recently, when I install zabbix-agent2 by using this role, I found I couldn't install userparameter.yml by adding variables.
There are some missing tasks in the playbook.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
