### PR TITLE
Rework zabbix agent2 (windows)

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -264,7 +264,9 @@ _Supporting Windows is a best effort (I don't have the possibility to either tes
 * `zabbix_win_download_link`: The download url to the `win.zip` file.
 * `zabbix_win_install_dir`: The directory where Zabbix needs to be installed.
 * `zabbix_agent_win_logfile`: The full path to the logfile for the Zabbix Agent.
-* `zabbix_agent_win_include`: The directory in which the Zabbix specific configuration files are stored.
+* `zabbix_agent_win_include`: The directory in which the Zabbix Agent 2 specific configuration files are stored.
+* `zabbix_agent2_win_logfile`: The full path to the logfile for the Zabbix Agent 2.
+* `zabbix_agent2_win_include`: The directory in which the Zabbix Agent 2 specific configuration files are stored.
 * `zabbix_agent_win_svc_recovery`: Enable Zabbix Agent service auto-recovery settings.
 
 ## macOS Variables

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -264,7 +264,7 @@ _Supporting Windows is a best effort (I don't have the possibility to either tes
 * `zabbix_win_download_link`: The download url to the `win.zip` file.
 * `zabbix_win_install_dir`: The directory where Zabbix needs to be installed.
 * `zabbix_agent_win_logfile`: The full path to the logfile for the Zabbix Agent.
-* `zabbix_agent_win_include`: The directory in which the Zabbix Agent 2 specific configuration files are stored.
+* `zabbix_agent_win_include`: The directory in which the Zabbix Agent specific configuration files are stored.
 * `zabbix_agent_win_svc_recovery`: Enable Zabbix Agent service auto-recovery settings.
 
 ## macOS Variables

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -265,8 +265,6 @@ _Supporting Windows is a best effort (I don't have the possibility to either tes
 * `zabbix_win_install_dir`: The directory where Zabbix needs to be installed.
 * `zabbix_agent_win_logfile`: The full path to the logfile for the Zabbix Agent.
 * `zabbix_agent_win_include`: The directory in which the Zabbix Agent 2 specific configuration files are stored.
-* `zabbix_agent2_win_logfile`: The full path to the logfile for the Zabbix Agent 2.
-* `zabbix_agent2_win_include`: The directory in which the Zabbix Agent 2 specific configuration files are stored.
 * `zabbix_agent_win_svc_recovery`: Enable Zabbix Agent service auto-recovery settings.
 
 ## macOS Variables

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -205,6 +205,8 @@ zabbix_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_agent_version
 zabbix_win_install_dir: 'C:\Zabbix'
 zabbix_agent_win_logfile: 'C:\Zabbix\zabbix_agentd.log'
 zabbix_agent_win_include: 'C:\Zabbix\zabbix_agent.d\'
+zabbix_agent2_win_logfile: 'C:\Zabbix\zabbix_agent2.log'
+zabbix_agent2_win_include: 'C:\Zabbix\zabbix_agent2.d\'
 zabbix_agent_win_svc_recovery: True
 
 # macOS Related

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -205,8 +205,6 @@ zabbix_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_agent_version
 zabbix_win_install_dir: 'C:\Zabbix'
 zabbix_agent_win_logfile: 'C:\Zabbix\zabbix_agentd.log'
 zabbix_agent_win_include: 'C:\Zabbix\zabbix_agent.d\'
-zabbix_agent2_win_logfile: 'C:\Zabbix\zabbix_agent2.log'
-zabbix_agent2_win_include: 'C:\Zabbix\zabbix_agent2.d\'
 zabbix_agent_win_svc_recovery: True
 
 # macOS Related

--- a/roles/zabbix_agent/handlers/main.yml
+++ b/roles/zabbix_agent/handlers/main.yml
@@ -21,6 +21,13 @@
   when:
     - zabbix_agent_os_family == "Windows"
 
+- name: restart win zabbix agent 2
+  win_service:
+    name: "{{ zabbix_win_agent2_service }}"
+    state: restarted
+  when:
+    - zabbix_agent_os_family == "Windows"
+
 - name: restart mac zabbix agent
   command: "launchctl kickstart -k system/{{ zabbix_agent_service }}"
   become: true

--- a/roles/zabbix_agent/handlers/main.yml
+++ b/roles/zabbix_agent/handlers/main.yml
@@ -16,14 +16,7 @@
 
 - name: restart win zabbix agent
   win_service:
-    name: "{{ zabbix_win_agent_service }}"
-    state: restarted
-  when:
-    - zabbix_agent_os_family == "Windows"
-
-- name: restart win zabbix agent 2
-  win_service:
-    name: "{{ zabbix_win_agent2_service }}"
+    name: "{{ zabbix_win_svc_name }}"
     state: restarted
   when:
     - zabbix_agent_os_family == "Windows"

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -119,17 +119,6 @@
     - "{{ zabbix_agent_win_include }}"
   when:
     - ('.conf' not in zabbix_agent_win_include)
-    - not zabbix_agent2
-
-- name: "Windows | Create directory structure, includes (agent 2)"
-  win_file:
-    path: "{{ item }}"
-    state: directory
-  with_items:
-    - "{{ zabbix_agent2_win_include }}"
-  when:
-    - ('.conf' not in zabbix_agent2_win_include)
-    - zabbix_agent2 | bool
 
 - name: "Windows | Place TLS-PSK file"
   win_copy:

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: "Set default ip address for zabbix_agent_ip"
   set_fact:
     zabbix_agent_ip: "{{ hostvars[inventory_hostname]['ansible_ip_addresses'][0] }}"
@@ -21,12 +20,19 @@
   set_fact:
     zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\win{{ windows_arch }}\zabbix_agentd.exe'
 
-- name: "Windows | Set variables specific to Zabbix 4.0"
+- name: "Windows | Set variables specific to Zabbix >= 4"
   set_fact:
-    zabbix_win_package: zabbix_agent-{{ zabbix_version_long }}-windows-amd64.zip
+    zabbix_win_svc_name: Zabbix Agent
     zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\zabbix_agentd.exe'
   when:
     - zabbix_version_long is version('4.0.0', '>=')
+
+- name: "Windows | Set variables specific to Zabbix (agent 2)"
+  set_fact:
+    zabbix_win_svc_name: Zabbix Agent 2
+    zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\zabbix_agent2.exe'
+  when:
+    - zabbix_agent2 | bool
 
 - name: "Windows | Check if Zabbix agent is present"
   win_stat:
@@ -54,9 +60,9 @@
     - zabbix_win_exe_info.win_file_version.product_version is version(zabbix_version_long, '<')
     - zabbix_agent_package_state == 'latest'
 
-- name: Windows | Check Zabbix service
+- name: "Windows | Check Zabbix service"
   win_service:
-    name: Zabbix Agent
+    name: "{{ zabbix_win_svc_name }}"
   register: zabbix_service_info
 
 - name: Windows | Check firewall service
@@ -66,11 +72,12 @@
 
 - name: "Windows | Stop Zabbix (Update)"
   win_service:
-    name: Zabbix Agent
+    name: "{{ zabbix_win_svc_name }}"
     start_mode: auto
     state: stopped
   when:
     - zabbix_service_info.exists
+    - update_zabbix_agent | bool
     - zabbix_service_info.state == 'running'
 
 - name: "Windows | Uninstall Zabbix (Update)"
@@ -78,6 +85,15 @@
   register: zabbix_windows_install
   when:
     - zabbix_service_info.exists
+    - update_zabbix_agent | bool
+
+- name: "Windows | Uninstall Zabbix (Update) (agent 2)"
+  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agent2.conf" --uninstall'
+  register: zabbix_windows_install
+  when:
+    - zabbix_service_info.exists
+    - update_zabbix_agent | bool
+    - zabbix_agent2 | bool
 
 - name: "Windows | Removing Zabbix Directory (Update)"
   win_file:
@@ -103,6 +119,16 @@
     - "{{ zabbix_agent_win_include }}"
   when:
     - ('.conf' not in zabbix_agent_win_include)
+
+- name: "Windows | Create directory structure, includes (agent 2)"
+  win_file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ zabbix_agent2_win_include }}"
+  when:
+    - ('.conf' not in zabbix_agent2_win_include)
+    - zabbix_agent2 | bool
 
 - name: "Windows | Place TLS-PSK file"
   win_copy:
@@ -145,12 +171,32 @@
     src: zabbix_agentd.conf.j2
     dest: '{{ zabbix_win_install_dir }}\zabbix_agentd.conf'
   notify: restart win zabbix agent
+  when:
+    - not zabbix_agent2
+
+- name: "Windows | Configure zabbix-agent2"
+  win_template:
+    src: zabbix_agentd.conf.j2
+    dest: '{{ zabbix_win_install_dir }}\zabbix_agent2.conf'
+  notify: restart win zabbix agent 2
+  when:
+    - zabbix_agent2 | bool
 
 - name: "Windows | Register Service"
   win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agentd.conf" --install'
   register: zabbix_windows_install
   args:
     creates: '{{ zabbix_win_install_dir }}\.installed'
+  when:
+    - not zabbix_agent2
+
+- name: "Windows | Register Service (agent 2)"
+  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agent2.conf" --install'
+  register: zabbix_windows_install
+  args:
+    creates: '{{ zabbix_win_install_dir }}\.installed'
+  when:
+    - zabbix_agent2 | bool
 
 - name: "Windows | Create done file so it won't register itself again"
   win_file:
@@ -160,26 +206,26 @@
 
 - name: "Windows | Set service startup mode to auto and ensure it is started"
   win_service:
-    name: Zabbix Agent
+    name: "{{ zabbix_win_svc_name }}"
     start_mode: auto
     state: started
 
 - name: "Windows | Getting Zabbix Service Recovery Settings"
-  win_shell: sc.exe qfailure "Zabbix Agent" 1100
+  win_shell: 'sc.exe qfailure "{{ zabbix_win_svc_name }}" 1100'
   register: svc_recovery
   changed_when: false
   check_mode: false
   when: zabbix_agent_win_svc_recovery
 
 - name: "Windows | Setting Zabbix Service Recovery"
-  win_shell: sc.exe failure "Zabbix Agent" actions= restart/5000/restart/10000/restart/20000 reset= 86400
+  win_shell: 'sc.exe failure "{{ zabbix_win_svc_name }}" actions= restart/5000/restart/10000/restart/20000 reset= 86400'
   when:
     - "'RESTART -- Delay' not in svc_recovery.stdout"
     - zabbix_agent_win_svc_recovery
 
 - name: "Windows | Firewall rule"
   win_firewall_rule:
-    name: Zabbix Agent
+    name: "{{ zabbix_win_svc_name }}"
     localport: "{{ zabbix_agent_listenport }}"
     action: allow
     direction: in

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -156,6 +156,13 @@
     dest: "{{ zabbix_win_install_dir }}"
     creates: '{{ zabbix_win_exe_path }}'
 
+- name: "Windows | Cleanup downloaded Zabbix Agent Zip file"
+  win_file:
+    path: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
+    state: absent
+  when:
+    - zabbix_agent_win_download_zip.changed
+
 - name: "Windows | Configure zabbix-agent"
   win_template:
     src: zabbix_agentd.conf.j2

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -175,7 +175,7 @@
   win_template:
     src: zabbix_agent2.conf.j2
     dest: '{{ zabbix_win_install_dir }}\zabbix_agent2.conf'
-  notify: restart win zabbix agent 2
+  notify: restart win zabbix agent
   when:
     - zabbix_agent2 | bool
 

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -77,7 +77,7 @@
     state: stopped
   when:
     - zabbix_service_info.exists
-    - update_zabbix_agent | bool
+    - update_zabbix_agent | default(False) | bool
     - zabbix_service_info.state == 'running'
 
 - name: "Windows | Uninstall Zabbix (Update)"
@@ -85,14 +85,14 @@
   register: zabbix_windows_install
   when:
     - zabbix_service_info.exists
-    - update_zabbix_agent | bool
+    - update_zabbix_agent | default(False) | bool
 
 - name: "Windows | Uninstall Zabbix (Update) (agent 2)"
   win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agent2.conf" --uninstall'
   register: zabbix_windows_install
   when:
     - zabbix_service_info.exists
-    - update_zabbix_agent | bool
+    - update_zabbix_agent | default(False) | bool
     - zabbix_agent2 | bool
 
 - name: "Windows | Removing Zabbix Directory (Update)"

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -119,6 +119,7 @@
     - "{{ zabbix_agent_win_include }}"
   when:
     - ('.conf' not in zabbix_agent_win_include)
+    - not zabbix_agent2
 
 - name: "Windows | Create directory structure, includes (agent 2)"
   win_file:

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -176,7 +176,7 @@
 
 - name: "Windows | Configure zabbix-agent2"
   win_template:
-    src: zabbix_agentd.conf.j2
+    src: zabbix_agent2.conf.j2
     dest: '{{ zabbix_win_install_dir }}\zabbix_agent2.conf'
   notify: restart win zabbix agent 2
   when:

--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -9,7 +9,9 @@
 # Mandatory: no
 # Default:
 
+{% if zabbix_agent_os_family != "Windows" %}
 PidFile={{ zabbix_agent2_pidfile }}
+{% endif %}
 
 ### Option: LogType
 #	Specifies where log messages are written to:
@@ -52,6 +54,7 @@ LogFileSize={{ zabbix_agent2_logfilesize }}
 # Mandatory: no
 # Range: 0-5
 # Default:
+
 DebugLevel={{ zabbix_agent2_debuglevel }}
 
 ### Option: SourceIP
@@ -59,6 +62,7 @@ DebugLevel={{ zabbix_agent2_debuglevel }}
 #
 # Mandatory: no
 # Default:
+
 {% if zabbix_agent2_sourceip is defined and zabbix_agent2_sourceip %}
 SourceIP={{ zabbix_agent2_sourceip }}
 {% endif %}
@@ -303,7 +307,6 @@ Timeout={{ zabbix_agent2_timeout }}
 #
 # Mandatory: no
 # Default:
-
 {% if zabbix_agent_os_family == "Windows" %}
 Include={{ zabbix_agent_win_include }}
 {% else %}
@@ -341,8 +344,9 @@ UnsafeUserParameters={{ zabbix_agent2_unsafeuserparameters }}
 # Mandatory: no
 # Default:
 # ControlSocket=
-
+{% if zabbix_agent_os_family != "Windows" %}
 ControlSocket={{ zabbix_agent2_controlsocket }}
+{% endif %}
 
 ####### TLS-RELATED PARAMETERS #######
 

--- a/roles/zabbix_agent/vars/Windows.yml
+++ b/roles/zabbix_agent/vars/Windows.yml
@@ -2,3 +2,4 @@
 # vars file for zabbix agent (Windows)
 
 zabbix_win_agent_service: "zabbix agent"
+zabbix_win_agent2_service: "zabbix agent 2"

--- a/roles/zabbix_agent/vars/Windows.yml
+++ b/roles/zabbix_agent/vars/Windows.yml
@@ -1,5 +1,2 @@
 ---
 # vars file for zabbix agent (Windows)
-
-zabbix_win_agent_service: "zabbix agent"
-zabbix_win_agent2_service: "zabbix agent 2"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Deployment of Zabbix Agent 2 wasn't possible under Windows systems.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
https://github.com/ansible-collections/community.zabbix/issues/432
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Now it's possible to install Zabbix Agent 2 under Windows systems.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Zabbix deployment is successful on Windows (agent and agent 2), there is no upgrade path between agent und agent 2.
If you want to upgrade to agent 2 you must remove agent before.

