### PR TITLE
Added parameter to allow uninstall old zabbix-agent when zabbix-agent2 is installed.

### DIFF
--- a/changelogs/fragments/role-agent-allow-uninstall-agent.yaml
+++ b/changelogs/fragments/role-agent-allow-uninstall-agent.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - "Added parameter `zabbix_agent_package_remove` when set to `true` and `zabbix_agent2` is set to `true` it will uninstall the `zabbix-agent` service and package."

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -124,6 +124,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_agent_server`: The ip address for the zabbix-server or zabbix-proxy.
 * `zabbix_agent_serveractive`: The ip address for the zabbix-server or zabbix-proxy for active checks.
 * `zabbix_agent_listeninterface`: Interface zabbix-agent listens on. Leave blank for all.
+* `zabbix_agent_package_remove`: If `zabbix_agent2: True` and you want to remove the old installation. Default: `False`.
 * `zabbix_agent_package`: The name of the zabbix-agent package. Default: `zabbix-agent`. In case for EPEL, it is automatically renamed.
 * `zabbix_sender_package`: The name of the zabbix-sender package. Default: `zabbix-sender`. In case for EPEL, it is automatically renamed.
 * `zabbix_get_package`: The name of the zabbix-get package. Default: `zabbix-get`. In case for EPEL, it is automatically renamed.

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -6,6 +6,7 @@ zabbix_agent_version: 5.0
 zabbix_version: "{{ zabbix_agent_version }}"
 zabbix_version_patch: 0
 zabbix_repo: zabbix
+zabbix_agent_package_remove: False
 zabbix_agent_package: zabbix-agent
 zabbix_sender_package: zabbix-sender
 zabbix_get_package: zabbix-get

--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -263,6 +263,12 @@
     - firewalld-reload
   tags: zabbix_agent_firewalld_enable
 
+- name: "Remove zabbix-agent installation when zabbix-agent2 is used."
+  include: remove.yml
+  when:
+    - zabbix_agent2
+    - zabbix_agent_package_remove
+
 - name: "Make sure the zabbix-agent service is running"
   service:
     name: "{{ zabbix_agent_service }}"

--- a/roles/zabbix_agent/tasks/remove.yml
+++ b/roles/zabbix_agent/tasks/remove.yml
@@ -1,0 +1,20 @@
+---
+
+- name: "Remove | Make sure the \"old\" zabbix-agent service is running"
+  service:
+    name: "{{ zabbix_agent_service }}"
+    state: stopped
+    enabled: no
+  become: yes
+
+- name: "Remove | package removal"
+  package:
+    name: "zabbix-agent"
+    state: absent
+  become: yes
+
+- name: "Remove | Remove the agent-include-dir"
+  file:
+    path: "{{ zabbix_agent_include  }}"
+    state: absent
+  become: yes


### PR DESCRIPTION
Added parameter to allow uninstall old zabbix-agent when zabbix-agent2 installs

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #239

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
