### PR TITLE
add documentation for zabbix_agent_allow_key

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -156,6 +156,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_agent_apt_priority`: Add a weight (`Pin-Priority`) for the APT repository.
 * `zabbix_agent_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 * `zabbix_agent_dont_detect_ip`: Default `false`. When set to `true`, it won't detect available ip addresses on the host and no need for the Python module `netaddr` to be installed.
+* `zabbix_agent_allow_key`: list of AllowKey configurations.
 
 ### Zabbix Agent vs Zabbix Agent 2 configuration
 


### PR DESCRIPTION
##### SUMMARY
Adds documentation for https://github.com/ansible-collections/community.zabbix/pull/358

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zabbix_agent role documentation
