### PR TITLE
Possibility to disable StatusPort

### DIFF
--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -104,7 +104,9 @@ ListenIP={{ zabbix_agent2_listenip }}
 # Range: 1024-32767
 # Default:
 # StatusPort=
+{% if zabbix_agent2_statusport is defined and zabbix_agent2_statusport %}
 StatusPort={{ zabbix_agent2_statusport }}
+{% endif %}
 
 ##### Active checks related
 


### PR DESCRIPTION
Disable StatusPort if variable zabbix_agent2_statusport not defined #371 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.zabbix.zabbix_agent