### PR TITLE
Add always tag for php_version tasks

### DIFF
--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -12,6 +12,8 @@
     - files:
         - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
         - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
+  tags:
+    - always
 
 - name: "Set some versions"
   set_fact:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zabbix-web role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

When we execute a playbook using this collection with a tag, some tasks in role zabbix-web role are executed also because they have the tag called always.

However the task **Include distribution and version-specific vars** does not have the tag always. In this case the variable __zabbix_php_version_ is not defined for some OS and the error below is displayed.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
msg: |-                                                                                                                                                                                                          
    The task includes an option with an undefined variable. The error was: '_zabbix_php_version' is undefined
```
