### PR TITLE
Add support for SAML certificate to zabbix.conf.php

### DIFF
--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -112,6 +112,9 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_htpasswd_file`: Default: `/etc/zabbix/web/htpasswd`. Allows the change the default path to the htpasswd file.
 * `zabbix_web_htpasswd_users`: (Optional) Dictionary for creating users via `htpasswd_user` and passphrases via `htpasswd_pass` in htpasswd file.
 * `zabbix_web_allowlist_ips`: (Optional) Allow web access at webserver level to a list of defined IPs or CIDR.
+* `zabbix_saml_idp_crt`: (Optional) TLS Certificate of the Identity Provider used for SAML authentication
+* `zabbix_saml_sp_crt`: (Optional) Public TLS certificate of Zabbix as Service Provider
+* `zabbix_saml_sp_key`: (Optional) Private TLS certificate of Zabbix as Service Provider
 
 #### Apache configuration
 

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -112,9 +112,9 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_htpasswd_file`: Default: `/etc/zabbix/web/htpasswd`. Allows the change the default path to the htpasswd file.
 * `zabbix_web_htpasswd_users`: (Optional) Dictionary for creating users via `htpasswd_user` and passphrases via `htpasswd_pass` in htpasswd file.
 * `zabbix_web_allowlist_ips`: (Optional) Allow web access at webserver level to a list of defined IPs or CIDR.
-* `zabbix_saml_idp_crt`: (Optional) TLS Certificate of the Identity Provider used for SAML authentication
-* `zabbix_saml_sp_crt`: (Optional) Public TLS certificate of Zabbix as Service Provider
-* `zabbix_saml_sp_key`: (Optional) Private TLS certificate of Zabbix as Service Provider
+* `zabbix_saml_idp_crt`: (Optional) The path to the certificate of the Identity Provider used for SAML authentication
+* `zabbix_saml_sp_crt`: (Optional) The path to the public certificate of Zabbix as Service Provider
+* `zabbix_saml_sp_key`: (Optional) The path to the private certificate of Zabbix as Service Provider
 
 #### Apache configuration
 

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -123,3 +123,8 @@ zabbix_server_history_types:
 
 selinux_allow_zabbix_can_network: False
 _zabbix_web_apache_php_addition: False
+
+# SAML certificates
+# zabbix_saml_idp_crt:
+# zabbix_saml_sp_crt:
+# zabbix_saml_sp_key:

--- a/roles/zabbix_web/templates/zabbix.conf.php.j2
+++ b/roles/zabbix_web/templates/zabbix.conf.php.j2
@@ -39,4 +39,14 @@ $DB['DOUBLE_IEEE754']   = true;
 putenv("{{env}}={{val}}");
 {% endfor %}
 {% endif %}
+
+{% if zabbix_saml_idp_crt is defined %}
+$SSO['IDP_CERT'] = '{{ zabbix_saml_idp_crt }}';
+{% endif %}
+{% if zabbix_saml_sp_crt is defined %}
+$SSO['SP_CERT'] = '{{ zabbix_saml_sp_crt }}';
+{% endif %}
+{% if zabbix_saml_sp_key is defined %}
+$SSO['SP_KEY'] = '{{ zabbix_saml_sp_key }}';
+{% endif %}
 ?>


### PR DESCRIPTION
##### SUMMARY
This adds support for setting the certificates you need to use SAML authentication with Zabbix: https://www.zabbix.com/documentation/current/manual/web_interface/frontend_sections/administration/authentication#saml_authentication

These certificates need to be set up in the config file, the rest can be done from the web UI.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
Add support for certificates for SAML authentication
