### PR TITLE
tlspsk_auto with windows agent

### DIFF
--- a/roles/zabbix_agent/tasks/tlspsk_auto.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto.yml
@@ -1,21 +1,9 @@
 ---
-- name: AutoPSK | Set default path variables for Linux
-  set_fact:
-    zabbix_agent_tlspskfile: "/etc/zabbix/tls_psk_auto.secret"
-    zabbix_agent_tlspskidentity_file: "/etc/zabbix/tls_psk_auto.identity"
+- include_tasks: tlspsk_auto_linux.yml
   when: (zabbix_agent_os_family != "Windows") or (zabbix_agent_docker | bool)
 
-- name: AutoPSK | Set default path variables for Windows
-  set_fact:
-    zabbix_agent_tlspskfile: "{{ zabbix_win_install_dir }}\tls_psk_auto.secret.txt"
-    zabbix_agent_tlspskidentity_file: "{{ zabbix_win_install_dir }}\tls_psk_auto.identity.txt"
-  when: zabbix_agent_os_family == "Windows"
-
-- name: AutoPSK | Check for existing TLS PSK file
-  stat:
-    path: "{{ zabbix_agent_tlspskfile }}"
-  register: zabbix_agent_tlspskcheck
-  become: yes
+- include_tasks: tlspsk_auto_windows.yml
+  when: (zabbix_agent_os_family == "Windows")
 
 - name: AutoPSK | read existing TLS PSK file
   slurp:
@@ -38,12 +26,6 @@
   set_fact:
     zabbix_agent_tlspsk_secret: "{{ lookup('password', '/dev/null chars=hexdigits length=64') }}"
   when: not zabbix_agent_tlspskcheck.stat.exists or zabbix_agent_tlspsk_read|length < 32
-
-- name: AutoPSK | Check for existing TLS PSK identity
-  stat:
-    path: "{{ zabbix_agent_tlspskidentity_file }}"
-  register: zabbix_agent_tlspskidentity_check
-  become: yes
 
 - name: AutoPSK | Read existing TLS PSK identity file
   slurp:

--- a/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
@@ -1,21 +1,9 @@
 ---
-- name: AutoPSK | Set default path variables for Linux
-  set_fact:
-    zabbix_agent2_tlspskfile: "/etc/zabbix/tls_psk_auto.secret"
-    zabbix_agent2_tlspskidentity_file: "/etc/zabbix/tls_psk_auto.identity"
+- include_tasks: tlspsk_auto_agent2_linux.yml
   when: (zabbix_agent_os_family != "Windows") or (zabbix_agent_docker | bool)
 
-- name: AutoPSK | Set default path variables for Windows
-  set_fact:
-    zabbix_agent2_tlspskfile: "{{ zabbix_win_install_dir }}\tls_psk_auto.secret.txt"
-    zabbix_agent2_tlspskidentity_file: "{{ zabbix_win_install_dir }}\tls_psk_auto.identity.txt"
-  when: zabbix_agent_os_family == "Windows"
-
-- name: AutoPSK | Check for existing TLS PSK file
-  stat:
-    path: "{{ zabbix_agent2_tlspskfile }}"
-  register: zabbix_agent2_tlspskcheck
-  become: yes
+- include_tasks: tlspsk_auto_agent2_windows.yml
+  when: (zabbix_agent_os_family == "Windows")
 
 - name: AutoPSK | read existing TLS PSK file
   slurp:
@@ -38,12 +26,6 @@
   set_fact:
     zabbix_agent2_tlspsk_secret: "{{ lookup('password', '/dev/null chars=hexdigits length=64') }}"
   when: not zabbix_agent2_tlspskcheck.stat.exists or zabbix_agent2_tlspsk_read|length < 32
-
-- name: AutoPSK | Check for existing TLS PSK identity
-  stat:
-    path: "{{ zabbix_agent2_tlspskidentity_file }}"
-  register: zabbix_agent2_tlspskidentity_check
-  become: yes
 
 - name: AutoPSK | Read existing TLS PSK identity file
   slurp:

--- a/roles/zabbix_agent/tasks/tlspsk_auto_agent2_linux.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_agent2_linux.yml
@@ -1,0 +1,17 @@
+---
+- name: AutoPSK | Set default path variables for Linux
+  set_fact:
+    zabbix_agent2_tlspskfile: "/etc/zabbix/tls_psk_auto.secret"
+    zabbix_agent2_tlspskidentity_file: "/etc/zabbix/tls_psk_auto.identity"
+
+- name: AutoPSK | Check for existing TLS PSK file (Linux)
+  stat:
+    path: "{{ zabbix_agent2_tlspskfile }}"
+  register: zabbix_agent2_tlspskcheck
+  become: yes
+
+- name: AutoPSK | Check for existing TLS PSK identity (Linux)
+  stat:
+    path: "{{ zabbix_agent2_tlspskidentity_file }}"
+  register: zabbix_agent2_tlspskidentity_check
+  become: yes

--- a/roles/zabbix_agent/tasks/tlspsk_auto_agent2_windows.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_agent2_windows.yml
@@ -1,0 +1,17 @@
+---
+- name: AutoPSK | Set default path variables for Windows
+  set_fact:
+    zabbix_agent2_tlspskfile: "{{ zabbix_win_install_dir }}\\tls_psk_auto.secret.txt"
+    zabbix_agent2_tlspskidentity_file: "{{ zabbix_win_install_dir }}\\tls_psk_auto.identity.txt"
+
+- name: AutoPSK | Check for existing TLS PSK file (Windows)
+  win_stat:
+    path: "{{ zabbix_agent2_tlspskfile }}"
+  register: zabbix_agent2_tlspskcheck
+  become: yes
+
+- name: AutoPSK | Check for existing TLS PSK identity (Windows)
+  win_stat:
+    path: "{{ zabbix_agent2_tlspskidentity_file }}"
+  register: zabbix_agent2_tlspskidentity_check
+  become: yes

--- a/roles/zabbix_agent/tasks/tlspsk_auto_linux.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_linux.yml
@@ -15,4 +15,3 @@
     path: "{{ zabbix_agent_tlspskidentity_file }}"
   register: zabbix_agent_tlspskidentity_check
   become: yes
-

--- a/roles/zabbix_agent/tasks/tlspsk_auto_linux.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_linux.yml
@@ -1,0 +1,18 @@
+---
+- name: AutoPSK | Set default path variables for Linux
+  set_fact:
+    zabbix_agent_tlspskfile: "/etc/zabbix/tls_psk_auto.secret"
+    zabbix_agent_tlspskidentity_file: "/etc/zabbix/tls_psk_auto.identity"
+
+- name: AutoPSK | Check for existing TLS PSK file (Linux)
+  stat:
+    path: "{{ zabbix_agent_tlspskfile }}"
+  register: zabbix_agent_tlspskcheck
+  become: yes
+
+- name: AutoPSK | Check for existing TLS PSK identity (Linux)
+  stat:
+    path: "{{ zabbix_agent_tlspskidentity_file }}"
+  register: zabbix_agent_tlspskidentity_check
+  become: yes
+

--- a/roles/zabbix_agent/tasks/tlspsk_auto_windows.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_windows.yml
@@ -1,0 +1,18 @@
+---
+- name: AutoPSK | Set default path variables for Windows
+  set_fact:
+    zabbix_agent_tlspskfile: "{{ zabbix_win_install_dir }}\\tls_psk_auto.secret.txt"
+    zabbix_agent_tlspskidentity_file: "{{ zabbix_win_install_dir }}\\tls_psk_auto.identity.txt"
+
+- name: AutoPSK | Check for existing TLS PSK file (Windows)
+  win_stat:
+    path: "{{ zabbix_agent_tlspskfile }}"
+  register: zabbix_agent_tlspskcheck
+  become: yes
+
+- name: AutoPSK | Check for existing TLS PSK identity (Windows)
+  win_stat:
+    path: "{{ zabbix_agent_tlspskidentity_file }}"
+  register: zabbix_agent_tlspskidentity_check
+  become: yes
+

--- a/roles/zabbix_agent/tasks/tlspsk_auto_windows.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_windows.yml
@@ -15,4 +15,3 @@
     path: "{{ zabbix_agent_tlspskidentity_file }}"
   register: zabbix_agent_tlspskidentity_check
   become: yes
-


### PR DESCRIPTION
##### SUMMARY
Fixed some tiny things with agent deployment on windows

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tls_autopsk-_agent2) tasks in the zabbix_agent role

##### ADDITIONAL INFORMATION
- autopsk was not working because ansible stat module was used. -> added tasks which use win_stat when the OS is windows. https://github.com/ansible-collections/community.zabbix/issues/396#issue-920572152

