### PR TITLE
Update zabbix_web selinux conditionals for RHEL 8

### DIFF
--- a/roles/zabbix_web/tasks/selinux.yml
+++ b/roles/zabbix_web/tasks/selinux.yml
@@ -32,6 +32,7 @@
   when:
     - ansible_os_family == "RedHat"
     - selinux_allow_zabbix_can_network
+    - ansible_distribution_major_version == "8"
   tags:
     - zabbix-web
 


### PR DESCRIPTION
This conditional runs no matter if the host is RHEL 5/6/7 when it should only run for when the host is a RHEL 8 machine. The package is not available for below RHEL 8 and fails every time without this flag. 

Failure Message:
```
fatal: [default]: FAILED! => {"attempts": 3, "changed": false, "msg": "No package matching 'python3-libsemanage' found available, installed or updated", "rc": 126, "results": ["No package matching 'python3-libsemanage' found available, installed or updated"]}
```

##### SUMMARY
This fixes an issue where the RHEL 8 package would be attempted to install and would fail because the package is only for RHEL 8 when the host is RHEL 7. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_web -> selinux

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
