### PR TITLE
Fixing Windows agent service handling and update process

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -197,9 +197,9 @@ zabbix_agent2_tlspsk_auto: False
 zabbix_version_long: 4.4.4
 
 # Windows Related
-zabbix_win_package: zabbix_agent-{{ zabbix_version_long }}-windows-i386.zip
-zabbix_win_download_url: https://www.zabbix.com/downloads
-zabbix_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long }}/{{ zabbix_win_package }}"
+zabbix_win_package: zabbix_agent-{{ zabbix_version_long }}-windows-amd64-openssl.zip
+zabbix_win_download_url: https://cdn.zabbix.com/zabbix/binaries/stable
+zabbix_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_agent_version }}/{{ zabbix_version_long }}/{{ zabbix_win_package }}"
 zabbix_win_install_dir: 'C:\Zabbix'
 zabbix_agent_win_logfile: 'C:\Zabbix\zabbix_agentd.log'
 zabbix_agent_win_include: 'C:\Zabbix\zabbix_agent.d\'

--- a/roles/zabbix_agent/handlers/main.yml
+++ b/roles/zabbix_agent/handlers/main.yml
@@ -5,7 +5,7 @@
   service:
     name: "{{ zabbix_agent_service }}"
     state: restarted
-    start_mode: auto
+    enabled: yes
   become: yes
   when:
     - not zabbix_agent_docker

--- a/roles/zabbix_agent/handlers/main.yml
+++ b/roles/zabbix_agent/handlers/main.yml
@@ -5,7 +5,7 @@
   service:
     name: "{{ zabbix_agent_service }}"
     state: restarted
-    enabled: yes
+    start_mode: auto
   become: yes
   when:
     - not zabbix_agent_docker
@@ -18,7 +18,6 @@
   win_service:
     name: "{{ zabbix_win_agent_service }}"
     state: restarted
-    enabled: yes
   when:
     - zabbix_agent_os_family == "Windows"
 

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -54,23 +54,6 @@
     - zabbix_win_exe_info.win_file_version.product_version is version(zabbix_version_long, '<')
     - zabbix_agent_package_state == 'latest'
 
-- name: "Windows | Create directory structure"
-  win_file:
-    path: "{{ item }}"
-    state: directory
-  with_items:
-    - "{{ zabbix_win_install_dir }}"
-    - "{{ zabbix_agent_win_include }}"
-
-- name: "Windows | Place TLS-PSK file"
-  win_copy:
-    content: "{{ zabbix_agent_tlspsk_secret }}"
-    dest: "{{ zabbix_agent_tlspskfile }}"
-  when:
-    - zabbix_agent_tlspskfile is defined
-    - zabbix_agent_tlspsk_secret is defined
-  notify: restart win zabbix agent
-
 - name: "Windows | Stop Zabbix (Update)"
   win_service:
     name: Zabbix Agent
@@ -95,6 +78,23 @@
     - update_zabbix_agent | default(false)
     - agent_file_info.stat.exists
 
+- name: "Windows | Create directory structure"
+  win_file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ zabbix_win_install_dir }}"
+    - "{{ zabbix_agent_win_include }}"
+
+- name: "Windows | Place TLS-PSK file"
+  win_copy:
+    content: "{{ zabbix_agent_tlspsk_secret }}"
+    dest: "{{ zabbix_agent_tlspskfile }}"
+  when:
+    - zabbix_agent_tlspskfile is defined
+    - zabbix_agent_tlspsk_secret is defined
+  notify: restart win zabbix agent
+  
 - name: "Windows | Check if file is already downloaded"
   win_stat:
     path: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'


### PR DESCRIPTION
##### SUMMARY
Fixes #271 - Unsupported "enabled" parameter
Fixing Windows agent update: previous behavior was to create Zabbix agent directory structure before updating and deleting the directory resulting in an error when trying to download the agent.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- Updated roles/zabbix_agent/tasks/Windows.yml
- Updated roles/zabbix_agent/handlers/main.yml
