### PR TITLE
Add ability to define DenyKey in zabbix_agentd.conf and zabbix_agent2.conf

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -157,6 +157,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_agent_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 * `zabbix_agent_dont_detect_ip`: Default `false`. When set to `true`, it won't detect available ip addresses on the host and no need for the Python module `netaddr` to be installed.
 * `zabbix_agent_allow_key`: list of AllowKey configurations.
+* `zabbix_agent_deny_key`: list of DenyKey configurations.
 
 ### Zabbix Agent vs Zabbix Agent 2 configuration
 

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -18,6 +18,8 @@ zabbix_agent_src_reinstall: False
 zabbix_agent_apt_priority:
 zabbix_agent_conf_mode: "0644"
 zabbix_agent_dont_detect_ip: False
+zabbix_agent_allow_key: []
+zabbix_agent_deny_key: []
 
 # Selinux related vars 
 selinux_allow_zabbix_run_sudo: False

--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -213,6 +213,24 @@ AllowKey={{ item }}
 {% endfor %}
 {% endif %}
 
+### Option: DenyKey
+#   Deny execution of items keys matching pattern.
+#   Multiple keys matching rules may be defined in combination with AllowKey.
+#   Key pattern is wildcard expression, which support "*" character to match any number of any characters in certain position. It might be used in both key name and key arguments.
+#   Parameters are processed one by one according their appearance order.
+#   If no AllowKey or DenyKey rules defined, all keys are allowed.
+#       Unless another system.run[*] rule is specified DenyKey=system.run[*] is added by default.
+#
+# Mandatory: no
+# Default:
+# DenyKey=system.run[*]
+
+{% if zabbix_agent_deny_key is defined and zabbix_agent_deny_key %}
+{% for item in zabbix_agent_deny_key %}
+DenyKey={{ item }}
+{% endfor %}
+{% endif %}
+
 ### Option: RefreshActiveChecks
 #	How often list of active checks is refreshed, in seconds.
 #

--- a/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
@@ -141,6 +141,8 @@ HostMetadata={{ zabbix_agent_hostmetadata }}
 HostMetadataItem={{ zabbix_agent_hostmetadataitem }}
 {% endif %}
 
+
+
 ### Option: AllowKey
 # 	Optional parameter that defines AllowKey
 # 	Allow execution of those item keys that match a pattern.
@@ -151,6 +153,24 @@ HostMetadataItem={{ zabbix_agent_hostmetadataitem }}
 {% if zabbix_agent_allow_key is defined and zabbix_agent_allow_key %}
 {% for item in zabbix_agent_allow_key %}
 AllowKey={{ item }}
+{% endfor %}
+{% endif %}
+
+### Option: DenyKey
+#   Deny execution of items keys matching pattern.
+#   Multiple keys matching rules may be defined in combination with AllowKey.
+#   Key pattern is wildcard expression, which support "*" character to match any number of any characters in certain position. It might be used in both key name and key arguments.
+#   Parameters are processed one by one according their appearance order.
+#   If no AllowKey or DenyKey rules defined, all keys are allowed.
+#       Unless another system.run[*] rule is specified DenyKey=system.run[*] is added by default.
+#
+# Mandatory: no
+# Default:
+# DenyKey=system.run[*]
+
+{% if zabbix_agent_deny_key is defined and zabbix_agent_deny_key %}
+{% for item in zabbix_agent_deny_key %}
+DenyKey={{ item }}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
##### SUMMARY
Adds the ability to define a DenyKey option on config files for the agent.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Zabbix Agent

##### ADDITIONAL INFORMATION
DenyKey seems to be a standard option in the Zabbix Agent config file which does not seem to be part of the template in this project
