### PR TITLE
Including API calls with api tag

### DIFF
--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -100,6 +100,8 @@
   include_tasks: api.yml
   when:
     - (zabbix_api_create_hostgroup | bool) or (zabbix_api_create_hosts | bool)
+  tags:
+    - api
 
 - name: "Including userparameters"
   include_tasks: "userparameter.yml"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- api.yml is not included if only the 'api' tag is used
- added 'api' tag to relevant task
- this is useful for making Zabbix api-only updates
  - i.e. removing a host from Zabbix

This change allows bare minimum of tasks to be executed when removing a host from Zabbix. As is, when the `api` tag is specified when running a playbook, the `api.yml` tasks file is not executed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #332 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_agent

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

