### PR TITLE
zabbix_web: Don't set listen.acl_users for PHP FPM on Debian (#301)

### DIFF
--- a/roles/zabbix_web/templates/php-fpm.conf.j2
+++ b/roles/zabbix_web/templates/php-fpm.conf.j2
@@ -3,7 +3,7 @@ user = {{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is defined else z
 group = {{ zabbix_php_fpm_conf_group if zabbix_php_fpm_conf_group is defined else zabbix_web_conf_web_group }}
 
 listen = {{ zabbix_php_fpm_listen }}
-{% if zabbix_php_fpm_conf_listen %}
+{% if zabbix_php_fpm_conf_listen and ansible_os_family != 'Debian' %}
 listen.acl_users = {{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is defined else zabbix_web_conf_web_user }}
 {% endif %}
 {% if zabbix_php_fpm_conf_enable_user is defined %}


### PR DESCRIPTION
##### SUMMARY
Fixes #301 by don't set listen.acl_users on Debian as it breaks PHP FPM service.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
zabbix_web