### PR TITLE
TimescaleDB support for Zabbix Server role

### DIFF
--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -132,7 +132,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_database_creation`: Default: `True`. When you don't want to create the database including user, you can set it to False.
 * `zabbix_server_install_database_client`: Default: `True`. False does not install database client. Default true
 * `zabbix_database_sqlload`:True / False. When you don't want to load the sql files into the database, you can set it to False.
-* `zabbix_database_timescaledb`:False / True. When you want to use timescaledb extension into the database, you can set it to True.
+* `zabbix_database_timescaledb`:False / True. When you want to use timescaledb extension into the database, you can set it to True (this option only works for postgreSQL database).
 * `zabbix_server_dbencoding`: Default: `utf8`. The encoding for the MySQL database.
 * `zabbix_server_dbcollation`: Default: `utf8_bin`. The collation for the MySQL database.
 

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -132,6 +132,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_database_creation`: Default: `True`. When you don't want to create the database including user, you can set it to False.
 * `zabbix_server_install_database_client`: Default: `True`. False does not install database client. Default true
 * `zabbix_database_sqlload`:True / False. When you don't want to load the sql files into the database, you can set it to False.
+* `zabbix_database_timescaledb`:False / True. When you want to use timescaledb extension into the database, you can set it to True.
 * `zabbix_server_dbencoding`: Default: `utf8`. The encoding for the MySQL database.
 * `zabbix_server_dbcollation`: Default: `utf8_bin`. The collation for the MySQL database.
 

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -42,7 +42,7 @@ zabbix_server_database: pgsql
 zabbix_server_database_long: postgresql
 zabbix_database_creation: True
 zabbix_database_sqlload: True
-zabbix_database_timescaledb: True
+zabbix_database_timescaledb: False
 zabbix_server_dbtlsconnect:
 zabbix_server_dbtlscafile:
 zabbix_server_dbtlscertfile:

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -42,6 +42,7 @@ zabbix_server_database: pgsql
 zabbix_server_database_long: postgresql
 zabbix_database_creation: True
 zabbix_database_sqlload: True
+zabbix_database_timescaledb: True
 zabbix_server_dbtlsconnect:
 zabbix_server_dbtlscafile:
 zabbix_server_dbtlscertfile:

--- a/roles/zabbix_server/tasks/postgresql.yml
+++ b/roles/zabbix_server/tasks/postgresql.yml
@@ -29,6 +29,11 @@
         priv: ALL
         state: present
         encrypted: yes
+    - name: "PostgreSQL | Delegated | Create timescaledb extension"
+      community.postgresql.postgresql_ext:
+        db: "{{ zabbix_server_dbname }}"
+        name: timescaledb
+      when: zabbix_database_timescaledb
   become: yes
   become_user: postgres
   delegate_to: "{{ delegated_dbhost }}"
@@ -62,6 +67,15 @@
         priv: ALL
         state: present
         encrypted: yes
+    - name: "PostgreSQL | Remote | Create timescaledb extension"
+      community.postgresql.postgresql_ext:
+        login_host: "{{ zabbix_server_pgsql_login_host | default(omit) }}"
+        login_user: "{{ zabbix_server_pgsql_login_user | default(omit) }}"
+        login_password: "{{ zabbix_server_pgsql_login_password | default(omit) }}"
+        login_unix_socket: "{{ zabbix_server_pgsql_login_unix_socket | default(omit) }}"
+        db: "{{ zabbix_server_dbname }}"
+        name: timescaledb
+      when: zabbix_database_timescaledb
   when:
     - zabbix_database_creation
     - zabbix_server_pgsql_login_host is defined
@@ -90,44 +104,26 @@
     - zabbix-server
     - database
 
-- name: "PostgreSQL | Create TimescaleDB extension"
-  shell: >
-     psql -h '{{ zabbix_server_dbhost }}'
-     -U '{{ zabbix_server_dbuser }}'
-     -d '{{ zabbix_server_dbname }}'
-     -p '{{ zabbix_server_dbport }}'
-     -c 'CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;' && touch /etc/zabbix/timescaledb_ext.done
-   args:
-     creates: /etc/zabbix/timescaledb_ext.done
-     warn: no
-   environment:
-     PGPASSWORD: "{{ zabbix_server_dbpassword }}"
-   when:
-     - zabbix_version is version('3.0', '>=')
-     - zabbix_database_timescaledb
-   tags:
-     - zabbix-server
-     - database
-
 - name: "PostgreSQL | Create TimescaleDB hypertables"
   shell: >
-     cd {{ datafiles_path }} &&
-     psql -h '{{ zabbix_server_dbhost }}'
-     -U '{{ zabbix_server_dbuser }}'
-     -d '{{ zabbix_server_dbname }}'
-     -p '{{ zabbix_server_dbport }}'
-     -f timescaledb.sql && touch /etc/zabbix/timescaledb.done
-   args:
-     creates: /etc/zabbix/timescaledb.done
-     warn: no
-   environment:
-     PGPASSWORD: "{{ zabbix_server_dbpassword }}"
-   when:
-     - zabbix_version is version('3.0', '>=')
-     - zabbix_database_timescaledb
-   tags:
-     - zabbix-server
-     - database
+    cd {{ datafiles_path }} &&
+    if [ -f timescaledb.sql.gz ]; then gunzip timescaledb.sql.gz ; fi &&
+    psql -h '{{ zabbix_server_dbhost }}'
+    -U '{{ zabbix_server_dbuser }}'
+    -d '{{ zabbix_server_dbname }}'
+    -p '{{ zabbix_server_dbport }}'
+    -f timescaledb.sql && touch /etc/zabbix/timescaledb.done
+  args:
+    creates: /etc/zabbix/timescaledb.done
+    warn: no
+  environment:
+    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
+  when:
+    - zabbix_version is version('3.0', '>=')
+    - zabbix_database_timescaledb
+  tags:
+    - zabbix-server
+    - database
 
 - name: "Get complete path"
   shell: ls -d {{ datafiles_path }}

--- a/roles/zabbix_server/tasks/postgresql.yml
+++ b/roles/zabbix_server/tasks/postgresql.yml
@@ -90,6 +90,45 @@
     - zabbix-server
     - database
 
+- name: "PostgreSQL | Create TimescaleDB extension"
+  shell: >
+     psql -h '{{ zabbix_server_dbhost }}'
+     -U '{{ zabbix_server_dbuser }}'
+     -d '{{ zabbix_server_dbname }}'
+     -p '{{ zabbix_server_dbport }}'
+     -c 'CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;' && touch /etc/zabbix/timescaledb_ext.done
+   args:
+     creates: /etc/zabbix/timescaledb_ext.done
+     warn: no
+   environment:
+     PGPASSWORD: "{{ zabbix_server_dbpassword }}"
+   when:
+     - zabbix_version is version('3.0', '>=')
+     - zabbix_database_timescaledb
+   tags:
+     - zabbix-server
+     - database
+
+- name: "PostgreSQL | Create TimescaleDB hypertables"
+  shell: >
+     cd {{ datafiles_path }} &&
+     psql -h '{{ zabbix_server_dbhost }}'
+     -U '{{ zabbix_server_dbuser }}'
+     -d '{{ zabbix_server_dbname }}'
+     -p '{{ zabbix_server_dbport }}'
+     -f timescaledb.sql && touch /etc/zabbix/timescaledb.done
+   args:
+     creates: /etc/zabbix/timescaledb.done
+     warn: no
+   environment:
+     PGPASSWORD: "{{ zabbix_server_dbpassword }}"
+   when:
+     - zabbix_version is version('3.0', '>=')
+     - zabbix_database_timescaledb
+   tags:
+     - zabbix-server
+     - database
+
 - name: "Get complete path"
   shell: ls -d {{ datafiles_path }}
   register: datafiles_path_full


### PR DESCRIPTION
##### SUMMARY
Modification of zabbix_server role to allow support of TimescaleDB.
It requires tha timescaledb is already installed (as PostgreSQL)

HINT: Include "TimescaleDB support for Zabbix Server #334"

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
TimescaleDB support for Zabbix Server

##### ADDITIONAL INFORMATION
You can use this ansible role (https://github.com/SimBou/ansible-role-timescaledb.git) to install TimescaleDB
