### PR TITLE
zabbix_agent_listeninterface validity check fix

### DIFF
--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -36,8 +36,8 @@
   fail:
     msg: "The specified network interface does not exist"
   when:
-    - zabbix_agent_listeninterface | bool
-    - (zabbix_agent_listeninterface not in ansible_all_ipv4_addresses)
+    - (zabbix_agent_listeninterface)
+    - (zabbix_agent_listeninterface not in ansible_interfaces)
   tags:
     - zabbix-agent
     - config


### PR DESCRIPTION
SUMMARY
The incoming `zabbix_agent_listeninterface` variable was being used to check against `ansible_all_ipv4_addresses` which doesn't make sense. Updated to check that the value for `zabbix_agent_listeninterface` looks at the list in the `ansible_interfaces` variable instead.

Also update how Ansible is looking at the `zabbix_agent_listeninterface` variable to verify that it exists and is not blank.

`zabbix_agent_listeninterface | bool` returns False even if it's defined.

`(zabbix_agent_listeninterface)` is the proper check here.

ISSUE TYPE
Bugfix Pull Request
COMPONENT NAME
Zabbix Agent