### PR TITLE
Support for Zabbix proxy StatsAllowedIP configuration parameter

### DIFF
--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -104,6 +104,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_proxy_groupid`: The GID of the group on the host. Will only be used when `zabbix_repo: epel` is used.
 * `zabbix_proxy_include_mode`: Default: `0755`. The "mode" for the directory configured with `zabbix_proxy_include`.
 * `zabbix_proxy_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
+* `zabbix_proxy_statsallowedip`: Default: `127.0.0.1`. Allowed IP foe remote gathering of the ZabbixPorixy internal metrics.
 
 ### Database specific
 

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -59,7 +59,7 @@ zabbix_proxy_database_long: mysql
 # zabbix_proxy_database: sqlite3
 # zabbix_proxy_database_long: sqlite3
 
-# zabbix-proxy specifc vars
+# zabbix-proxy specific vars
 zabbix_proxy_mode: 0
 zabbix_proxy_hostname: "{{ inventory_hostname }}"
 zabbix_proxy_listenport: 10051
@@ -126,6 +126,7 @@ zabbix_proxy_include_mode: '0755'
 zabbix_proxy_libdir: /usr/lib/zabbix
 zabbix_proxy_loadmodulepath: "{{ zabbix_proxy_libdir }}/modules"
 zabbix_proxy_manage_service: True
+zabbix_proxy_statsallowedip: '127.0.0.1'
 
 # TLS settings
 zabbix_proxy_tlsconnect:

--- a/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
+++ b/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
@@ -416,6 +416,22 @@ LoadModulePath={{ zabbix_proxy_loadmodulepath }}
 LoadModule={{ zabbix_proxy_loadmodule }}
 {% endif %}
 
+{% if zabbix_version is version_compare('4.0', '>=') %}
+### Option: StatsAllowedIP
+#       List of comma delimited IP addresses, optionally in CIDR notation, or DNS names of external Zabbix instances.
+#       Stats request will be accepted only from the addresses listed here. If this parameter is not set no stats requests
+#       will be accepted.
+#       If IPv6 support is enabled then '127.0.0.1', '::127.0.0.1', '::ffff:127.0.0.1' are treated equally
+#       and '::/0' will allow any IPv4 or IPv6 address.
+#       '0.0.0.0/0' can be used to allow any IPv4 address.
+#       Example: StatsAllowedIP=127.0.0.1,192.168.1.0/24,::1,2001:db8::/32,zabbix.example.com
+#
+# Mandatory: no
+# Default:
+# StatsAllowedIP=
+StatsAllowedIP={{ zabbix_proxy_statsallowedip }}
+{% endif %}
+
 {% if zabbix_version is version_compare('3.0', '>=') %}
 ####### TLS-RELATED PARAMETERS #######
 


### PR DESCRIPTION
##### SUMMARY
Added support for configuration parameter StatsAllowedIP info zabbix_proxy.conf.j2 template
Fixes #336

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Zabbix Proxy


