### PR TITLE
zabbix_web: Improve Nginx option with out-of-the-box setup (#303)

### DIFF
--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -15,10 +15,9 @@ zabbix_url: zabbix.example.com
 zabbix_websrv: apache
 zabbix_websrv_servername: "{{ zabbix_url | regex_findall('(?:https?\\://)?([\\w\\-\\.]+)') | first }}"
 zabbix_url_aliases: []
-zabbix_apache_vhost_port: 80
-zabbix_apache_vhost_tls_port: 443
 zabbix_timezone: Europe/Amsterdam
 zabbix_vhost: True
+
 zabbix_php_frontend_deprecated: False
 zabbix_php_fpm: False
 zabbix_php_fpm_dir_etc: /etc/opt/rh/rh-php72/
@@ -28,6 +27,9 @@ zabbix_php_fpm_conf_enable_user: true
 zabbix_php_fpm_conf_enable_group: true
 zabbix_php_fpm_conf_mode: "0664"
 zabbix_php_fpm_conf_enable_mode: true
+
+zabbix_apache_vhost_port: 80
+zabbix_apache_vhost_tls_port: 443
 zabbix_apache_vhost_listen_ip: "*"
 zabbix_apache_tls: False
 zabbix_apache_redirect: False
@@ -35,19 +37,24 @@ zabbix_apache_tls_crt: /etc/pki/server.crt
 zabbix_apache_tls_key: /etc/pki/server.key
 zabbix_apache_tls_chain:
 zabbix_apache_can_connect_ldap: False
+zabbix_apache_include_custom_fragment: true
+zabbix_apache_SSLPassPhraseDialog: exec:/usr/libexec/httpd-ssl-pass-dialog
+zabbix_apache_SSLSessionCache: shmcb:/run/httpd/sslcache(512000)
+zabbix_apache_SSLSessionCacheTimeout: 300
+zabbix_apache_SSLCryptoDevice: builtin
 
 zabbix_nginx_vhost_port: 80
 zabbix_nginx_vhost_tls_port: 443
 zabbix_nginx_tls: False
 zabbix_nginx_redirect: False
-zabbix_nginx_tls_crt: /etc/pki/server.crt
-zabbix_nginx_tls_key: /etc/pki/server.key
-zabbix_nginx_tls_dhparam: /etc/pki/dhparam-server.pem
 zabbix_nginx_tls_session_timeout: 1d
 zabbix_nginx_tls_session_cache: shared:MySSL:10m
-zabbix_nginx_tls_session_tickets: off
+zabbix_nginx_tls_session_tickets: !!str off
 zabbix_nginx_tls_protocols: TLSv1.2
 zabbix_nginx_tls_ciphers: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+
+zabbix_letsencrypt: False
+zabbix_letsencrypt_webroot_path: /var/www/letsencrypt
 
 zabbix_repo_yum_schema: https
 zabbix_repo_yum_disabled: "*"
@@ -84,12 +91,6 @@ zabbix_web_post_max_size: 16M
 zabbix_web_upload_max_filesize: 2M
 zabbix_web_max_input_time: 300
 zabbix_web_max_input_vars: 10000
-zabbix_apache_include_custom_fragment: true
-
-zabbix_apache_SSLPassPhraseDialog: exec:/usr/libexec/httpd-ssl-pass-dialog
-zabbix_apache_SSLSessionCache: shmcb:/run/httpd/sslcache(512000)
-zabbix_apache_SSLSessionCacheTimeout: 300
-zabbix_apache_SSLCryptoDevice: builtin
 
 # Database
 zabbix_server_database: pgsql

--- a/roles/zabbix_web/handlers/main.yml
+++ b/roles/zabbix_web/handlers/main.yml
@@ -9,7 +9,16 @@
   when:
     - zabbix_websrv == 'apache'
 
-- name: restart nginx
+- name: test nginx config
+  listen: restart nginx
+  command: nginx -t
+  register: zabbix_nginx_cfg_check
+  notify: restart nginx tested
+  become: yes
+  when:
+    - zabbix_websrv == 'nginx'
+
+- name: restart nginx tested
   service:
     name: nginx
     state: restarted
@@ -17,6 +26,7 @@
   become: yes
   when:
     - zabbix_websrv == 'nginx'
+    - zabbix_nginx_cfg_check.rc == 0
 
 - name: restart php-fpm
   service:

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -85,25 +85,6 @@
   when:
     - zabbix_websrv == 'apache'
 
-- name: "Debian | Install Nginx vhost"
-  template:
-    src: nginx_vhost.conf.j2
-    dest: /etc/nginx/conf.d/zabbix.conf
-    owner: root
-    group: root
-    mode: 0644
-  when:
-    - zabbix_vhost
-    - zabbix_websrv == 'nginx'
-  become: yes
-  notify:
-    - restart nginx
-  tags:
-    - zabbix-web
-    - init
-    - config
-    - nginx
-
 - name: "Configure SELinux when enabled"
   include: selinux.yml
   when:

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -44,16 +44,13 @@
   when:
     - zabbix_websrv == 'apache'
 
-- name: "Set websrv specific variables (nginx)"
-  set_fact:
-    zabbix_web_conf_web_user: "{{ zabbix_web_conf_web_user if zabbix_web_conf_web_user is defined else _nginx_user }}"
-    zabbix_web_conf_web_group: "{{ zabbix_web_conf_web_group if zabbix_web_conf_web_group is defined else _nginx_group }}"
-  when:
-    - zabbix_websrv == 'nginx'
-
 - include_tasks: apache.yml
   when:
     - zabbix_websrv == 'apache'
+
+- include_tasks: nginx.yml
+  when:
+    - zabbix_websrv == 'nginx'
 
 - name: "Install the correct repository"
   include: "RedHat.yml"

--- a/roles/zabbix_web/tasks/nginx.yml
+++ b/roles/zabbix_web/tasks/nginx.yml
@@ -1,0 +1,144 @@
+---
+- name: "Nginx | Set websrv specific variables"
+  set_fact:
+    zabbix_web_conf_web_user: "{{ zabbix_web_conf_web_user if zabbix_web_conf_web_user is defined else _nginx_user }}"
+    zabbix_web_conf_web_group: "{{ zabbix_web_conf_web_group if zabbix_web_conf_web_group is defined else _nginx_group }}"
+    zabbix_nginx_config_path: "{{ zabbix_nginx_config_path if zabbix_nginx_config_path is defined else _nginx_config_path }}"
+    zabbix_nginx_log_path: "{{ zabbix_nginx_log_path if zabbix_nginx_log_path is defined else _nginx_log_path }}"
+    zabbix_nginx_service: "{{ zabbix_nginx_service if zabbix_nginx_service is defined else _nginx_service }}"
+    zabbix_nginx_tls_crt: "{{ zabbix_nginx_tls_crt if zabbix_nginx_tls_crt is defined else _nginx_tls_crt }}"
+    zabbix_nginx_tls_key: "{{ zabbix_nginx_tls_key if zabbix_nginx_tls_key is defined else _nginx_tls_key }}"
+    zabbix_nginx_tls_dhparam: "{{ zabbix_nginx_tls_dhparam if zabbix_nginx_tls_dhparam is defined else _nginx_tls_dhparam }}"
+    zabbix_apache_service: "{{ zabbix_apache_service if zabbix_apache_service is defined else _apache_service }}"
+
+- name: "Nginx | Check Apache service if same ports"
+  command: systemctl status "{{ zabbix_apache_service }}"
+  failed_when: false
+  register: zabbix_apache_service_check
+  changed_when: zabbix_apache_service_check.rc == 0
+  check_mode: no
+  when:
+    - zabbix_apache_vhost_port == zabbix_nginx_vhost_port
+    - zabbix_apache_vhost_tls_port == zabbix_nginx_vhost_tls_port
+
+- name: "Nginx | Stop Apache running on same ports"
+  service:
+    name: "{{ zabbix_apache_service }}"
+    state: stopped
+    enabled: no
+  tags:
+    - zabbix-web
+  when:
+    - zabbix_apache_vhost_port == zabbix_nginx_vhost_port
+    - zabbix_apache_vhost_tls_port == zabbix_nginx_vhost_tls_port
+    - zabbix_apache_service_check.rc == 0
+
+- name: "Nginx | Debian | Install Nginx and ssl-cert packages"
+  # README don't go for HTTP2 with nginx-full yet due to:
+  # https://support.zabbix.com/browse/ZBXNEXT-4670
+  apt:
+    state: present
+    name:
+      - nginx-light
+      - ssl-cert
+  when: ansible_os_family == "Debian"
+
+- name: "Nginx | RedHat | Install Nginx packages"
+  yum:
+    state: present
+    name:
+      - nginx
+  when: ansible_os_family == "RedHat"
+
+- name: "Nginx | Start and enable service"
+  service:
+    name: "{{ zabbix_nginx_service }}"
+    state: started
+    enabled: yes
+
+- name: "Nginx | Install OpenSSL package for DH parameters"
+  package:
+    name: openssl
+    state: present
+
+- name: "Nginx | Generate SSL DH parameters"
+  command: "openssl dhparam -out {{ zabbix_nginx_tls_dhparam }} {{ zabbix_nginx_tls_dhparam_bits | default('2048') }}"
+  args:
+    creates: "{{ zabbix_nginx_tls_dhparam }}"
+
+- name: "Let's Encrypt | check for certificate created by certbot"
+  stat:
+    path: "/etc/letsencrypt/live/{{ zabbix_websrv_servername }}/fullchain.pem"
+  register: zabbix_letsencrypt_cert
+  failed_when: false
+  when: zabbix_letsencrypt
+
+- name: "Nginx | Install vhost in conf.d"
+  template:
+    src: nginx_vhost.conf.j2
+    dest: "{{ zabbix_nginx_config_path }}/zabbix.conf"
+    owner: root
+    group: root
+    mode: 0644
+  when:
+    - zabbix_vhost
+  become: yes
+  notify:
+    - restart nginx
+
+- name: "Let's Encrypt | Check if zabbix_websrv_servername is resolvable"
+  set_fact:
+    zabbix_websrv_servername_ip: "{{ lookup('dig', 'qtype=A', '{{ zabbix_websrv_servername }}')}}"
+  changed_when: zabbix_websrv_servername_ip != ansible_default_ipv4.address
+  register: zabbix_letsencrypt_resolve
+  when: zabbix_letsencrypt
+
+- name: "Let's Encrypt | check if certbot CLI is present"
+  shell: "certbot --version"
+  register: zabbix_cerbot_check
+  changed_when: zabbix_cerbot_check.rc != 0
+  check_mode: no
+  when: zabbix_letsencrypt
+
+- name: "Let's Encrypt | flash all handlers before certbot"
+  meta: flush_handlers
+  when:
+    - zabbix_letsencrypt
+    - zabbix_letsencrypt_resolve is not changed
+    - zabbix_cerbot_check.rc == 0
+
+- name: "Let's Encrypt | generate certs with certbot CLI"
+  command: >
+    certbot --non-interactive certonly --expand
+    -a webroot --webroot-path={{ zabbix_letsencrypt_webroot_path }}
+    --email {{ zabbix_letsencrypt_account_email }} --agree-tos
+    --cert-name {{ zabbix_websrv_servername }}
+    -d {{ zabbix_websrv_servername }}
+  args:
+    creates: "/etc/letsencrypt/live/{{ zabbix_websrv_servername }}/fullchain.pem"
+  when:
+    - zabbix_letsencrypt
+    - zabbix_letsencrypt_resolve is not changed
+    - zabbix_cerbot_check.rc == 0
+
+- name: "Let's Encrypt | Check for certificate created by certbot"
+  stat:
+    path: "/etc/letsencrypt/live/{{ zabbix_websrv_servername }}/fullchain.pem"
+  register: zabbix_letsencrypt_cert
+  failed_when: false
+  when: zabbix_letsencrypt
+
+- name: "Let's Encrypt | Reinstall Nginx vhost"
+  template:
+    src: nginx_vhost.conf.j2
+    dest: /etc/nginx/conf.d/zabbix.conf
+    owner: root
+    group: root
+    mode: 0644
+  when:
+    - zabbix_letsencrypt
+    - zabbix_letsencrypt_resolve is not changed
+    - zabbix_cerbot_check.rc == 0
+  become: yes
+  notify:
+    - restart nginx

--- a/roles/zabbix_web/templates/nginx_vhost.conf.j2
+++ b/roles/zabbix_web/templates/nginx_vhost.conf.j2
@@ -1,10 +1,10 @@
 # Nginx configuration for Zabbix Web
 
 server {
-    {% if not zabbix_nginx_tls %}
-    listen          80;
-    {% else %}
-    {% if zabbix_letsencrypt %}
+{% if not zabbix_nginx_tls %}
+    listen 80;
+{% else %}
+{% if zabbix_letsencrypt %}
     server_tokens off;
     server_name     {{ zabbix_websrv_servername }} {% for alias in zabbix_url_aliases -%}{{ alias -}} {% endfor %};
     location ^~ /.well-known/acme-challenge {
@@ -18,8 +18,8 @@ server {
 }
 
 server {
-    {% endif %}
-    listen          443 ssl http2;
+{% endif %}
+    listen 443 ssl;
 {% if zabbix_letsencrypt and zabbix_letsencrypt_cert.stat.exists %}
     ssl_certificate /etc/letsencrypt/live/{{ zabbix_websrv_servername }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ zabbix_websrv_servername }}/privkey.pem;
@@ -36,7 +36,8 @@ server {
     ssl_ciphers {{ zabbix_nginx_tls_ciphers }};
     ssl_prefer_server_ciphers off;
 
-    {% endif %}
+{% endif %}
+    server_tokens off;
     server_name     {{ zabbix_websrv_servername }} {% for alias in zabbix_url_aliases -%}{{ alias -}} {% endfor %};
 
     root    /usr/share/zabbix;

--- a/roles/zabbix_web/templates/nginx_vhost.conf.j2
+++ b/roles/zabbix_web/templates/nginx_vhost.conf.j2
@@ -4,9 +4,29 @@ server {
     {% if not zabbix_nginx_tls %}
     listen          80;
     {% else %}
+    {% if zabbix_letsencrypt %}
+    server_tokens off;
+    server_name     {{ zabbix_websrv_servername }} {% for alias in zabbix_url_aliases -%}{{ alias -}} {% endfor %};
+    location ^~ /.well-known/acme-challenge {
+        root {{ zabbix_letsencrypt_webroot | default('/var/www/letsencrypt') }};
+        # disables IP restrictions and HTTP auth
+        allow all;
+        default_type text/plain;
+        try_files $uri =404;
+    }
+    location / { return 301 https://$host$request_uri; }
+}
+
+server {
+    {% endif %}
     listen          443 ssl http2;
+{% if zabbix_letsencrypt and zabbix_letsencrypt_cert.stat.exists %}
+    ssl_certificate /etc/letsencrypt/live/{{ zabbix_websrv_servername }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ zabbix_websrv_servername }}/privkey.pem;
+{% else %}
     ssl_certificate {{ zabbix_nginx_tls_crt }};
     ssl_certificate_key {{ zabbix_nginx_tls_key }};
+{% endif %}
     ssl_session_timeout {{ zabbix_nginx_tls_session_timeout }};
     ssl_session_cache {{ zabbix_nginx_tls_session_cache }};
     ssl_session_tickets {{ zabbix_nginx_tls_session_tickets }};

--- a/roles/zabbix_web/vars/Debian.yml
+++ b/roles/zabbix_web/vars/Debian.yml
@@ -12,3 +12,9 @@ _zabbix_php_fpm_allowed_clients: 127.0.0.1
 
 _nginx_user: www-data
 _nginx_group: www-data
+_nginx_config_path: /etc/nginx/conf.d
+_nginx_log_path: /var/log/nginx
+_nginx_service: nginx
+_nginx_tls_crt: /etc/ssl/certs/ssl-cert-snakeoil.pem
+_nginx_tls_key: /etc/ssl/private/ssl-cert-snakeoil.key
+_nginx_tls_dhparam: /etc/ssl/private/dhparams.pem

--- a/roles/zabbix_web/vars/RedHat.yml
+++ b/roles/zabbix_web/vars/RedHat.yml
@@ -10,3 +10,6 @@ _php_fpm_listen: /run/php-fpm/zabbix.sock
 
 _nginx_user: nginx
 _nginx_group: nginx
+_nginx_tls_crt: /etc/pki/server.crt
+_nginx_tls_key: /etc/pki/server.key
+_nginx_tls_dhparam: /etc/pki/dhparam-server.pem

--- a/roles/zabbix_web/vars/RedHat.yml
+++ b/roles/zabbix_web/vars/RedHat.yml
@@ -10,6 +10,9 @@ _php_fpm_listen: /run/php-fpm/zabbix.sock
 
 _nginx_user: nginx
 _nginx_group: nginx
+_nginx_config_path: /etc/nginx/conf.d
+_nginx_log_path: /var/log/nginx
+_nginx_service: nginx
 _nginx_tls_crt: /etc/pki/server.crt
 _nginx_tls_key: /etc/pki/server.key
 _nginx_tls_dhparam: /etc/pki/dhparam-server.pem


### PR DESCRIPTION
##### SUMMARY
"Fixes #303" with a bunch of consolidiation and feature changes:
* Consolidate all Nginx tasks to tasks/nginx.yml
* Set distro specific variables via vars/$DISTRO
* Stop Apache if running on same port as Nginx
* Install and use snakeoil SSL certs on Debian
* Avoid unsecure HTTPS by generating DH parameters
* Allow domain validated certs with Let's Encrypt
* Prerun config check before Nginx restart handler

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_web role

##### ADDITIONAL INFORMATION
Bunch of changes but for optional role features keeping defaults.
Sorry for this bigger chunk in future we aim to keep small deltas.
But wanted to upstream for more synergy on this in the new year :D