### PR TITLE
zabbix_template: Fix encode error occurs when using Python2

### DIFF
--- a/changelogs/fragments/297-zabbix_template_modules.yml
+++ b/changelogs/fragments/297-zabbix_template_modules.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - zabbix_template - fixed encode error occurs when using Python2 (https://github.com/ansible-collections/community.zabbix/pull/297).
+bugfixes:
+  - zabbix_template_info - fixed encode error occurs when using Python2 (https://github.com/ansible-collections/community.zabbix/pull/297).

--- a/changelogs/fragments/297-zabbix_template_modules.yml
+++ b/changelogs/fragments/297-zabbix_template_modules.yml
@@ -1,4 +1,3 @@
 bugfixes:
   - zabbix_template - fixed encode error occurs when using Python2 (https://github.com/ansible-collections/community.zabbix/pull/297).
-bugfixes:
   - zabbix_template_info - fixed encode error occurs when using Python2 (https://github.com/ansible-collections/community.zabbix/pull/297).

--- a/changelogs/fragments/297-zabbix_template_modules.yml
+++ b/changelogs/fragments/297-zabbix_template_modules.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - zabbix_template - fixed encode error occurs when using Python2 (https://github.com/ansible-collections/community.zabbix/pull/297).
-  - zabbix_template_info - fixed encode error occurs when using Python2 (https://github.com/ansible-collections/community.zabbix/pull/297).
+  - zabbix_template - fixed encode error when using Python2 (https://github.com/ansible-collections/community.zabbix/pull/297).
+  - zabbix_template_info - fixed encode error when using Python2 (https://github.com/ansible-collections/community.zabbix/pull/297).

--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -311,7 +311,7 @@ import xml.etree.ElementTree as ET
 from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six import PY3
+from ansible.module_utils.six import PY2
 
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
 import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
@@ -468,10 +468,10 @@ class Template(ZabbixBase):
                     date = xmlroot.find(".date")
                     if date is not None:
                         xmlroot.remove(date)
-                if PY3:
-                    return str(ET.tostring(xmlroot, encoding='utf-8').decode('utf-8'))
-                else:
+                if PY2:
                     return str(ET.tostring(xmlroot, encoding='utf-8'))
+                else:
+                    return str(ET.tostring(xmlroot, encoding='utf-8').decode('utf-8'))
             else:
                 return self.load_json_template(dump, omit_date=omit_date)
 

--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -311,6 +311,7 @@ import xml.etree.ElementTree as ET
 from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
+from ansible.module_utils.six import PY3
 
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
 import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
@@ -467,7 +468,10 @@ class Template(ZabbixBase):
                     date = xmlroot.find(".date")
                     if date is not None:
                         xmlroot.remove(date)
-                return str(ET.tostring(xmlroot, encoding='utf-8').decode('utf-8'))
+                if PY3:
+                    return str(ET.tostring(xmlroot, encoding='utf-8').decode('utf-8'))
+                else:
+                    return str(ET.tostring(xmlroot, encoding='utf-8'))
             else:
                 return self.load_json_template(dump, omit_date=omit_date)
 

--- a/plugins/modules/zabbix_template_info.py
+++ b/plugins/modules/zabbix_template_info.py
@@ -149,6 +149,7 @@ import xml.etree.ElementTree as ET
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
+from ansible.module_utils.six import PY3
 
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
 import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
@@ -188,7 +189,10 @@ class TemplateInfo(ZabbixBase):
                     date = xmlroot.find(".date")
                     if date is not None:
                         xmlroot.remove(date)
-                return str(ET.tostring(xmlroot, encoding='utf-8').decode('utf-8'))
+                if PY3:
+                    return str(ET.tostring(xmlroot, encoding='utf-8').decode('utf-8'))
+                else:
+                    return str(ET.tostring(xmlroot, encoding='utf-8'))
             else:
                 return self.load_json_template(dump, omit_date)
         except Exception as e:

--- a/plugins/modules/zabbix_template_info.py
+++ b/plugins/modules/zabbix_template_info.py
@@ -149,7 +149,7 @@ import xml.etree.ElementTree as ET
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six import PY3
+from ansible.module_utils.six import PY2
 
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
 import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
@@ -189,10 +189,10 @@ class TemplateInfo(ZabbixBase):
                     date = xmlroot.find(".date")
                     if date is not None:
                         xmlroot.remove(date)
-                if PY3:
-                    return str(ET.tostring(xmlroot, encoding='utf-8').decode('utf-8'))
-                else:
+                if PY2:
                     return str(ET.tostring(xmlroot, encoding='utf-8'))
+                else:
+                    return str(ET.tostring(xmlroot, encoding='utf-8').decode('utf-8'))
             else:
                 return self.load_json_template(dump, omit_date)
         except Exception as e:


### PR DESCRIPTION
##### SUMMARY

This PR is to fix encode error occurs when using Python2.  
fixes: https://github.com/ansible-collections/community.zabbix/issues/233

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/297-zabbix_template_modules.yml
plugins/modules/zabbix_template.py
plugins/modules/zabbix_template_info.py

##### ADDITIONAL INFORMATION