### PR TITLE
zabbix_web: Allow authentication at webserver level (#299)

### DIFF
--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -108,6 +108,10 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_env`: (Optional) A Dictionary of PHP Environments settings.
 * `zabbix_web_conf_web_user`: When provided, the user (which should already exist on the host) will be used for ownership for web/php related processes. (Default set to either `apache` (`www-data` for Debian) or `nginx`).
 * `zabbix_web_conf_web_group`: When provided, the group (which should already exist on the host) will be used for ownership for web/php related processes. (Default set to either `apache` (`www-data` for Debian) or `nginx`).
+* `zabbix_web_htpasswd`: (Optional) Allow HTTP authentication at the webserver level via a htpasswd file.
+* `zabbix_web_htpasswd_file`: Default: `/etc/zabbix/web/htpasswd`. Allows the change the default path to the htpasswd file.
+* `zabbix_web_htpasswd_users`: (Optional) Dictionary for creating users via `htpasswd_user` and passphrases via `htpasswd_pass` in htpasswd file.
+* `zabbix_web_allowlist_ips`: (Optional) Allow web access at webserver level to a list of defined IPs or CIDR.
 
 #### Apache configuration
 

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -15,6 +15,8 @@ zabbix_url: zabbix.example.com
 zabbix_websrv: apache
 zabbix_websrv_servername: "{{ zabbix_url | regex_findall('(?:https?\\://)?([\\w\\-\\.]+)') | first }}"
 zabbix_url_aliases: []
+zabbix_web_htpasswd: False
+zabbix_web_htpasswd_file: /etc/zabbix/web/htpasswd
 zabbix_apache_vhost_port: 80
 zabbix_apache_vhost_tls_port: 443
 zabbix_timezone: Europe/Amsterdam

--- a/roles/zabbix_web/tasks/access.yml
+++ b/roles/zabbix_web/tasks/access.yml
@@ -5,6 +5,7 @@
   when:
     - zabbix_web_htpasswd is defined
     - zabbix_web_htpasswd
+    - zabbix_web_htpasswd_users is defined
 
 - name: "htpasswd | install passlib for Python interpreter"
   package:
@@ -13,6 +14,7 @@
   when:
     - zabbix_web_htpasswd is defined
     - zabbix_web_htpasswd
+    - zabbix_web_htpasswd_users is defined
 
 - name: "htpasswd | manage HTTP authentication controls"
   htpasswd:
@@ -27,3 +29,4 @@
   when:
     - zabbix_web_htpasswd is defined
     - zabbix_web_htpasswd
+    - zabbix_web_htpasswd_users is defined

--- a/roles/zabbix_web/tasks/access.yml
+++ b/roles/zabbix_web/tasks/access.yml
@@ -1,0 +1,29 @@
+---
+- name: "htpasswd | check Python version to set prefix variable"
+  set_fact:
+    zabbix_python_prefix: "python{% if ansible_python_version is version_compare('3', '>=') %}3{% endif %}"
+  when:
+    - zabbix_web_htpasswd is defined
+    - zabbix_web_htpasswd
+
+- name: "htpasswd | install passlib for Python interpreter"
+  package:
+    name: "{{ zabbix_python_prefix }}-passlib"
+    state: present
+  when:
+    - zabbix_web_htpasswd is defined
+    - zabbix_web_htpasswd
+
+- name: "htpasswd | manage HTTP authentication controls"
+  htpasswd:
+    path: "{{ zabbix_web_htpasswd_file }}"
+    name: "{{ item.value.htpasswd_user }}"
+    password: "{{ item.value.htpasswd_pass }}"
+    group: www-data
+    state: present
+  loop_control:
+    label: "{{ item.value.htpasswd_user }}"
+  with_dict: "{{ zabbix_web_htpasswd_users }}"
+  when:
+    - zabbix_web_htpasswd is defined
+    - zabbix_web_htpasswd

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -92,3 +92,11 @@
     - zabbix-web
     - init
     - config
+
+- include_tasks: access.yml
+  when:
+    - zabbix_web_htpasswd
+  tags:
+    - zabbix-web
+    - init
+    - config

--- a/roles/zabbix_web/templates/nginx_vhost.conf.j2
+++ b/roles/zabbix_web/templates/nginx_vhost.conf.j2
@@ -26,13 +26,14 @@ server {
     allow {{ ip }};
 {% endfor %}
     deny all;
+
 {% endif %}
 {% if zabbix_web_htpasswd is defined and zabbix_web_htpasswd %}
     # HTTP authentication via zabbix_web_htpasswd
     auth_basic "Restricted";
     auth_basic_user_file {{ zabbix_web_htpasswd_file }};
-{% endif %}
 
+{% endif %}
     root    /usr/share/zabbix;
 
     index   index.php;

--- a/roles/zabbix_web/templates/nginx_vhost.conf.j2
+++ b/roles/zabbix_web/templates/nginx_vhost.conf.j2
@@ -19,6 +19,20 @@ server {
     {% endif %}
     server_name     {{ zabbix_websrv_servername }} {% for alias in zabbix_url_aliases -%}{{ alias -}} {% endfor %};
 
+{% if zabbix_web_allowlist_ips is defined and zabbix_web_allowlist_ips %}
+    # Allow list IPs via zabbix_web_allowlist_ips
+    satisfy any;
+{% for ip in zabbix_web_allowlist_ips | ipaddr %}
+    allow {{ ip }};
+{% endfor %}
+    deny all;
+{% endif %}
+{% if zabbix_web_htpasswd is defined and zabbix_web_htpasswd %}
+    # HTTP authentication via zabbix_web_htpasswd
+    auth_basic "Restricted";
+    auth_basic_user_file {{ zabbix_web_htpasswd_file }};
+{% endif %}
+
     root    /usr/share/zabbix;
 
     index   index.php;


### PR DESCRIPTION
##### SUMMARY
Fixes #299 with inital support for htpasswd and allowlist IPs in NGINX.
Support in Apache can be extended but can't test it properly currently.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_web

##### ADDITIONAL INFORMATION
This is only our first pull request few more on PHP and NGINX follow ...