### PR TITLE
Fix database import script location (& whitespace)

### DIFF
--- a/roles/zabbix_server/tasks/RedHat.yml
+++ b/roles/zabbix_server/tasks/RedHat.yml
@@ -21,19 +21,19 @@
   tags:
     - zabbix-server
 
-- name: "RedHat | Set some facts Zabbix < 3.0"
+- name: "RedHat | Set some facts Zabbix <= 3.2"
   set_fact:
     datafiles_path: "/usr/share/doc/zabbix-server-{{ zabbix_server_database }}-{{ zabbix_version }}*"
   when:
-    - zabbix_version is version('3.0', '<')
+    - zabbix_version is version('3.2', '<=')
   tags:
     - zabbix-server
 
-- name: "RedHat | Set facts for Zabbix >= 3.0"
+- name: "RedHat | Set facts for Zabbix > 3.2"
   set_fact:
-    datafiles_path: "/usr/share/doc/zabbix-server-{{ zabbix_server_database }}-{{ zabbix_version }}*"
+    datafiles_path: "/usr/share/doc/zabbix-server-{{ zabbix_server_database }}*"
   when:
-    - zabbix_version is version('3.0', '>=')
+    - zabbix_version is version('3.2', '>')
   tags:
     - zabbix-server
 
@@ -60,7 +60,7 @@
     state: present
   become: yes
   when:
-    - zabbix_repo == "epel"  
+    - zabbix_repo == "epel"
 
 - name: "RedHat | Create 'zabbix' user (EPEL)"
   user:
@@ -71,7 +71,7 @@
   become: yes
   when:
     - zabbix_repo == "epel"
-    
+
 - name: "Make sure old file is absent"
   file:
     path: /etc/yum.repos.d/zabbix-supported.repo


### PR DESCRIPTION
##### SUMMARY

Zabbix 3.0 (currently supported) and 3.2 (now unsupported) placed
import scripts at
/usr/share/doc/zabbix-server-{mysql,pgsql}-{3.0.0,3.2.0}/create.sql.gz,
while newer versions (3.4, 4.x, 5.x) have scripts at
/usr/share/doc/zabbix-server-{mysql,pgsql}/create.sql.gz.

References for currently supported versions:
3.0: https://www.zabbix.com/documentation/3.0/manual/installation/install_from_packages/server_installation_with_mysql#creating_initial_database
4.0: https://www.zabbix.com/documentation/4.0/manual/installation/install_from_packages/rhel_centos#importing_data
5.0: https://www.zabbix.com/download?zabbix=5.0&os_distribution=red_hat_enterprise_linux&os_version=8&db=mysql
5.2: https://www.zabbix.com/download?zabbix=5.2&os_distribution=red_hat_enterprise_linux&os_version=8&db=mysql

This commit should make all versions since 3.0 work (this includes all
supported versions.)

Even older (unsupported) versions had additional locations, but this
commit does not include support for those versions. For example, Zabbix
2.0 had scripts in a further subdirectory at
/usr/share/doc/zabbix-server-mysql-2.4.0/create
(https://www.zabbix.com/documentation/2.4/manual/installation/install_from_packages#creating_initial_database)
with three separate scripts; this would break assumptions made elsewhere
in this module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_server role