### PR TITLE
Add Feature for setting AllowKey on Zabbix Agent(2)

### DIFF
--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -201,7 +201,7 @@ HostInterfaceItem={{ zabbix_agent2_hostinterfaceitem }}
 ### Option: AllowKey
 # 	Optional parameter that defines AllowKey
 # 	Allow execution of those item keys that match a pattern.
-# 	Key pattern is a wildcard expression that supports “*” character to match any number of any characters.
+# 	Key pattern is a wildcard expression that supports "*" character to match any number of any characters.
 # 	Multiple key matching rules may be defined in combination with DenyKey.
 # 	The parameters are processed one by one according to their appearance order.
 
@@ -366,7 +366,9 @@ TLSConnect={{ zabbix_agent2_tlsconnect }}
 #
 # Mandatory: yes, if TLS certificate or PSK parameters are defined (even for 'unencrypted' connection)
 # Default:
-{% if zabbix_agent2_tlsaccept is defined and zabbix_agent2_tlsaccept %}
+{% if zabbix_agent_connections_tlsaccept is defined and zabbix_agent_connections_tlsaccept %}
+TLSAccept={{ zabbix_agent_connections_tlsaccept }}
+{% elif zabbix_agent2_tlsaccept is defined and zabbix_agent2_tlsaccept %}
 TLSAccept={{ zabbix_agent2_tlsaccept }}
 {% endif %}
 

--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -198,6 +198,19 @@ HostInterface={{ zabbix_agent2_hostinterface }}
 HostInterfaceItem={{ zabbix_agent2_hostinterfaceitem }}
 {% endif %}
 
+### Option: AllowKey
+# 	Optional parameter that defines AllowKey
+# 	Allow execution of those item keys that match a pattern.
+# 	Key pattern is a wildcard expression that supports “*” character to match any number of any characters.
+# 	Multiple key matching rules may be defined in combination with DenyKey.
+# 	The parameters are processed one by one according to their appearance order.
+
+{% if zabbix_agent_allow_key is defined and zabbix_agent_allow_key %}
+{% for item in zabbix_agent_allow_key %}
+AllowKey={{ item }}
+{% endfor %}
+{% endif %}
+
 ### Option: RefreshActiveChecks
 #	How often list of active checks is refreshed, in seconds.
 #

--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -366,9 +366,7 @@ TLSConnect={{ zabbix_agent2_tlsconnect }}
 #
 # Mandatory: yes, if TLS certificate or PSK parameters are defined (even for 'unencrypted' connection)
 # Default:
-{% if zabbix_agent_connections_tlsaccept is defined and zabbix_agent_connections_tlsaccept %}
-TLSAccept={{ zabbix_agent_connections_tlsaccept }}
-{% elif zabbix_agent2_tlsaccept is defined and zabbix_agent2_tlsaccept %}
+{% if zabbix_agent2_tlsaccept is defined and zabbix_agent2_tlsaccept %}
 TLSAccept={{ zabbix_agent2_tlsaccept }}
 {% endif %}
 

--- a/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
@@ -292,8 +292,8 @@ TLSConnect={{ zabbix_agent_tlsconnect }}
 # Mandatory: yes, if TLS certificate or PSK parameters are defined (even for 'unencrypted' connection)
 # Default:
 # TLSAccept=unencrypted
-{% if zabbix_agent2_tlsaccept is defined and zabbix_agent2_tlsaccept %}
-TLSAccept={{ zabbix_agent2_tlsaccept }}
+{% if zabbix_agent_tlsaccept is defined and zabbix_agent_tlsaccept %}
+TLSAccept={{ zabbix_agent_tlsaccept }}
 {% endif %}
 
 ### Option: TLSCAFile

--- a/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
@@ -292,9 +292,7 @@ TLSConnect={{ zabbix_agent_tlsconnect }}
 # Mandatory: yes, if TLS certificate or PSK parameters are defined (even for 'unencrypted' connection)
 # Default:
 # TLSAccept=unencrypted
-{% if zabbix_agent_connections_tlsaccept is defined and zabbix_agent_connections_tlsaccept %}
-TLSAccept={{ zabbix_agent_connections_tlsaccept }}
-{% elif zabbix_agent2_tlsaccept is defined and zabbix_agent2_tlsaccept %}
+{% if zabbix_agent2_tlsaccept is defined and zabbix_agent2_tlsaccept %}
 TLSAccept={{ zabbix_agent2_tlsaccept }}
 {% endif %}
 

--- a/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
@@ -144,7 +144,7 @@ HostMetadataItem={{ zabbix_agent_hostmetadataitem }}
 ### Option: AllowKey
 # 	Optional parameter that defines AllowKey
 # 	Allow execution of those item keys that match a pattern.
-# 	Key pattern is a wildcard expression that supports “*” character to match any number of any characters.
+# 	Key pattern is a wildcard expression that supports "*" character to match any number of any characters.
 # 	Multiple key matching rules may be defined in combination with DenyKey.
 # 	The parameters are processed one by one according to their appearance order.
 
@@ -292,8 +292,10 @@ TLSConnect={{ zabbix_agent_tlsconnect }}
 # Mandatory: yes, if TLS certificate or PSK parameters are defined (even for 'unencrypted' connection)
 # Default:
 # TLSAccept=unencrypted
-{% if zabbix_agent_tlsaccept is defined and zabbix_agent_tlsaccept %}
-TLSAccept={{ zabbix_agent_tlsaccept }}
+{% if zabbix_agent_connections_tlsaccept is defined and zabbix_agent_connections_tlsaccept %}
+TLSAccept={{ zabbix_agent_connections_tlsaccept }}
+{% elif zabbix_agent2_tlsaccept is defined and zabbix_agent2_tlsaccept %}
+TLSAccept={{ zabbix_agent2_tlsaccept }}
 {% endif %}
 
 ### Option: TLSCAFile

--- a/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
@@ -141,6 +141,19 @@ HostMetadata={{ zabbix_agent_hostmetadata }}
 HostMetadataItem={{ zabbix_agent_hostmetadataitem }}
 {% endif %}
 
+### Option: AllowKey
+# 	Optional parameter that defines AllowKey
+# 	Allow execution of those item keys that match a pattern.
+# 	Key pattern is a wildcard expression that supports “*” character to match any number of any characters.
+# 	Multiple key matching rules may be defined in combination with DenyKey.
+# 	The parameters are processed one by one according to their appearance order.
+
+{% if zabbix_agent_allow_key is defined and zabbix_agent_allow_key %}
+{% for item in zabbix_agent_allow_key %}
+AllowKey={{ item }}
+{% endfor %}
+{% endif %}
+
 ### option: refreshactivechecks
 #       how often list of active checks is refreshed, in seconds.
 #


### PR DESCRIPTION
##### SUMMARY
Introducing new Attribute "zabbix_agent_allow_key" to configure Zabbix Agent(2) AllowKey Configuration.

##### ISSUE TYPE
Fix #306 

##### COMPONENT NAME
roles/zabbix_agent/templates/zabbix_agent(2/d).conf.j2

##### ADDITIONAL INFORMATION
Example:
zabbix_agent_allow_key: 
  - system.run[zabbix_proxy -R snmp_cache_reload]
  - system.run[*]

Config Output:
AllowKey=system.run[zabbix_proxy -R snmp_cache_reload]
AllowKey=system.run[*]
