### PR TITLE
Install necessary packages for mysql on RHEL8

### DIFF
--- a/roles/zabbix_server/tasks/RedHat.yml
+++ b/roles/zabbix_server/tasks/RedHat.yml
@@ -148,6 +148,24 @@
   tags:
     - zabbix-server
 
+- name: "RedHat | Install Mysql Client packages RHEL8"
+  yum:
+    name:
+      - mysql
+      - python3-PyMySQL
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  register: zabbix_server_dependencies_installed
+  until: zabbix_server_dependencies_installed is succeeded
+  become: yes
+  when:
+    - zabbix_server_database == 'mysql'
+    - ansible_distribution_major_version == "8"
+  tags:
+    - zabbix-server
+
 - name: "RedHat | Install Mysql Client package RHEL7"
   yum:
     name:


### PR DESCRIPTION
Several commands require a `mysql` binary to be installed, for example
```
- name: "MySQL | Get current value for innodb_default_row_format"
  shell: |
    set -euo pipefail
    mysql -h {{ zabbix_server_dbhost }} -u{{ zabbix_server_dbuser }} \
    -p'{{ zabbix_server_dbpassword }}' \
    -e 'SHOW VARIABLES;' 2>&1 | grep innodb_default_row_format \
    | awk '{print $2}' | tr [:upper:] [:lower:]
  register: mysql_innodb_default_row_format
  args:
    executable: /bin/bash
  changed_when: False
  become: true
```

Also, the `mysql_db` module requires PyMySQL for python3. (Python3 is
the default version of python on RHEL8.)
https://docs.ansible.com/ansible/2.9/modules/mysql_db_module.html#requirements

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
