### PR TITLE
zabbix_template: Fix the issue for the unicode strings doesn’t decode in python2

### DIFF
--- a/changelogs/fragments/322-zabbix_template.yml
+++ b/changelogs/fragments/322-zabbix_template.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_template - fixed the bug that it doesn't decode the Unicode in Python2 (https://github.com/ansible-collections/community.zabbix/pull/322).

--- a/tests/integration/targets/test_zabbix_template/files/template1_50_higher_decode_unicode.json
+++ b/tests/integration/targets/test_zabbix_template/files/template1_50_higher_decode_unicode.json
@@ -1,0 +1,29 @@
+{
+    "zabbix_export": {
+        "version": "5.0",
+        "groups": [
+            {
+                "name": "Templates"
+            }
+        ],
+        "templates": [
+            {
+                "template": "ExampleTemplate314",
+                "name": "ExampleTemplate314",
+                "description": "\u30c6\u30b9\u30c8\u30b3\u30e1\u30f3\u30c8",
+                "groups": [
+                    {
+                        "name": "Templates"
+                    }
+                ],
+                "items": [
+                    {
+                        "name": "test",
+                        "type": "ZABBIX_ACTIVE",
+                        "key": "logrt[\"/test.*test.log\",\"test.*total=([0-9.]+)\",,,skip,\\1]"
+                    }
+                ],
+            }
+        ],
+    }
+}

--- a/tests/integration/targets/test_zabbix_template/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template/tasks/main.yml
@@ -420,9 +420,19 @@
         state: present
       register: import_template_json
 
+    - name: Gather Zabbix template infomation.
+      zabbix_template_info:
+        server_url: "{{ zabbix_server_url }}"
+        login_user: "{{ zabbix_login_user }}"
+        login_password: "{{ zabbix_login_password }}"
+        template_name: ExampleTemplate314
+        format: json
+      register: gather_template_result
+
     - assert:
         that:
           - import_template_json.changed is sameas true
+          - gather_template_result.template_json.zabbix_export.templates.0.description == "\u30c6\u30b9\u30c8\u30b3\u30e1\u30f3\u30c8"
 
     - name: Delete Zabbix template.
       zabbix_template:

--- a/tests/integration/targets/test_zabbix_template/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template/tasks/main.yml
@@ -406,3 +406,33 @@
 - assert:
     that:
       - delete_zabbix_template_result.changed is sameas false
+
+- when: zabbix_version is version('5.0', '>=')
+  block:
+    # The test if decode Unicode correctly and to be imported the template.
+    # https://github.com/ansible-collections/community.zabbix/issues/314
+    - name: Import Zabbix template from JSON file with unicode.
+      zabbix_template:
+        server_url: "{{ zabbix_server_url }}"
+        login_user: "{{ zabbix_login_user }}"
+        login_password: "{{ zabbix_login_password }}"
+        template_json: "{{ lookup('file', 'template1_50_higher_decode_unicode.json') }}"
+        state: present
+      register: import_template_json
+
+    - assert:
+        that:
+          - import_template_json.changed is sameas true
+
+    - name: Delete Zabbix template.
+      zabbix_template:
+        server_url: "{{ zabbix_server_url }}"
+        login_user: "{{ zabbix_login_user }}"
+        login_password: "{{ zabbix_login_password }}"
+        template_name: ExampleTemplate314
+        state: absent
+      register: delete_zabbix_template_result
+
+    - assert:
+        that:
+          - delete_zabbix_template_result.changed is sameas true


### PR DESCRIPTION
##### SUMMARY

I added the codecs processing for decoding unicode in Python2 to the zabbix_template module previously.  
https://github.com/ansible-collections/community.zabbix/pull/226

It turns out that this process also removes the necessary escape characters(slash) in Python2 and 3.  
So, this PR will fix that issue.

fixes: https://github.com/ansible-collections/community.zabbix/issues/314

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/zabbix_template.py

##### ADDITIONAL INFORMATION

tested on Zabbix 5.0