### PR TITLE
zabbix_user: Remove part of the default values from the parameters of the module.

### DIFF
--- a/changelogs/fragments/382-zabbix_user.yml
+++ b/changelogs/fragments/382-zabbix_user.yml
@@ -1,2 +1,2 @@
-minor_changes
+minor_changes:
   - zabbix_user - removed some default values because a configuration should be changed only if specified a parameter (https://github.com/ansible-collections/community.zabbix/pull/382).

--- a/changelogs/fragments/382-zabbix_user.yml
+++ b/changelogs/fragments/382-zabbix_user.yml
@@ -1,0 +1,2 @@
+minor_changes
+  - zabbix_user - removed some default values because a configuration should be changed only if specified a parameter (https://github.com/ansible-collections/community.zabbix/pull/382).

--- a/changelogs/fragments/382-zabbix_user.yml
+++ b/changelogs/fragments/382-zabbix_user.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - zabbix_user - removed some default values because a configuration should be changed only if specified a parameter (https://github.com/ansible-collections/community.zabbix/pull/382).
+  - zabbix_user - removed some of the default values because a configuration should be changed only if specified as a parameter (https://github.com/ansible-collections/community.zabbix/pull/382).

--- a/plugins/module_utils/helpers.py
+++ b/plugins/module_utils/helpers.py
@@ -144,6 +144,7 @@ def helper_compare_dictionaries(d1, d2, diff_dict):
                 diff_dict[k] = v
     return diff_dict
 
+
 def helper_normalize_data(data, del_keys=[]):
     """
     Delete None parameter or specified keys from data.

--- a/plugins/module_utils/helpers.py
+++ b/plugins/module_utils/helpers.py
@@ -145,7 +145,7 @@ def helper_compare_dictionaries(d1, d2, diff_dict):
     return diff_dict
 
 
-def helper_normalize_data(data, del_keys=[]):
+def helper_normalize_data(data, del_keys=None):
     """
     Delete None parameter or specified keys from data.
 
@@ -156,6 +156,9 @@ def helper_normalize_data(data, del_keys=[]):
         data: None parameter removed data
         del_keys: deleted keys
     """
+    if del_keys is None:
+        del_keys = []
+
     for key, value in data.items():
         if value is None:
             del_keys.append(key)

--- a/plugins/module_utils/helpers.py
+++ b/plugins/module_utils/helpers.py
@@ -143,3 +143,24 @@ def helper_compare_dictionaries(d1, d2, diff_dict):
             if v != d2[k]:
                 diff_dict[k] = v
     return diff_dict
+
+def helper_normalize_data(data, del_keys=[]):
+    """
+    Delete None parameter or specified keys from data.
+
+    Parameters:
+        data: dictionary
+
+    Returns:
+        data: None parameter removed data
+        del_keys: deleted keys
+    """
+    for key, value in data.items():
+        if value is None:
+            del_keys.append(key)
+
+    for key in del_keys:
+        if key in data.keys():
+            del data[key]
+
+    return data, del_keys

--- a/plugins/modules/zabbix_user.py
+++ b/plugins/modules/zabbix_user.py
@@ -612,9 +612,6 @@ def main():
         required_if=[
             ['state', 'present', ['usrgrps', 'refresh', 'rows_per_page', 'type']]
         ],
-        mutually_exclusive=[
-            ('autologin', 'autologout')
-        ],
         supports_check_mode=True
     )
 

--- a/plugins/modules/zabbix_user.py
+++ b/plugins/modules/zabbix_user.py
@@ -98,14 +98,10 @@ options:
     refresh:
         description:
             - Automatic refresh period in seconds.
-            - The default value will be removed at the version 2.0.0.
-        default: '30'
         type: str
     rows_per_page:
         description:
             - Amount of object rows to show per page.
-            - The default value will be removed at the version 2.0.0.
-        default: '50'
         type: str
     after_login_url:
         description:
@@ -585,8 +581,8 @@ def main():
         theme=dict(type='str', choices=['default', 'blue-theme', 'dark-theme']),
         autologin=dict(type='bool'),
         autologout=dict(type='str'),
-        refresh=dict(type='str', default='30'),
-        rows_per_page=dict(type='str', default='50'),
+        refresh=dict(type='str'),
+        rows_per_page=dict(type='str'),
         after_login_url=dict(type='str'),
         user_medias=dict(type='list', elements='dict',
                          options=dict(mediatype=dict(type='str', default='Email'),
@@ -616,7 +612,7 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         required_if=[
-            ['state', 'present', ['usrgrps', 'refresh', 'rows_per_page']]
+            ['state', 'present', ['usrgrps']]
         ],
         supports_check_mode=True
     )

--- a/tests/integration/targets/test_zabbix_user/tasks/for_zabbix_50_lower.yml
+++ b/tests/integration/targets/test_zabbix_user/tasks/for_zabbix_50_lower.yml
@@ -1019,7 +1019,7 @@
       that:
         - delete_existing_user_result.changed is sameas true
 
-# The tests are to check the patch for PR hasn’t a problem.
+# The tests are to check the patch for PR hasn't a problem.
 # https://github.com/ansible-collections/community.zabbix/pull/382
 - name: test - Create a zabbix user with minimum parameters
   zabbix_user:

--- a/tests/integration/targets/test_zabbix_user/tasks/for_zabbix_50_lower.yml
+++ b/tests/integration/targets/test_zabbix_user/tasks/for_zabbix_50_lower.yml
@@ -1018,3 +1018,77 @@
   - assert:
       that:
         - delete_existing_user_result.changed is sameas true
+
+# The tests are to check the patch for PR hasn’t a problem.
+# https://github.com/ansible-collections/community.zabbix/pull/382
+- name: test - Create a zabbix user with minimum parameters
+  zabbix_user:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    alias: example2
+    usrgrps:
+      - Guests
+    passwd: password
+  register: create_zabbix_user_with_minimum_params_result
+
+- assert:
+    that:
+      - create_zabbix_user_with_minimum_params_result.changed is sameas true
+
+- name: test - Create a zabbix user with minimum parameters(again)
+  zabbix_user:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    alias: example2
+    usrgrps:
+      - Guests
+    passwd: password
+  register: create_zabbix_user_with_minimum_params_result
+
+- assert:
+    that:
+      - create_zabbix_user_with_minimum_params_result.changed is sameas false
+
+- name: test - Update the parameters without role_name
+  zabbix_user:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    alias: example2
+    name: example2
+    surname: test
+    usrgrps:
+      - Guests
+    passwd: password
+  register: update_params_without_role_name_result
+
+- assert:
+    that:
+      - update_params_without_role_name_result.changed is sameas true
+
+- name: test - Update the parameters without role_name(again)
+  zabbix_user:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    alias: example2
+    name: example2
+    surname: test
+    usrgrps:
+      - Guests
+    passwd: password
+  register: update_params_without_role_name_result
+
+- assert:
+    that:
+      - update_params_without_role_name_result.changed is sameas false
+
+- name: test - Delete existing user
+  zabbix_user:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    alias: example2
+    state: absent

--- a/tests/integration/targets/test_zabbix_user/tasks/for_zabbix_52_higher.yml
+++ b/tests/integration/targets/test_zabbix_user/tasks/for_zabbix_52_higher.yml
@@ -1075,3 +1075,79 @@
   - assert:
       that:
         - delete_existing_user_result.changed is sameas true
+
+# The tests are to check the patch for PR hasn’t a problem.
+# https://github.com/ansible-collections/community.zabbix/pull/382
+- name: test - Create a zabbix user with minimum parameters
+  zabbix_user:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    alias: example2
+    usrgrps:
+      - Guests
+    passwd: password
+    role_name: "User role"
+  register: create_zabbix_user_with_minimum_params_result
+
+- assert:
+    that:
+      - create_zabbix_user_with_minimum_params_result.changed is sameas true
+
+- name: test - Create a zabbix user with minimum parameters(again)
+  zabbix_user:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    alias: example2
+    usrgrps:
+      - Guests
+    passwd: password
+    role_name: "User role"
+  register: create_zabbix_user_with_minimum_params_result
+
+- assert:
+    that:
+      - create_zabbix_user_with_minimum_params_result.changed is sameas false
+
+- name: test - Update the parameters without role_name
+  zabbix_user:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    alias: example2
+    name: example2
+    surname: test
+    usrgrps:
+      - Guests
+    passwd: password
+  register: update_params_without_role_name_result
+
+- assert:
+    that:
+      - update_params_without_role_name_result.changed is sameas true
+
+- name: test - Update the parameters without role_name(again)
+  zabbix_user:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    alias: example2
+    name: example2
+    surname: test
+    usrgrps:
+      - Guests
+    passwd: password
+  register: update_params_without_role_name_result
+
+- assert:
+    that:
+      - update_params_without_role_name_result.changed is sameas false
+
+- name: test - Delete existing user
+  zabbix_user:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    alias: example2
+    state: absent

--- a/tests/integration/targets/test_zabbix_user/tasks/for_zabbix_52_higher.yml
+++ b/tests/integration/targets/test_zabbix_user/tasks/for_zabbix_52_higher.yml
@@ -1076,7 +1076,7 @@
       that:
         - delete_existing_user_result.changed is sameas true
 
-# The tests are to check the patch for PR hasn’t a problem.
+# The tests are to check the patch for PR hasn't a problem.
 # https://github.com/ansible-collections/community.zabbix/pull/382
 - name: test - Create a zabbix user with minimum parameters
   zabbix_user:


### PR DESCRIPTION
##### SUMMARY

This PR will remove some default values because the users want to change a configuration only if specified a parameter.
But, I'll leave part of the default value because a backward-compatible is broken if refresh and rows_per_page remove.  
(The integration test didn't be passed if refresh and row_per_page the default value remove.)  
In about those, I added the version to be removed into the documentation.

fixes: https://github.com/ansible-collections/community.zabbix/issues/380
fixes: https://github.com/ansible-collections/community.zabbix/issues/384

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/382-zabbix_user.yml
plugins/module_utils/helpers.py
plugins/modules/zabbix_user.py
tests/integration/targets/test_zabbix_user/tasks/for_zabbix_50_lower.yml
tests/integration/targets/test_zabbix_user/tasks/for_zabbix_52_higher.yml

##### ADDITIONAL INFORMATION