### PR TITLE
TLS fixes for Agent2

### DIFF
--- a/changelogs/fragments/agent2-psk-fixes.yml
+++ b/changelogs/fragments/agent2-psk-fixes.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - zabbix_agent - fixed issue with zabbix_agent2_tlspsk_auto having no effect when using zabbix_agent2
+  - zabbix_agent - fixed issue with zabbix_api_create_hosts and TLS configuration when using zabbix_agent2, where zabbix_agent_tls* settings were used instead of zabbix_agent2_tls*

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -160,6 +160,48 @@
     ipmi_username: "{{ zabbix_agent_ipmi_username | default(omit) }}"
   when:
     - zabbix_api_create_hosts | bool
+    - not zabbix_agent2
+  register: zabbix_api_host_created
+  until: zabbix_api_host_created is succeeded
+  delegate_to: localhost
+  become: no
+  changed_when: false
+  tags:
+    - api
+
+- name: "Create a new host using agent2 or update an existing host's info"
+  zabbix_host:
+    server_url: "{{ zabbix_url }}"
+    http_login_user: "{{ zabbix_api_http_user | default(omit) }}"
+    http_login_password: "{{ zabbix_api_http_password | default(omit) }}"
+    login_user: "{{ zabbix_api_user }}"
+    login_password: "{{ zabbix_api_pass }}"
+    host_name: "{{ zabbix_agent_hostname }}"
+    host_groups: "{{ zabbix_host_groups }}"
+    link_templates: "{{ zabbix_link_templates }}"
+    status: "{{ zabbix_host_status }}"
+    state: "{{ zabbix_create_host }}"
+    force: "{{ zabbix_update_host }}"
+    proxy: "{{ zabbix_proxy }}"
+    inventory_mode: "{{ zabbix_inventory_mode }}"
+    interfaces: "{{ zabbix_agent_interfaces }}"
+    visible_name: "{{ zabbix_visible_hostname | default(zabbix_agent_hostname) }}"
+    tls_psk: "{{ zabbix_agent2_tlspsk_secret | default(omit) }}"
+    tls_psk_identity: "{{ zabbix_agent2_tlspskidentity | default(omit) }}"
+    tls_issuer: "{{ zabbix_agent2_tlsservercertissuer | default(omit) }}"
+    tls_subject: "{{ zabbix_agent2_tlsservercertsubject | default(omit) }}"
+    tls_accept: "{{ zabbix_agent_tls_config[zabbix_agent2_tlsaccept if zabbix_agent2_tlsaccept else 'unencrypted'] }}"
+    tls_connect: "{{ zabbix_agent_tls_config[zabbix_agent2_tlsconnect if zabbix_agent2_tlsconnect else 'unencrypted'] }}"
+    validate_certs: "{{ zabbix_validate_certs | default(omit) }}"
+    description: "{{ zabbix_agent_description | default(omit) }}"
+    inventory_zabbix: "{{ zabbix_agent_inventory_zabbix | default({}) }}"
+    ipmi_authtype: "{{ zabbix_agent_ipmi_authtype | default(omit) }}"
+    ipmi_password: "{{ zabbix_agent_ipmi_password| default(omit) }}"
+    ipmi_privilege: "{{ zabbix_agent_ipmi_privilege | default(omit) }}"
+    ipmi_username: "{{ zabbix_agent_ipmi_username | default(omit) }}"
+  when:
+    - zabbix_api_create_hosts | bool
+    - zabbix_agent2 | bool
   register: zabbix_api_host_created
   until: zabbix_api_host_created is succeeded
   delegate_to: localhost

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -62,9 +62,18 @@
 - name: "Encrypt with TLS PSK auto management"
   include_tasks: tlspsk_auto.yml
   when:
+    - not zabbix_agent2
     - zabbix_agent_tlspsk_auto | bool
     - (zabbix_agent_tlspskfile is undefined) or (zabbix_agent_tlspskfile | length == '0')
     - (zabbix_agent_tlspsk_secret is undefined) or (zabbix_agent_tlspsk_secret | length == '0')
+
+- name: "Encrypt with TLS PSK auto management"
+  include_tasks: tlspsk_auto_agent2.yml
+  when:
+    - zabbix_agent2 | bool
+    - zabbix_agent2_tlspsk_auto | bool
+    - (zabbix_agent2_tlspskfile is undefined) or (zabbix_agent2_tlspskfile | length == '0')
+    - (zabbix_agent2_tlspsk_secret is undefined) or (zabbix_agent2_tlspsk_secret | length == '0')
 
 - name: "Install the correct repository"
   include_tasks: Windows.yml

--- a/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
@@ -1,0 +1,85 @@
+---
+- name: AutoPSK | Set default path variables for Linux
+  set_fact:
+    zabbix_agent2_tlspskfile: "/etc/zabbix/tls_psk_auto.secret"
+    zabbix_agent2_tlspskidentity_file: "/etc/zabbix/tls_psk_auto.identity"
+  when: (zabbix_agent_os_family != "Windows") or (zabbix_agent_docker | bool)
+
+- name: AutoPSK | Set default path variables for Windows
+  set_fact:
+    zabbix_agent2_tlspskfile: "{{ zabbix_win_install_dir }}\tls_psk_auto.secret.txt"
+    zabbix_agent2_tlspskidentity_file: "{{ zabbix_win_install_dir }}\tls_psk_auto.identity.txt"
+  when: zabbix_agent_os_family == "Windows"
+
+- name: AutoPSK | Check for existing TLS PSK file
+  stat:
+    path: "{{ zabbix_agent2_tlspskfile }}"
+  register: zabbix_agent2_tlspskcheck
+  become: yes
+
+- name: AutoPSK | read existing TLS PSK file
+  slurp:
+    src: "{{ zabbix_agent2_tlspskfile }}"
+  register: zabbix_agent2_tlspsk_base64
+  become: yes
+  when: zabbix_agent2_tlspskcheck.stat.exists
+
+- name: AutoPSK | Save existing TLS PSK secret
+  set_fact:
+    zabbix_agent2_tlspsk_read: "{{ zabbix_agent2_tlspsk_base64['content'] | b64decode | trim }}"
+  when: zabbix_agent2_tlspskcheck.stat.exists
+
+- name: AutoPSK | Use existing TLS PSK secret
+  set_fact:
+    zabbix_agent2_tlspsk_secret: "{{ zabbix_agent2_tlspsk_read }}"
+  when: zabbix_agent2_tlspskcheck.stat.exists and zabbix_agent2_tlspsk_read|length >= 32
+
+- name: AutoPSK | Generate new TLS PSK secret
+  set_fact:
+    zabbix_agent2_tlspsk_secret: "{{ lookup('password', '/dev/null chars=hexdigits length=64') }}"
+  when: not zabbix_agent2_tlspskcheck.stat.exists or zabbix_agent2_tlspsk_read|length < 32
+
+- name: AutoPSK | Check for existing TLS PSK identity
+  stat:
+    path: "{{ zabbix_agent2_tlspskidentity_file }}"
+  register: zabbix_agent2_tlspskidentity_check
+  become: yes
+
+- name: AutoPSK | Read existing TLS PSK identity file
+  slurp:
+    src: "{{ zabbix_agent2_tlspskidentity_file }}"
+  register: zabbix_agent2_tlspskidentity_base64
+  become: yes
+  when: zabbix_agent2_tlspskidentity_check.stat.exists
+
+- name: AutoPSK | Use existing TLS PSK identity
+  set_fact:
+    zabbix_agent2_tlspskidentity: "{{ zabbix_agent2_tlspskidentity_base64['content'] | b64decode | trim }}"
+  when: zabbix_agent2_tlspskidentity_check.stat.exists
+
+- name: AutoPSK | Generate new TLS PSK identity
+  set_fact:
+    zabbix_agent2_tlspskidentity: "{{ zabbix_visible_hostname | default(zabbix_agent_hostname) + '_' + lookup('password', '/dev/null chars=hexdigits length=4') }}"
+  when: not zabbix_agent2_tlspskidentity_check.stat.exists
+
+- name: AutoPSK | Template TLS PSK identity in file
+  copy:
+    dest: "{{ zabbix_agent2_tlspskidentity_file }}"
+    content: "{{ zabbix_agent2_tlspskidentity }}"
+    owner: zabbix
+    group: zabbix
+    mode: 0400
+  become: yes
+  when:
+    - zabbix_agent2_tlspskidentity_file is defined
+    - zabbix_agent2_tlspskidentity is defined
+  notify:
+    - restart zabbix-agent
+    - restart win zabbix agent
+    - restart mac zabbix agent
+
+- name: AutoPSK | Default tlsaccept and tlsconnect to enforce PSK
+  set_fact:
+    zabbix_agent2_tlsaccept: psk
+    zabbix_agent2_tlsconnect: psk
+  when: zabbix_api_create_hosts


### PR DESCRIPTION
##### SUMMARY
When configuring zabbix_agent with zabbix_agent2 the settings for TLS were ignored in favour of the original agent settings not the agent2 settings documented.

zabbix_agent2_tlspsk_auto had no effect and did not generate a PSK

zabbix_api_create_hosts ignored the TLS settings for agent2 and used the original agent settings resulting in zabbix_agent being unable to communicate with zabbix_server

##### ISSUE TYPE
- Bug Fix

##### COMPONENT NAME
Role: zabbix_agent