### PR TITLE
Update php version for Debian 10

### DIFF
--- a/changelogs/fragments/322-zabbix_template.yml
+++ b/changelogs/fragments/322-zabbix_template.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_template - fixed the bug that it doesn't decode the Unicode in Python2 (https://github.com/ansible-collections/community.zabbix/pull/322).

--- a/molecule/zabbix_web/molecule.yml
+++ b/molecule/zabbix_web/molecule.yml
@@ -55,13 +55,13 @@ provisioner:
     host_vars:
       zabbix-web-pgsql-debian:
         zabbix_websrv: apache
-        php_default_version_debian: 7.4
+        php_default_version_debian: 7.3
         zabbix_php_fpm_conf_listen: False
         zabbix_url: zabbix-web-pgsql-debian
         zabbix_websrv_servername: zabbix-web-pgsql-debian
       zabbix-web-mysql-debian:
         zabbix_websrv: apache
-        php_default_version_debian: 7.4
+        php_default_version_debian: 7.3
         zabbix_php_fpm_conf_listen: False
         zabbix_url: zabbix-web-mysql-debian
         zabbix_websrv_servername: zabbix-web-mysql-debian

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -209,8 +209,8 @@ zabbix_agent_win_svc_recovery: True
 
 # macOS Related
 zabbix_mac_package: zabbix_agent-{{ zabbix_version_long }}-macos-amd64-openssl.pkg
-zabbix_mac_download_url: https://www.zabbix.com/downloads
-zabbix_mac_download_link: "{{ zabbix_mac_download_url }}/{{ zabbix_version_long }}/{{ zabbix_mac_package }}"
+zabbix_mac_download_url: https://cdn.zabbix.com/zabbix/binaries/stable
+zabbix_mac_download_link: "{{ zabbix_mac_download_url }}/{{ zabbix_agent_version }}/{{ zabbix_version_long }}/{{ zabbix_mac_package }}"
 
 # Zabbix Agent Docker facts
 zabbix_agent_docker: False

--- a/roles/zabbix_web/vars/Debian-10.yml
+++ b/roles/zabbix_web/vars/Debian-10.yml
@@ -1,3 +1,3 @@
 ---
 
-_zabbix_php_version: 7.4
+_zabbix_php_version: 7.3

--- a/tests/integration/targets/test_zabbix_template/files/template1_50_higher_decode_unicode.json
+++ b/tests/integration/targets/test_zabbix_template/files/template1_50_higher_decode_unicode.json
@@ -1,0 +1,29 @@
+{
+    "zabbix_export": {
+        "version": "5.0",
+        "groups": [
+            {
+                "name": "Templates"
+            }
+        ],
+        "templates": [
+            {
+                "template": "ExampleTemplate314",
+                "name": "ExampleTemplate314",
+                "description": "\u30c6\u30b9\u30c8\u30b3\u30e1\u30f3\u30c8",
+                "groups": [
+                    {
+                        "name": "Templates"
+                    }
+                ],
+                "items": [
+                    {
+                        "name": "test",
+                        "type": "ZABBIX_ACTIVE",
+                        "key": "logrt[\"/test.*test.log\",\"test.*total=([0-9.]+)\",,,skip,\\1]"
+                    }
+                ],
+            }
+        ],
+    }
+}

--- a/tests/integration/targets/test_zabbix_template/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template/tasks/main.yml
@@ -406,3 +406,43 @@
 - assert:
     that:
       - delete_zabbix_template_result.changed is sameas false
+
+- when: zabbix_version is version('5.0', '>=')
+  block:
+    # The test if decode Unicode correctly and to be imported the template.
+    # https://github.com/ansible-collections/community.zabbix/issues/314
+    - name: Import Zabbix template from JSON file with unicode.
+      zabbix_template:
+        server_url: "{{ zabbix_server_url }}"
+        login_user: "{{ zabbix_login_user }}"
+        login_password: "{{ zabbix_login_password }}"
+        template_json: "{{ lookup('file', 'template1_50_higher_decode_unicode.json') }}"
+        state: present
+      register: import_template_json
+
+    - name: Gather Zabbix template infomation.
+      zabbix_template_info:
+        server_url: "{{ zabbix_server_url }}"
+        login_user: "{{ zabbix_login_user }}"
+        login_password: "{{ zabbix_login_password }}"
+        template_name: ExampleTemplate314
+        format: json
+      register: gather_template_result
+
+    - assert:
+        that:
+          - import_template_json.changed is sameas true
+          - gather_template_result.template_json.zabbix_export.templates.0.description == "\u30c6\u30b9\u30c8\u30b3\u30e1\u30f3\u30c8"
+
+    - name: Delete Zabbix template.
+      zabbix_template:
+        server_url: "{{ zabbix_server_url }}"
+        login_user: "{{ zabbix_login_user }}"
+        login_password: "{{ zabbix_login_password }}"
+        template_name: ExampleTemplate314
+        state: absent
+      register: delete_zabbix_template_result
+
+    - assert:
+        that:
+          - delete_zabbix_template_result.changed is sameas true


### PR DESCRIPTION
PHP 7.4 is not packaged for Debian 10. The default version of php on Buster is 7.3

##### SUMMARY
Fix version of PHP


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
role zabbix_web

##### ADDITIONAL INFORMATION
This role doesn't work on Debian Buster the default PHP version is 7.3 and not 7.4
