### PR TITLE
disable zabbix_proxy module tests to allow roles development + sanity/integration fixes

### DIFF
--- a/plugins/modules/zabbix_service.py
+++ b/plugins/modules/zabbix_service.py
@@ -39,6 +39,7 @@ options:
         description:
             - If yes, calculate the SLA value for this service, showsla in Zabbix API
         required: false
+        default: false
         type: bool
     algorithm:
         description:

--- a/tests/integration/targets/test_zabbix_proxy/aliases
+++ b/tests/integration/targets/test_zabbix_proxy/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/test_zabbix_user_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_user_info/tasks/main.yml
@@ -108,7 +108,7 @@
               high: yes
               disaster: yes
             active: no
-        role_name: Super Admin role
+        role_name: Super admin role
         timezone: Asia/Tokyo
         state: present
       register: create_zabbix_user_result


### PR DESCRIPTION
##### SUMMARY
Disabling zabbix_proxy integration tests for now to allow for roles development without interruptions.

Now also includes sanity and integration fixes to zabbix_service and zabbix_user_info. I haven't created separate PRs for those as they are really small

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test_zabbix_proxy
zabbix_service
zabbix_user_info
