### PR TITLE
removed zabbix_win_package: zabbix_agent-{{ zabbix_version_long }}-wi…

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -205,6 +205,8 @@ zabbix_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_agent_version
 zabbix_win_install_dir: 'C:\Zabbix'
 zabbix_agent_win_logfile: 'C:\Zabbix\zabbix_agentd.log'
 zabbix_agent_win_include: 'C:\Zabbix\zabbix_agent.d\'
+zabbix_agent2_win_logfile: 'C:\Zabbix\zabbix_agent2.log'
+zabbix_agent2_win_include: 'C:\Zabbix\zabbix_agent2.d\'
 zabbix_agent_win_svc_recovery: True
 
 # macOS Related

--- a/roles/zabbix_agent/handlers/main.yml
+++ b/roles/zabbix_agent/handlers/main.yml
@@ -21,6 +21,13 @@
   when:
     - zabbix_agent_os_family == "Windows"
 
+- name: restart win zabbix agent 2
+  win_service:
+    name: "{{ zabbix_win_agent2_service }}"
+    state: restarted
+  when:
+    - zabbix_agent_os_family == "Windows"
+
 - name: restart mac zabbix agent
   command: "launchctl kickstart -k system/{{ zabbix_agent_service }}"
   become: true

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: "Set default ip address for zabbix_agent_ip"
   set_fact:
     zabbix_agent_ip: "{{ hostvars[inventory_hostname]['ansible_ip_addresses'][0] }}"
@@ -21,12 +20,20 @@
   set_fact:
     zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\win{{ windows_arch }}\zabbix_agentd.exe'
 
-- name: "Windows | Set variables specific to Zabbix 4.0"
+- name: "Windows | Set variables specific to Zabbix >= 4"
   set_fact:
+    zabbix_win_svc_name: Zabbix Agent
     zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\zabbix_agentd.exe'
   when:
     - zabbix_version_long is version('4.0.0', '>=')
-    
+
+- name: "Windows | Set variables specific to Zabbix (agent 2)"
+  set_fact:
+    zabbix_win_svc_name: Zabbix Agent 2
+    zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\zabbix_agent2.exe'
+  when:
+    - zabbix_agent2 | bool
+
 - name: "Windows | Check if Zabbix agent is present"
   win_stat:
     path: '{{ zabbix_win_exe_path }}'
@@ -53,9 +60,9 @@
     - zabbix_win_exe_info.win_file_version.product_version is version(zabbix_version_long, '<')
     - zabbix_agent_package_state == 'latest'
 
-- name: Windows | Check Zabbix service
+- name: "Windows | Check Zabbix service"
   win_service:
-    name: Zabbix Agent
+    name: "{{ zabbix_win_svc_name }}"
   register: zabbix_service_info
 
 - name: Windows | Check firewall service
@@ -65,11 +72,12 @@
 
 - name: "Windows | Stop Zabbix (Update)"
   win_service:
-    name: Zabbix Agent
+    name: "{{ zabbix_win_svc_name }}"
     start_mode: auto
     state: stopped
   when:
     - zabbix_service_info.exists
+    - update_zabbix_agent | bool
     - zabbix_service_info.state == 'running'
 
 - name: "Windows | Uninstall Zabbix (Update)"
@@ -77,6 +85,15 @@
   register: zabbix_windows_install
   when:
     - zabbix_service_info.exists
+    - update_zabbix_agent | bool
+
+- name: "Windows | Uninstall Zabbix (Update) (agent 2)"
+  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agent2.conf" --uninstall'
+  register: zabbix_windows_install
+  when:
+    - zabbix_service_info.exists
+    - update_zabbix_agent | bool
+    - zabbix_agent2 | bool
 
 - name: "Windows | Removing Zabbix Directory (Update)"
   win_file:
@@ -102,6 +119,16 @@
     - "{{ zabbix_agent_win_include }}"
   when:
     - ('.conf' not in zabbix_agent_win_include)
+
+- name: "Windows | Create directory structure, includes (agent 2)"
+  win_file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ zabbix_agent2_win_include }}"
+  when:
+    - ('.conf' not in zabbix_agent2_win_include)
+    - zabbix_agent2 | bool
 
 - name: "Windows | Place TLS-PSK file"
   win_copy:
@@ -144,12 +171,32 @@
     src: zabbix_agentd.conf.j2
     dest: '{{ zabbix_win_install_dir }}\zabbix_agentd.conf'
   notify: restart win zabbix agent
+  when:
+    - not zabbix_agent2
+
+- name: "Windows | Configure zabbix-agent2"
+  win_template:
+    src: zabbix_agentd.conf.j2
+    dest: '{{ zabbix_win_install_dir }}\zabbix_agent2.conf'
+  notify: restart win zabbix agent 2
+  when:
+    - zabbix_agent2 | bool
 
 - name: "Windows | Register Service"
   win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agentd.conf" --install'
   register: zabbix_windows_install
   args:
     creates: '{{ zabbix_win_install_dir }}\.installed'
+  when:
+    - not zabbix_agent2
+
+- name: "Windows | Register Service (agent 2)"
+  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agent2.conf" --install'
+  register: zabbix_windows_install
+  args:
+    creates: '{{ zabbix_win_install_dir }}\.installed'
+  when:
+    - zabbix_agent2 | bool
 
 - name: "Windows | Create done file so it won't register itself again"
   win_file:
@@ -159,26 +206,26 @@
 
 - name: "Windows | Set service startup mode to auto and ensure it is started"
   win_service:
-    name: Zabbix Agent
+    name: "{{ zabbix_win_svc_name }}"
     start_mode: auto
     state: started
 
 - name: "Windows | Getting Zabbix Service Recovery Settings"
-  win_shell: sc.exe qfailure "Zabbix Agent" 1100
+  win_shell: 'sc.exe qfailure "{{ zabbix_win_svc_name }}" 1100'
   register: svc_recovery
   changed_when: false
   check_mode: false
   when: zabbix_agent_win_svc_recovery
 
 - name: "Windows | Setting Zabbix Service Recovery"
-  win_shell: sc.exe failure "Zabbix Agent" actions= restart/5000/restart/10000/restart/20000 reset= 86400
+  win_shell: 'sc.exe failure "{{ zabbix_win_svc_name }}" actions= restart/5000/restart/10000/restart/20000 reset= 86400'
   when:
     - "'RESTART -- Delay' not in svc_recovery.stdout"
     - zabbix_agent_win_svc_recovery
 
 - name: "Windows | Firewall rule"
   win_firewall_rule:
-    name: Zabbix Agent
+    name: "{{ zabbix_win_svc_name }}"
     localport: "{{ zabbix_agent_listenport }}"
     action: allow
     direction: in

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -23,11 +23,10 @@
 
 - name: "Windows | Set variables specific to Zabbix 4.0"
   set_fact:
-    zabbix_win_package: zabbix_agent-{{ zabbix_version_long }}-windows-amd64.zip
     zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\zabbix_agentd.exe'
   when:
     - zabbix_version_long is version('4.0.0', '>=')
-
+    
 - name: "Windows | Check if Zabbix agent is present"
   win_stat:
     path: '{{ zabbix_win_exe_path }}'

--- a/roles/zabbix_agent/vars/Windows.yml
+++ b/roles/zabbix_agent/vars/Windows.yml
@@ -2,3 +2,4 @@
 # vars file for zabbix agent (Windows)
 
 zabbix_win_agent_service: "zabbix agent"
+zabbix_win_agent2_service: "zabbix agent 2"


### PR DESCRIPTION
Edit task for Windows deployment of agent.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Removed one line from set_fact task, because it is already set via defaults or inventory.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
set_fact

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
https://github.com/ansible-collections/community.zabbix/issues/430

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
variable is already set and every run overwrites value.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

TASK [show some vars] **********************************************************
task path: /tmp/awx_33919_lenslep2/project/playbooks/zabbix/zabbix_agent_windows.yml:9
Tuesday 27 July 2021 07:46:09 +0000 (0:00:10.962) 0:00:11.003 **********
ok: [pmw0180-rds0001] => {
"msg": [
"zabbix_win_package: \"zabbix_agent2-5.0.14-windows-amd64-openssl.zip\"",
"zabbix_win_download_url: \"http://mirror.domain.net/other\"",
"zabbix_win_download_link: \"http://mirror.domain.net/other/zabbix_agent2-5.0.14-windows-amd64-openssl.zip\""
]
{
"changed": false,
"invocation": {
"module_args": {
"url": "http://mirror.domain.net/other/zabbix_agent-5.0.14-windows-amd64.zip",
"dest": "C:\Program Files\Zabbix Agent\\zabbix_agent-5.0.14-windows-amd64.zip",
"headers": null,
"maximum_redirection": 50,
"checksum_algorithm": "sha1",
"proxy_use_default_credential": false,
"method": null,
"proxy_password": null,
"proxy_username": null,
"force_basic_auth": false,
"url_password": null,
"url_username": null,
"client_cert": null,
"client_cert_password": null,
"checksum_url": null,
"follow_redirects": "all",
"use_proxy": true,
"checksum": null,
"timeout": 120,
"force": false,
"use_default_credential": false,
"proxy_url": "",
"http_agent": "ansible-httpget",
"validate_certs": false
}
},
"elapsed": 0.1249993,
"url": "http://mirror.domain.net/other/zabbix_agent-5.0.14-windows-amd64.zip",
"dest": "C:\Program Files\Zabbix Agent\\zabbix_agent-5.0.14-windows-amd64.zip",
"msg": "Error downloading 'http://mirror.domain.net/other/zabbix_agent-5.0.14-windows-amd64.zip' to 'C:\Program Files\Zabbix Agent\\zabbix_agent-5.0.14-windows-amd64.zip': The remote server returned an error: (404) Not Found.",
"status_code": 404,
"exception": "The remote server returned an error: (404) Not Found.\r\nAt line:427 char:13\r\n+ $web_response = $Request.GetResponse()\r\n+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\r\n + CategoryInfo : NotSpecified: (:) [], WebException\r\n + FullyQualifiedErrorId : WebException\r\n\r\nScriptStackTrace:\r\nat Invoke-WithWebRequest, : line 427\r\nat Invoke-DownloadFile, : line 194\r\nat , : line 243",
"_ansible_no_log": false,
"attempts": 1,
"retries": 4
}

#####################################

{
    "changed": true,
    "invocation": {
        "module_args": {
            "url": "http://mirror.domain.net/other/zabbix_agent-5.0.14-windows-amd64-openssl.zip",
            "dest": "C:\\Program Files\\Zabbix Agent\\\\zabbix_agent-5.0.14-windows-amd64-openssl.zip",
            "headers": null,
            "maximum_redirection": 50,
            "checksum_algorithm": "sha1",
            "proxy_use_default_credential": false,
            "method": null,
            "proxy_password": null,
            "proxy_username": null,
            "force_basic_auth": false,
            "url_password": null,
            "url_username": null,
            "client_cert": null,
            "client_cert_password": null,
            "checksum_url": null,
            "follow_redirects": "all",
            "use_proxy": true,
            "checksum": null,
            "timeout": 120,
            "force": false,
            "use_default_credential": false,
            "proxy_url": "",
            "http_agent": "ansible-httpget",
            "validate_certs": false
        }
    },
    "elapsed": 0.2656185,
    "url": "http://mirror.domain.net/other/zabbix_agent-5.0.14-windows-amd64-openssl.zip",
    "dest": "C:\\Program Files\\Zabbix Agent\\\\zabbix_agent-5.0.14-windows-amd64-openssl.zip",
    "msg": "OK",
    "status_code": 200,
    "checksum_src": "a6b32ff36aa4989fc636bb1542b79aec383cdf29",
    "checksum_dest": "a6b32ff36aa4989fc636bb1542b79aec383cdf29",
    "size": 8391320,
    "_ansible_no_log": false,
    "attempts": 1
}
```
