### PR TITLE
reintroduced test_zabbix_maintenance without failing idempotency checks

### DIFF
--- a/tests/integration/targets/test_zabbix_maintenance/aliases
+++ b/tests/integration/targets/test_zabbix_maintenance/aliases
@@ -1,1 +1,0 @@
-disabled

--- a/tests/integration/targets/test_zabbix_maintenance/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_maintenance/tasks/main.yml
@@ -35,6 +35,7 @@
     that:
       - create_maintenance_host_name_result.changed is sameas true
 
+# This check doesn't modify maintenace object and thus will be changed=false unless there are hosts without visible name defined
 - name: "test - Create maintenance with a host_name param and disabled visible_name"
   zabbix_maintenance:
     server_url: "{{ zabbix_server_url }}"
@@ -46,9 +47,12 @@
     state: present
   register: create_maintenance_host_name_result
 
-- assert:
-    that:
-      - create_maintenance_host_name_result.changed is sameas true
+
+# BUGGED: sometimes when test "lags" and some time passes since previous tasks,
+# maintenance_start will not match and be updated, thus resulting in changed
+#- assert:
+#    that:
+#      - create_maintenance_host_name_result.changed is sameas false
 
 - name: "test - Create maintenance with a host_name param(again - expectations: no change will occur)"
   zabbix_maintenance:
@@ -60,9 +64,11 @@
     state: present
   register: create_maintenance_host_name_again_result
 
-- assert:
-    that:
-      - create_maintenance_host_name_again_result.changed is sameas false
+# BUGGED: sometimes when test "lags" and some time passes since previous tasks,
+# maintenance_start will not match and be updated, thus resulting in changed
+#- assert:
+#    that:
+#      - create_maintenance_host_name_again_result.changed is sameas false
 
 - name: "test - Update maintenance with a desc param"
   zabbix_maintenance:
@@ -92,9 +98,11 @@
     state: present
   register: update_maintenance_desc_again_result
 
-- assert:
-    that:
-      - update_maintenance_desc_again_result.changed is sameas false
+# BUGGED: sometimes when test "lags" and some time passes since previous tasks,
+# maintenance_start will not match and be updated, thus resulting in changed
+#- assert:
+#    that:
+#      - update_maintenance_desc_again_result.changed is sameas false
 
 - name: "test - Update maintenance with a collect_data"
   zabbix_maintenance:
@@ -124,9 +132,11 @@
     state: present
   register: update_maintenance_collect_data_again_result
 
-- assert:
-    that:
-      - update_maintenance_collect_data_again_result.changed is sameas false
+# BUGGED: sometimes when test "lags" and some time passes since previous tasks,
+# maintenance_start will not match and be updated, thus resulting in changed
+#- assert:
+#    that:
+#      - update_maintenance_collect_data_again_result.changed is sameas false
 
 - name: "test - Update maintenance with a minutes param"
   zabbix_maintenance:
@@ -158,9 +168,11 @@
     state: present
   register: update_maintenance_minutes_again_result
 
-- assert:
-    that:
-      - update_maintenance_minutes_again_result.changed is sameas false
+# BUGGED: sometimes when test "lags" and some time passes since previous tasks,
+# maintenance_start will not match and be updated, thus resulting in changed
+#- assert:
+#    that:
+#      - update_maintenance_minutes_again_result.changed is sameas false
 
 - name: "test - Update maintenance with a host_groups param"
   zabbix_maintenance:
@@ -198,9 +210,11 @@
     state: present
   register: update_maintenance_host_groups_again_result
 
-- assert:
-    that:
-      - update_maintenance_host_groups_again_result.changed is sameas false
+# BUGGED: sometimes when test "lags" and some time passes since previous tasks,
+# maintenance_start will not match and be updated, thus resulting in changed
+#- assert:
+#    that:
+#      - update_maintenance_host_groups_again_result.changed is sameas false
 
 - name: "test - Update maintenance with change host_name to host_names param"
   zabbix_maintenance:
@@ -242,9 +256,11 @@
     state: present
   register: update_maintenance_host_names_again_result
 
-- assert:
-    that:
-      - update_maintenance_host_names_again_result.changed is sameas false
+# BUGGED: sometimes when test "lags" and some time passes since previous tasks,
+# maintenance_start will not match and be updated, thus resulting in changed
+#- assert:
+#    that:
+#      - update_maintenance_host_names_again_result.changed is sameas false
 
 - name: "test - Delete maintenance"
   zabbix_maintenance:


### PR DESCRIPTION
##### SUMMARY
Reintroduce failing zabbix_maintenance tests, but without checking idempotency as that is failing due to `maintenace_start` always being `now()`. (And we know that sometimes `now() != now()` between two tests, especially if there is a lag)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tests/integration/targets/test_zabbix_maintenance