### PR TITLE
fixed zbx_host idempotency with multiple host interfaces of the same …

### DIFF
--- a/changelogs/fragments/391-zabbix_host-intf_idempotency_fix.yml
+++ b/changelogs/fragments/391-zabbix_host-intf_idempotency_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- zabbix_host - fixed issue where module was idempotent when multiple host interfaces of the same type were present (https://github.com/ansible-collections/community.zabbix/pull/391)

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -691,6 +691,8 @@ class Host(ZabbixBase):
         if sorted(i_ports) != sorted(exist_i_ports):
             return True
 
+        _matched_intfs = []
+
         for exist_interface in exist_interfaces:
             exist_interface_port = str(exist_interface['port'])
 
@@ -699,6 +701,10 @@ class Host(ZabbixBase):
                 exist_interface['details'] = {}
 
             for interface in interfaces:
+                # ensure one interface is not matched multiple times
+                if interface in _matched_intfs:
+                    continue
+
                 if str(interface['port']) == exist_interface_port:
                     for key in interface.keys():
                         # since 5.0, zabbix API returns details for each host interface, but only SNMP is not empty
@@ -718,6 +724,11 @@ class Host(ZabbixBase):
 
                         elif str(exist_interface[key]) != str(interface[key]):
                             return True
+
+                # if the code got here, that means interfaces did match, remove the one matched and break loop for
+                # current intf, otherwise it would start comparing to next intf of the same type and not match
+                _matched_intfs.append(interface)
+                break
 
         return False
 

--- a/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
+++ b/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
@@ -994,6 +994,48 @@
           that:
               - "zabbix_host1 is changed"
 
+- name: "reset interfaces to two of the same type"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    interfaces:
+      - type: "1"
+        main: 1
+        useip: 1
+        ip: 127.0.0.1
+      - type: "1"
+        useip: 1
+        ip: 127.0.1.1
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "reset interfaces to two of the same type (again)"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    interfaces:
+      - type: "1"
+        main: 1
+        useip: 1
+        ip: 127.0.0.1
+      - type: "1"
+        useip: 1
+        ip: 127.0.1.1
+  register: zabbix_host1
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
+
 - name: "test: add IPMI settings"
   zabbix_host:
     server_url: "{{ zabbix_server_url }}"

--- a/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
+++ b/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
@@ -994,6 +994,7 @@
           that:
               - "zabbix_host1 is changed"
 
+# https://github.com/ansible-collections/community.zabbix/pull/391
 - name: "reset interfaces to two of the same type"
   zabbix_host:
     server_url: "{{ zabbix_server_url }}"


### PR DESCRIPTION
…type

##### SUMMARY
Fixes #389 

It seems that loop where we compare existing interfaces to user-provided interfaces is checking each existing interface to ALL user-provided interfaces. Even the ones that are already matched are compared.

Additionally, if match is found, loop continues onward to next interface where it will detect difference, because it always compares interfaces that should not match.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/zabbix_host.py
tests/integration/targets/test_zabbix_host/

##### ADDITIONAL INFORMATION
All versions should be affected by this