### PR TITLE
Add ability to set gpgcheck for yum repos

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -21,7 +21,7 @@ zabbix_agent_dont_detect_ip: False
 zabbix_agent_allow_key: []
 zabbix_agent_deny_key: []
 
-# Selinux related vars 
+# Selinux related vars
 selinux_allow_zabbix_run_sudo: False
 
 zabbix_agent_install_agent_only: False
@@ -39,6 +39,7 @@ zabbix_apt_install_recommends: no
 zabbix_agent_distribution_major_version: "{{ ansible_distribution_major_version }}"
 zabbix_agent_distribution_release: "{{ ansible_distribution_release }}"
 zabbix_agent_os_family: "{{ ansible_os_family }}"
+zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https
 zabbix_repo_yum_disabled: "*"
 zabbix_repo_yum_enabled: []
@@ -47,14 +48,14 @@ zabbix_repo_yum:
     description: Zabbix Official Repository - $basearch
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ zabbix_agent_distribution_major_version }}/$basearch/"
     mode: '0644'
-    gpgcheck: 0
+    gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
   - name: zabbix-non-supported
     description: Zabbix Official Repository non-supported - $basearch
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/non-supported/rhel/{{ zabbix_agent_distribution_major_version }}/$basearch/"
     mode: '0644'
-    gpgcheck: 0
+    gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
 

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -8,13 +8,15 @@ zabbix_selinux: False
 zabbix_repo: zabbix
 zabbix_repo_yum_schema: https
 zabbix_java_gateway_conf_mode: "0644"
+
+zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_disabled: "*"
 zabbix_repo_yum_enabled: []
 zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
-    gpgcheck: 0
+    gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     mode: '0644'
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
@@ -22,7 +24,7 @@ zabbix_repo_yum:
     description: Zabbix Official Repository non-supported - $basearch
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     mode: '0644'
-    gpgcheck: 0
+    gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
 

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -18,13 +18,14 @@ zabbix_proxy_install_database_client: True
 zabbix_install_pip_packages: true
 zabbix_repo_yum_schema: https
 zabbix_proxy_conf_mode: "0644"
+zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_disabled: "*"
 zabbix_repo_yum_enabled: []
 zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
-    gpgcheck: 0
+    gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     mode: '0644'
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
@@ -32,7 +33,7 @@ zabbix_repo_yum:
     description: Zabbix Official Repository non-supported - $basearch
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     mode: '0644'
-    gpgcheck: 0
+    gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
 

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -14,6 +14,8 @@ zabbix_server_conf_mode: 0640
 
 zabbix_service_state: started
 zabbix_service_enabled: True
+
+zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https
 zabbix_repo_yum_disabled: "*"
 zabbix_repo_yum_enabled: []
@@ -21,7 +23,7 @@ zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
-    gpgcheck: 0
+    gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     mode: '0644'
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
@@ -29,7 +31,7 @@ zabbix_repo_yum:
     description: Zabbix Official Repository non-supported - $basearch
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     mode: '0644'
-    gpgcheck: 0
+    gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
 

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -59,6 +59,7 @@ zabbix_nginx_tls_ciphers: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA
 zabbix_letsencrypt: False
 zabbix_letsencrypt_webroot_path: /var/www/letsencrypt
 
+zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https
 zabbix_repo_yum_disabled: "*"
 zabbix_repo_yum_enabled: []
@@ -66,7 +67,7 @@ zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
-    gpgcheck: 0
+    gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     mode: '0644'
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
@@ -74,7 +75,7 @@ zabbix_repo_yum:
     description: Zabbix Official Repository non-supported - $basearch
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/non-supported/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     mode: '0644'
-    gpgcheck: 0
+    gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
 
@@ -83,7 +84,7 @@ zabbix_5_repo_yum:
     description: Zabbix Official Repository - $basearch
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version }}/rhel/{{ ansible_distribution_major_version }}/$basearch/frontend/"
     mode: '0644'
-    gpgcheck: 0
+    gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
 


### PR DESCRIPTION
##### SUMMARY
Add the ability and property(zabbix_repo_yum_gpgcheck) to control gpg key checking on the default yum repo entries

This feature should allow users to more easily toggle gpg key checking with the default yum repo values

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
improvement to role
