### PR TITLE
Allow zabbix_agent_loadmodule to be list or string

### DIFF
--- a/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
@@ -262,7 +262,13 @@ LoadModulePath={{ zabbix_agent_loadmodulepath }}
 #       It is allowed to include multiple LoadModule parameters.
 #
 {% if zabbix_agent_loadmodule is defined and zabbix_agent_loadmodule %}
+{% if zabbix_agent_loadmodule is string %}
 LoadModule={{ zabbix_agent_loadmodule }}
+{% else %}
+{% for module in zabbix_agent_loadmodule %}
+LoadModule={{ module }}
+{% endfor %}
+{% endif %}
 {% endif %}
 
 {% if zabbix_version is version_compare('3.0', '>=') %}


### PR DESCRIPTION
##### SUMMARY
This update allows the `zabbix_agent_loadmodule` to be a string or a list. This allows the author to add multiple modules to the LoadModule parameter in zabbix_agentd.conf as the comment documentation in that conf file states `It is allowed to include multiple LoadModule parameters.`

If the incoming variable is a list, the template will write out each item in the list on its own line, prepended with `LoadModule=`

If it is a string, only one line will be written out, prepended with `LoadModule=`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Zabbix Agent

##### ADDITIONAL INFORMATION
This allows the `zabbix_agent_loadmodule` variable to either be:

`zabbix_agent_loadmodule: 'i_am_a_module.so` 

or

```
zabbix_agent_loadmodule:
  - 'i_am_a_module1.so`
  - 'i_am_a_module2.so`
```