### PR TITLE
Using the version in the package name to install

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -26,6 +26,9 @@ jobs:
           - container: centos
             image: geerlingguy/docker-centos7-ansible:latest
             group: agent
+          - container: fedora32
+            image: geerlingguy/docker-fedora32-ansible:latest
+            group: agent
           - container: ubuntu
             image: geerlingguy/docker-ubuntu2004-ansible
             group: agent

--- a/changelogs/fragments/agent-use-version-for-rh.yml
+++ b/changelogs/fragments/agent-use-version-for-rh.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - "Zabbix packages were not able to install properly on Fedora. When the packages are installed, the version will be appended to the package name. This is eofr all RedHat related OS'es."

--- a/roles/zabbix_agent/tasks/RedHat.yml
+++ b/roles/zabbix_agent/tasks/RedHat.yml
@@ -33,11 +33,19 @@
     - ansible_distribution == "Amazon"
     - ansible_distribution_major_version == "2"
 
-- name: "Fedora | Override zabbix_agent_distribution_major_version for Fedora"
+- name: "Fedora | Override zabbix_agent_distribution_major_version for Fedora <= 27"
   set_fact:
     zabbix_agent_distribution_major_version: 7
   when:
     - ansible_distribution == "Fedora"
+    - ansible_distribution_major_version <= "27"
+
+- name: "Fedora | Override zabbix_agent_distribution_major_version for Fedora >= 27"
+  set_fact:
+    zabbix_agent_distribution_major_version: 8
+  when:
+    - ansible_distribution == "Fedora"
+    - ansible_distribution_major_version >= "27"
 
 - name: "XCP-ng | Override zabbix_agent_distribution_major_version for XCP-ng"
   set_fact:
@@ -78,7 +86,7 @@
 - name: "RedHat | Installing zabbix-agent"
   package:
     pkg:
-      - "{{ zabbix_agent_package }}"
+      - "{{ zabbix_agent_package }}-{{ zabbix_agent_version }}.*"
     disablerepo: "{{ '*' if (zabbix_repo_yum_enabled | length>0) else omit }}"
     enablerepo: "{{ zabbix_repo_yum_enabled if zabbix_repo_yum_enabled is iterable and (zabbix_repo_yum_enabled | length>0) else omit }}"
     state: "{{ zabbix_agent_package_state }}"
@@ -95,8 +103,8 @@
 - name: "RedHat | Installing zabbix-{sender,get}}"
   package:
     pkg:
-      - "{{ zabbix_sender_package }}"
-      - "{{ zabbix_get_package }}"
+      - "{{ zabbix_sender_package }}-{{ zabbix_agent_version }}.*"
+      - "{{ zabbix_get_package }}-{{ zabbix_agent_version }}.*"
     disablerepo: "{{ '*' if (zabbix_repo_yum_enabled | length>0) else omit }}"
     enablerepo: "{{ zabbix_repo_yum_enabled if zabbix_repo_yum_enabled is iterable and (zabbix_repo_yum_enabled | length>0) else omit }}"
     state: "{{ zabbix_agent_package_state }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Using the version in the package name to install. Instead of installing `zabbix-agent`, this will install for RedHat related OS'es `zabbix-agent-5.0.*`, where `5.0` is the same as `zabbix_agent_version`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

Fixes #223 