### PR TITLE
[+] Added zabbix_server_startlldprocessors var for ZBX Server

### DIFF
--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -76,6 +76,7 @@ zabbix_server_historystoragedateindex: 0
 zabbix_server_exportdir:
 zabbix_server_exportfilesize: 1G
 zabbix_server_startpollers: 5
+zabbix_server_startlldprocessors: 2
 zabbix_server_startipmipollers: 0
 zabbix_server_startpollersunreachable: 1
 zabbix_server_starttrappers: 5

--- a/roles/zabbix_server/templates/zabbix_server.conf.j2
+++ b/roles/zabbix_server/templates/zabbix_server.conf.j2
@@ -173,12 +173,14 @@ StartPollers={{ zabbix_server_startpollers }}
 #
 StartIPMIPollers={{ zabbix_server_startipmipollers }}
 
+{% if zabbix_version is version('4.2', '>=') %}
 ### option: StartLLDProcessors
 #	Number of pre-forked instances of low-level discovery (LLD) workers.
 # The LLD manager process is automatically started when an LLD worker is started.
 # This parameter is supported since Zabbix 4.2.0.
 # 
 StartLLDProcessors={{ zabbix_server_startlldprocessors }}
+{% endif %}
 
 {% if zabbix_version is version('4.2', '>=') %}
 ### Option: StartPreprocessors

--- a/roles/zabbix_server/templates/zabbix_server.conf.j2
+++ b/roles/zabbix_server/templates/zabbix_server.conf.j2
@@ -173,6 +173,13 @@ StartPollers={{ zabbix_server_startpollers }}
 #
 StartIPMIPollers={{ zabbix_server_startipmipollers }}
 
+### option: StartLLDProcessors
+#	Number of pre-forked instances of low-level discovery (LLD) workers.
+# The LLD manager process is automatically started when an LLD worker is started.
+# This parameter is supported since Zabbix 4.2.0.
+# 
+StartLLDProcessors={{ zabbix_server_startlldprocessors }}
+
 {% if zabbix_version is version('4.2', '>=') %}
 ### Option: StartPreprocessors
 #       Number of pre-forked instances of preprocessing workers.


### PR DESCRIPTION
##### SUMMARY

Added variable `StartLLDProcessors`. Allows to change default value of ZBX Server using `ansible-playbook`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- zabbix_server

##### ADDITIONAL INFORMATION

If you want to change default variable of ZBX Server — `StartLLDProcessors` _(default: 2)_ using current Ansible Collection, you can't do it, because the template does not have it, nor does the default value for this variable.

I added setting to _roles/zabbix_server/templates/zabbix_server.conf.j2_ and added variable **zabbix_server_startlldprocessors** to _roles/zabbix_server/defaults/main.yml_. 

Have a nice day!
