### PR TITLE
Update zabbix.yml

### DIFF
--- a/roles/zabbix_agent/vars/zabbix.yml
+++ b/roles/zabbix_agent/vars/zabbix.yml
@@ -60,8 +60,6 @@ sign_keys:
     xenial:
       sign_key: E709712C
   "42":
-    focal:
-      sign_key: A14FE591
     eoan:
       sign_key: A14FE591
     cosmic:


### PR DESCRIPTION
Zabbix repo does not contain ubuntu focal on zabbix version 4.2: https://repo.zabbix.com/zabbix/4.2/ubuntu/dists/

SUMMARY
Zabbix repo does not contain ubuntu focal on zabbix version 4.2: https://repo.zabbix.com/zabbix/4.2/ubuntu/dists/

Deployments to focal (20.04) specifying 4.2 will fail.

ISSUE TYPE
Bugfix Pull Request
COMPONENT NAME
Affects the "zabbix_version:" variable.

ADDITIONAL INFORMATION