### PR TITLE
Bug Fix PSK value issue related to #109

### DIFF
--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -141,7 +141,7 @@ zabbix_proxy_tlspskidentity:
 
 zabbix_proxy_tls_config:
   no_encryption: 'no_encryption'
-  PSK: 'PSK'
+  psk: 'PSK'
   certificate: 'certificate'
 
 # Zabbix API stuff


### PR DESCRIPTION
##### SUMMARY
Fixes #109 by changing the value to lowercase.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_proxy role

##### ADDITIONAL INFORMATION
Before fix Zabbix Proxy would fail to start
```paste below
TASK [community.zabbix.zabbix_proxy : zabbix-proxy started] ****************************************************************************************
fatal: [hostname]: FAILED! => {"changed": false, "msg": "Unable to start service zabbix-proxy: Job for zabbix-proxy.service failed because the control process exited with error code.\nSee \"systemctl status zabbix-proxy.service\" and \"journalctl -xe\" for details.\n"}

May 28 07:14:17 hostname zabbix_proxy[29974]: zabbix_proxy [29974]: ERROR: invalid value of "TLSAccept" parameter
May 28 07:14:17 hostname systemd[1]: zabbix-proxy.service: Control process exited, code=exited status=1
May 28 07:14:17 hostname systemd[1]: zabbix-proxy.service: Failed with result 'exit-code'.
May 28 07:14:17 hostname systemd[1]: Failed to start Zabbix Proxy.
-- Subject: Unit zabbix-proxy.service has failed
```

After the change
```
TASK [community.zabbix.zabbix_proxy : zabbix-proxy started] ****************************************************************************************
ok: [hostname]


 zabbix-proxy.service - Zabbix Proxy
   Loaded: loaded (/lib/systemd/system/zabbix-proxy.service; enabled; vendor preset: enabled)
   Active: active (running) since Fri 2021-05-28 16:55:18 UTC; 3min 7s ago
  Process: 2419 ExecStart=/usr/sbin/zabbix_proxy -c $CONFFILE (code=exited, status=0/SUCCESS)
 Main PID: 2439 (zabbix_proxy)
```