### PR TITLE
add support for ubuntu on Pi

### DIFF
--- a/changelogs/fragments/rapsberry.yaml
+++ b/changelogs/fragments/rapsberry.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-    - name: add support to install agent on arm64 (another repository) 

--- a/changelogs/fragments/rapsberry.yaml
+++ b/changelogs/fragments/rapsberry.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+    - name: add support to install agent on arm64 (another repository) 

--- a/changelogs/fragments/raspberry-server.yaml
+++ b/changelogs/fragments/raspberry-server.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- add support to install server and web on arm64 (another repository)

--- a/changelogs/fragments/raspberry.yaml
+++ b/changelogs/fragments/raspberry.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- add support to install agent on arm64 (another repository) 

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -149,8 +149,8 @@ See https://httpd.apache.org/docs/current/mod/mod_ssl.html for SSL* configuratio
 * `zabbix_nginx_tls_key`: The path to the TLS key file.
 * `zabbix_nginx_tls_dhparam`: The path to the TLS DHParam file.
 * `zabbix_nginx_tls_session_cache`: Type of the global/inter-process SSL Session Cache
-* `zabbix_nginx_tls_session_timeout`: 
-* `zabbix_nginx_tls_session_tickets`: 
+* `zabbix_nginx_tls_session_timeout`:
+* `zabbix_nginx_tls_session_tickets`:
 * `zabbix_nginx_tls_protocols`: The TLS Protocols to accept.
 * `zabbix_nginx_tls_ciphers`: The TLS Ciphers to be allowed.
 
@@ -264,6 +264,15 @@ zabbix.conf.php, for example to add LDAP CA certificates. To do this add a `zabb
   become: yes
   roles:
     - role: geerlingguy.apache
+    - role: geerlingguy.php
+      php_memory_limit: "128M"
+      php_max_execution_time: "300"
+      php_upload_max_filesize: "256M"
+      php_packages:
+        - php
+        - php-fpm
+        - php-acpu
+    - role: geerlingguy.apache-php-fpm
     - role: community.zabbix.zabbix_web
       zabbix_url: zabbix.mydomain.com
       zabbix_server_hostname: zabbix-server
@@ -301,7 +310,7 @@ zabbix_server_history_types:
 
 # Molecule
 
-This role is configured to be tested with Molecule. You can find on this page some more information regarding Molecule: 
+This role is configured to be tested with Molecule. You can find on this page some more information regarding Molecule:
 
 * http://werner-dijkerman.nl/2016/07/10/testing-ansible-roles-with-molecule-testinfra-and-docker/
 * http://werner-dijkerman.nl/2016/07/27/extending-ansible-role-testing-with-molecule-by-adding-group_vars-dependencies-and-using-travis-ci/

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -92,6 +92,42 @@
     - zabbix-agent
     - init
 
+- name: show fqdn
+  debug:
+    msg: System {{ansible_machine}} {{inventory_hostname}}-{{ansible_default_ipv4.address}} has gateway {{ ansible_default_ipv4.gateway }}
+
+- name: "Debian | Installing deb-src repository Ubuntu Arm64"
+  apt_repository:
+    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu-arm64/ {{ zabbix_agent_distribution_release }} main"
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_machine == "aarch64"
+    - zabbix_repo == "zabbix"
+  become: yes
+  tags:
+    - zabbix-agent
+    - init
+
+- name: "Debian | Installing deb repository Ubuntu Arm64"
+  apt_repository:
+    repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu-arm64/ {{ zabbix_agent_distribution_release }} main"
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_machine == "aarch64"
+    - zabbix_repo == "zabbix"
+  become: yes
+  tags:
+    - zabbix-agent
+    - init
+
 - name: "Debian | Installing deb-src repository Ubuntu"
   apt_repository:
     repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ zabbix_agent_distribution_release }} main"
@@ -101,6 +137,7 @@
     https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
   when:
     - ansible_distribution == "Ubuntu"
+    - ansible_machine != "aarch64"
     - zabbix_repo == "zabbix"
   become: yes
   tags:
@@ -116,11 +153,14 @@
     https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
   when:
     - ansible_distribution == "Ubuntu"
+    - ansible_machine != "aarch64"
     - zabbix_repo == "zabbix"
   become: yes
   tags:
     - zabbix-agent
     - init
+
+
 
 - name: "Debian | Create /etc/apt/preferences.d/"
   file:

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -29,7 +29,19 @@
   become: yes
   when:
     - ansible_distribution == "Debian"
+    - ansible_machine == "aarch64"
     - zabbix_repo == "zabbix"
+
+- name: "Debian | Installing repository Ubuntu"
+  apt_repository:
+    repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/ubuntu-arm64/ {{ ansible_distribution_release }} main"
+    state: present
+  become: yes
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_machine == "aarch64"
+    - zabbix_repo == "zabbix"
+
 
 - name: "Debian | Installing repository Ubuntu"
   apt_repository:
@@ -38,7 +50,19 @@
   become: yes
   when:
     - ansible_distribution == "Ubuntu"
+    - ansible_machine != "aarch64"
     - zabbix_repo == "zabbix"
+
+- name: "Debian | Installing repository Ubuntu"
+  apt_repository:
+    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/ubuntu-arm64/ {{ ansible_distribution_release }} main"
+    state: present
+  become: yes
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_machine == "aarch64"
+    - zabbix_repo == "zabbix"
+
 
 - name: "Debian | Installing repository Ubuntu"
   apt_repository:

--- a/roles/zabbix_server/requirements.yml
+++ b/roles/zabbix_server/requirements.yml
@@ -2,3 +2,4 @@
 - src: geerlingguy.apache
 - src: geerlingguy.mysql
 - src: geerlingguy.postgresql
+- src: community.postgresql

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -12,6 +12,21 @@
       - "main"
     zabbix_underscore_version: "{{ zabbix_version | regex_replace('\\.', '_') }}"
     zabbix_python_prefix: "python{% if ansible_python_version is version('3', '>=') %}3{% endif %}"
+  when:
+    - ansible_machine != "aarch64"
+
+- name: "Set some variables"
+  set_fact:
+    zabbix_short_version: "{{ zabbix_version | regex_replace('\\.', '') }}"
+    zabbix_server_apt_repository:
+      - "http://repo.zabbix.com/zabbix/{{ zabbix_version }}/{{ ansible_distribution.lower() }}-arm64/"
+      - "{{ ansible_distribution_release }}"
+      - "main"
+    zabbix_underscore_version: "{{ zabbix_version | regex_replace('\\.', '_') }}"
+    zabbix_python_prefix: "python{% if ansible_python_version is version('3', '>=') %}3{% endif %}"
+  when:
+    - ansible_machine == "aarch64"
+
 
 - name: "Debian | Set some facts"
   set_fact:

--- a/roles/zabbix_server/tasks/postgresql.yml
+++ b/roles/zabbix_server/tasks/postgresql.yml
@@ -16,12 +16,12 @@
 - name: "PostgreSQL | Delegated"
   block:
     - name: "PostgreSQL | Delegated | Create database"
-      postgresql_db:
+      community.postgresql.postgresql_db:
         name: "{{ zabbix_server_dbname }}"
         port: "{{ zabbix_server_dbport }}"
         state: present
     - name: "PostgreSQL | Delegated | Create database user"
-      postgresql_user:
+      community.postgresql.postgresql_user:
         db: "{{ zabbix_server_dbname }}"
         name: "{{ zabbix_server_dbuser }}"
         password: "md5{{ (zabbix_server_dbpassword + zabbix_server_dbuser)|hash('md5') }}"
@@ -42,7 +42,7 @@
 - name: "PostgreSQL | Remote"
   block:
     - name: "PostgreSQL | Remote | Create database"
-      postgresql_db:
+      community.postgresql.postgresql_db:
         login_host: "{{ zabbix_server_pgsql_login_host | default(omit) }}"
         login_user: "{{ zabbix_server_pgsql_login_user | default(omit) }}"
         login_password: "{{ zabbix_server_pgsql_login_password | default(omit) }}"
@@ -51,7 +51,7 @@
         port: "{{ zabbix_server_dbport }}"
         state: present
     - name: "PostgreSQL | Remote | Create database user"
-      postgresql_user:
+      community.postgresql.postgresql_user:
         login_host: "{{ zabbix_server_pgsql_login_host | default(omit) }}"
         login_user: "{{ zabbix_server_pgsql_login_user | default(omit) }}"
         login_password: "{{ zabbix_server_pgsql_login_password | default(omit) }}"
@@ -82,7 +82,7 @@
     creates: /etc/zabbix/schema.done
     warn: no
   environment:
-    PGPASSWORD: '{{ zabbix_server_dbpassword }}'
+    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
   when:
     - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload
@@ -127,7 +127,7 @@
     creates: /etc/zabbix/schema.done
     warn: no
   environment:
-    PGPASSWORD: '{{ zabbix_server_dbpassword }}'
+    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
   when:
     - (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
@@ -146,7 +146,7 @@
     creates: /etc/zabbix/images.done
     warn: no
   environment:
-    PGPASSWORD: '{{ zabbix_server_dbpassword }}'
+    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
   when: (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server
@@ -164,7 +164,7 @@
     creates: /etc/zabbix/data.done
     warn: no
   environment:
-    PGPASSWORD: '{{ zabbix_server_dbpassword }}'
+    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
   when: (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -26,6 +26,23 @@
   become: yes
   when:
     - zabbix_repo == "zabbix"
+    - ansible_machine != "aarch64"
+  with_items:
+    - deb-src
+    - deb
+  tags:
+    - zabbix-web
+    - init
+    - config
+
+- name: "Debian | Installing repository {{ ansible_distribution }}"
+  apt_repository:
+    repo: "{{ item }} http://repo.zabbix.com/zabbix/{{ zabbix_version }}/{{ ansible_distribution.lower() }}-arm64/ {{ ansible_distribution_release }} main"
+    state: present
+  become: yes
+  when:
+    - zabbix_repo == "zabbix"
+    - ansible_machine == "aarch64"
   with_items:
     - deb-src
     - deb


### PR DESCRIPTION
##### SUMMARY
Zabbix has a non conventional repo name for aarch64. 
A small fix for users

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zaggix_agent

##### ADDITIONAL INFORMATION
forge a repo name for aarch64, skip normal 
