### PR TITLE
fix: always use zabbix_agent_listenport for creating/updating Zabbix host via API

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -83,7 +83,7 @@ zabbix_agent_interfaces:
     useip: "{{ zabbix_useuip }}"
     ip: "{{ zabbix_agent_ip }}"
     dns: "{{ ansible_fqdn }}"
-    port: "{{ zabbix_agent_listenport }}"
+    port: "{{ (zabbix_agent2 == True) | ternary(zabbix_agent2_listenport, zabbix_agent_listenport) }}"
 
 zabbix_agent_firewall_enable: False
 zabbix_agent_firewalld_enable: False


### PR DESCRIPTION
…host even when agent2 is used

##### SUMMARY
use `zabbix_agent2_listenport` if `zabbix_agent2` is used for create/update host in Zabbix via API

Fixes: #399 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`roles/zabbix_agent/defaults/main.yml`

##### ADDITIONAL INFORMATION
