### PR TITLE
Make php socket accessible for webserver group

### DIFF
--- a/roles/zabbix_web/templates/php-fpm.conf.j2
+++ b/roles/zabbix_web/templates/php-fpm.conf.j2
@@ -10,7 +10,7 @@ listen.acl_users = {{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is de
 listen.owner = {{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is defined else zabbix_web_conf_web_user }}
 {% endif %}
 {% if zabbix_php_fpm_conf_enable_group %}
-listen.group = {{ zabbix_php_fpm_conf_group if zabbix_php_fpm_conf_group is defined else zabbix_web_conf_web_group }}
+listen.group = {{ _nginx_group if zabbix_websrv=='nginx' else _apache_group }}
 {% endif %}
 {% if zabbix_php_fpm_conf_enable_mode %}
 listen.mode = {{ zabbix_php_fpm_conf_mode }}


### PR DESCRIPTION
##### SUMMARY
Make php socket accessible for webserver group

In the current setup the user/group who owns the php-fpm socket is always identical to the user that is used to run the php-fpm processes (either zabbix_php_fpm_conf_user or zabbix_web_conf_web_user).

This produces an broken setup, as nginx/apache are running as different users (`www-data` on Debian), so they are not able to access the socket.

Fixes: #425 

I'm not entirely sure if this patch is really the nicest way to handle this, as now the user is no longer able to override the owner of the socket from a group var.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix-web

