### PR TITLE
Sort host interfaces before mapping them

### DIFF
--- a/changelogs/fragments/309-host-interfaces.yaml
+++ b/changelogs/fragments/309-host-interfaces.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- zabbix_host - should no longer fail with 'host cannot have more than one default interface' error (https://github.com/ansible-collections/community.zabbix/pull/309).

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -1102,6 +1102,7 @@ def main():
 
             # get existing host's interfaces
             exist_interfaces = host._zapi.hostinterface.get({'output': 'extend', 'hostids': host_id})
+            exist_interfaces.sort(key=lambda x: int(x['interfaceid']))
 
             # When force=no is specified, append existing interfaces to interfaces to update. When
             # no interfaces have been specified, copy existing interfaces as specified from the API.


### PR DESCRIPTION
##### SUMMARY
Should fix #253 and #244 when there is more than one interface

##### COMPONENT NAME
plugins/modules/zabbix_host.py
