### PR TITLE
fix: zabbix_maintenance - added visible_name

### DIFF
--- a/changelogs/fragments/350-zabbix_maintenance-visible_name.yaml
+++ b/changelogs/fragments/350-zabbix_maintenance-visible_name.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- zabbix_maintenance - it is now possible to target hosts by their technical name if it differs from the visible name

--- a/plugins/modules/zabbix_maintenance.py
+++ b/plugins/modules/zabbix_maintenance.py
@@ -65,6 +65,7 @@ options:
             - I(visible_name=yes) to search by visible name,  I(visible_name=no) to search by technical name.
         type: bool
         default: 'yes'
+        version_added: '2.0.0'
 
 extends_documentation_fragment:
 - community.zabbix.zabbix

--- a/plugins/modules/zabbix_maintenance.py
+++ b/plugins/modules/zabbix_maintenance.py
@@ -59,9 +59,10 @@ options:
             - Type of maintenance. With data collection, or without.
         type: bool
         default: 'yes'
-    visible_name
+    visible_name:
         description:
-            - Type of zabbix host name to use. No: Technical name of the host. Yes: Visible name of the host.
+            - Type of zabbix host name to use for identifying hosts to include in the maintenance.
+            - I(visible_name=yes) to search by visible name,  I(visible_name=no) to search by technical name.
         type: bool
         default: 'yes'
 

--- a/tests/integration/targets/test_zabbix_maintenance/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_maintenance/tasks/main.yml
@@ -35,6 +35,21 @@
     that:
       - create_maintenance_host_name_result.changed is sameas true
 
+- name: "test - Create maintenance with a host_name param and disabled visible_name"
+  zabbix_maintenance:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    name: maintenance
+    host_name: example
+    visible_name: no
+    state: present
+  register: create_maintenance_host_name_result
+
+- assert:
+    that:
+      - create_maintenance_host_name_result.changed is sameas true
+
 - name: "test - Create maintenance with a host_name param(again - expectations: no change will occur)"
   zabbix_maintenance:
     server_url: "{{ zabbix_server_url }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

If host have different names in zabbix (for example `hostname='server.example.net'`, `visible hostname='my test server'`), ansible module `zabbix_maintenance` crash, because it use [API](https://www.zabbix.com/documentation/5.0/manual/api/reference/host/object) property `name`  (visible name of the host) instead of `host` (technical name of the host).

I left the current state as default. So it's backwards compatible.
But it is now possible to select the type of name using `visible_name`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_maintenance

