### PR TITLE
windows agent(2) role refactoring

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -62,7 +62,7 @@ When you are a Windows user and using Ansible 2.10 or newer, then there is a dep
 ansible-galaxy collection install ansible.windows
 ```
 
-For more information, see: https://github.com/ansible-collections/community.zabbix/issues/236 
+For more information, see: https://github.com/ansible-collections/community.zabbix/issues/236
 
 ## Local system access
 
@@ -202,7 +202,7 @@ Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
 
 ## TLS Specific configuration
 
-These variables are specific for Zabbix 3.0 and higher. When `(2)` is used in the name of the property, like `zabbix_agent(2)_tlsconnect`, it will show that you can configure `zabbix_agent_tlsconnect` for the Zabbix Agent configuration file and `zabbix_agent2_tlsconnect` for the Zabbix Agent 2 configuration file. 
+These variables are specific for Zabbix 3.0 and higher. When `(2)` is used in the name of the property, like `zabbix_agent(2)_tlsconnect`, it will show that you can configure `zabbix_agent_tlsconnect` for the Zabbix Agent configuration file and `zabbix_agent2_tlsconnect` for the Zabbix Agent 2 configuration file.
 
 * `zabbix_agent(2)_tlsconnect`: How the agent should connect to server or proxy. Used for active checks.
     Possible values:
@@ -260,13 +260,18 @@ When `zabbix_api_create_hostgroup` or `zabbix_api_create_hosts` is set to `True`
 **NOTE**
 
 _Supporting Windows is a best effort (I don't have the possibility to either test/verify changes on the various amount of available Windows instances). PRs specific to Windows will almost immediately be merged, unless someone is able to provide a Windows test mechanism via Travis for Pull Requests._
+When `(2)` is used in the name of the property, like `zabbix_agent(2)_win_logfile`, it will show that you can configure `zabbix_agent_win_logfile` for the Zabbix Agent configuration file and `zabbix_agent2_win_logfile` for the Zabbix Agent 2 configuration file.
 
-* `zabbix_version_long`: The long (major.minor.patch) version of the Zabbix Agent. This will be used to generate the `zabbix_win_download_link` link and for Zabbix Agent update if `zabbix_agent_package_state: latest`.
-* `zabbix_win_download_link`: The download url to the `win.zip` file.
+Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
+
+* `zabbix(2)_win_package`: file name pattern (zip only). This will be used to generate the `zabbix(2)_win_download_link` variable.
+* `zabbix_version_long`: The long (major.minor.patch) version of the Zabbix Agent. This will be used to generate the `zabbix(2)_win_package` and `zabbix(2)_win_download_link` variables.
+* `zabbix(2)_win_download_link`: The download url to the `win.zip` file.
 * `zabbix_win_install_dir`: The directory where Zabbix needs to be installed.
-* `zabbix_agent_win_logfile`: The full path to the logfile for the Zabbix Agent.
+* `zabbix_agent(2)_win_logfile`: The full path to the logfile for the Zabbix Agent.
 * `zabbix_agent_win_include`: The directory in which the Zabbix Agent specific configuration files are stored.
 * `zabbix_agent_win_svc_recovery`: Enable Zabbix Agent service auto-recovery settings.
+* `zabbix_win_firewall_management`: Enable Windows firewall management (add service and port to allow rules). Default: `True`
 
 ## macOS Variables
 
@@ -460,7 +465,7 @@ Variables e.g. in the playbook or in `host_vars/myhost`:
 
 # Molecule
 
-This role is configured to be tested with Molecule. You can find on this page some more information regarding Molecule: 
+This role is configured to be tested with Molecule. You can find on this page some more information regarding Molecule:
 
 * http://werner-dijkerman.nl/2016/07/10/testing-ansible-roles-with-molecule-testinfra-and-docker/
 * http://werner-dijkerman.nl/2016/07/27/extending-ansible-role-testing-with-molecule-by-adding-group_vars-dependencies-and-using-travis-ci/

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -203,12 +203,16 @@ zabbix_version_long: 5.2.4
 
 # Windows Related
 zabbix_win_package: zabbix_agent-{{ zabbix_version_long }}-windows-amd64-openssl.zip
+zabbix2_win_package: zabbix_agent2-{{ zabbix_version_long }}-windows-amd64-openssl-static.zip
 zabbix_win_download_url: https://cdn.zabbix.com/zabbix/binaries/stable
 zabbix_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_agent_version }}/{{ zabbix_version_long }}/{{ zabbix_win_package }}"
+zabbix2_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_agent_version }}/{{ zabbix_version_long }}/{{ zabbix2_win_package }}"
 zabbix_win_install_dir: 'C:\Zabbix'
 zabbix_agent_win_logfile: 'C:\Zabbix\zabbix_agentd.log'
 zabbix_agent_win_include: 'C:\Zabbix\zabbix_agent.d\'
+zabbix_agent2_win_logfile: 'C:\Zabbix\zabbix_agent2.log'
 zabbix_agent_win_svc_recovery: True
+zabbix_win_firewall_management: True
 
 # macOS Related
 zabbix_mac_package: zabbix_agent-{{ zabbix_version_long }}-macos-amd64-openssl.pkg

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -41,7 +41,7 @@
 
 - name: "Windows | Get Installed Zabbix Agent Version"
   win_file_version:
-    path: "{{ zabbix_win_exe_path }}"
+    path: "{{ item.item }}"
   register: zabbix_win_exe_info
   when:
     - item.stat.exists | bool

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -24,19 +24,19 @@
   set_fact:
     zabbix_win_svc_name: Zabbix Agent
     zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\zabbix_agentd.exe'
+    zabbix_win_config_name: 'zabbix_agentd.conf'
+    zabbix2_win_svc_name: Zabbix Agent 2
+    zabbix2_win_exe_path: '{{ zabbix_win_install_dir }}\bin\zabbix_agent2.exe'
+    zabbix2_win_config_name: 'zabbix_agent2.conf'
   when:
     - zabbix_version_long is version('4.0.0', '>=')
 
-- name: "Windows | Set variables specific to Zabbix (agent 2)"
-  set_fact:
-    zabbix_win_svc_name: Zabbix Agent 2
-    zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\zabbix_agent2.exe'
-  when:
-    - zabbix_agent2 | bool
-
 - name: "Windows | Check if Zabbix agent is present"
   win_stat:
-    path: '{{ zabbix_win_exe_path }}'
+    path: '{{ item }}'
+  with_items:
+    - "{{ zabbix_win_exe_path }}"
+    - "{{ zabbix2_win_exe_path }}"
   register: agent_file_info
 
 - name: "Windows | Get Installed Zabbix Agent Version"
@@ -44,65 +44,104 @@
     path: "{{ zabbix_win_exe_path }}"
   register: zabbix_win_exe_info
   when:
-    - agent_file_info.stat.exists
+    - item.stat.exists | bool
+  with_items: "{{ agent_file_info.results }}"
 
-- name: "Windows | Checking Update (Set default)"
+- name: "Windows | Set facts current zabbix agent installation"
   set_fact:
-    update_zabbix_agent: False
+    zabbix_agent_1_binary_exist: True
+    zabbix_agent_1_version: zabbix_win_exe_info.results[0].win_file_version.product_version
   when:
-    - agent_file_info.stat.exists
+    - zabbix_win_exe_info.results[0] is defined
+    - zabbix_win_exe_info.results[0].item.stat.exists
+    - zabbix_win_exe_info.results[0].item.stat.path == zabbix_win_exe_path
+    - zabbix_win_exe_info.results[0].win_file_version.product_version
 
-- name: "Windows | Checking Update"
+- name: "Windows | Set facts current zabbix agent installation (agent 2)"
   set_fact:
-    update_zabbix_agent: True
+    zabbix_agent_2_binary_exist: True
+    zabbix_agent_2_version: zabbix_win_exe_info.results[1].win_file_version.product_version
   when:
-    - agent_file_info.stat.exists
-    - zabbix_win_exe_info.win_file_version.product_version is version(zabbix_version_long, '<')
-    - zabbix_agent_package_state == 'latest'
+    - zabbix_win_exe_info.results[1] is defined
+    - zabbix_win_exe_info.results[1].item.stat.exists
+    - zabbix_win_exe_info.results[1].item.stat.path == zabbix_win_exe_path
+    - zabbix_win_exe_info.results[1].win_file_version.product_version
 
 - name: "Windows | Check Zabbix service"
   win_service:
-    name: "{{ zabbix_win_svc_name }}"
+    name: "{{ (item.item.stat.path == zabbix_win_exe_path ) | ternary(zabbix_win_svc_name,zabbix2_win_svc_name) }}"
   register: zabbix_service_info
+  when: item.item.stat.exists
+  with_items: "{{ zabbix_win_exe_info.results }}"
 
-- name: Windows | Check firewall service
-  win_service:
-    name: MpsSvc
-  register: firewall_info
+- name: "Windows | Set facts about current zabbix agent service state"
+  set_fact:
+    zabbix_agent_1_service_exist: true
+  when:
+    - zabbix_service_info.results[0].exists is defined
+    - zabbix_service_info.results[0].exists
+    - zabbix_service_info.results[0].display_name == zabbix_win_svc_name
 
-- name: "Windows | Stop Zabbix (Update)"
+- name: "Windows | Set facts about current zabbix agent service state (agent 2)"
+  set_fact:
+    zabbix_agent_2_service_exist: true
+  when:
+    - zabbix_service_info.results[1].exists is defined
+    - zabbix_service_info.results[1].exists
+    - zabbix_service_info.results[1].display_name == zabbix2_win_svc_name
+
+- name: "Windows | Set fact about version change requirement"
+  set_fact:
+    zabbix_agent_version_change: true
+  when: (zabbix_agent_1_binary_exist | default(false) and zabbix_win_exe_info.results[0].win_file_version.product_version is version(zabbix_version_long, '<>')) or
+        (zabbix_agent_2_binary_exist | default(false) and zabbix_win_exe_info.results[1].win_file_version.product_version is version(zabbix_version_long, '<>')) or
+        (zabbix_agent_1_binary_exist | default(false) and zabbix_agent2) or
+        (zabbix_agent_2_binary_exist | default(false) and not zabbix_agent2)
+
+##################
+# delete section #
+##################
+
+- name: "Windows | Stop Zabbix agent v1"
   win_service:
     name: "{{ zabbix_win_svc_name }}"
     start_mode: auto
     state: stopped
   when:
-    - zabbix_service_info.exists
-    - update_zabbix_agent | default(False) | bool
-    - zabbix_service_info.state == 'running'
+    - zabbix_agent_version_change | default(false) or zabbix_agent2
+    - zabbix_agent_1_service_exist | default(false)
 
-- name: "Windows | Uninstall Zabbix (Update)"
-  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agentd.conf" --uninstall'
-  register: zabbix_windows_install
+- name: "Windows | Stop Zabbix agent v2"
+  win_service:
+    name: "{{ zabbix2_win_svc_name }}"
+    start_mode: auto
+    state: stopped
   when:
-    - zabbix_service_info.exists
-    - update_zabbix_agent | default(False) | bool
+    - zabbix_agent_version_change | default(false) or not zabbix_agent2
+    - zabbix_agent_2_service_exist | default(false)
 
-- name: "Windows | Uninstall Zabbix (Update) (agent 2)"
-  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agent2.conf" --uninstall'
-  register: zabbix_windows_install
+- name: "Windows | Uninstall Zabbix v1"
+  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix_win_config_name }}" --uninstall'
   when:
-    - zabbix_service_info.exists
-    - update_zabbix_agent | default(False) | bool
-    - zabbix_agent2 | bool
+    - zabbix_agent_version_change | default(false) or zabbix_agent2
+    - zabbix_agent_1_service_exist | default(false)
 
-- name: "Windows | Removing Zabbix Directory (Update)"
+- name: "Windows | Uninstall Zabbix v2"
+  win_command: '"{{ zabbix2_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix2_win_config_name }}" --uninstall'
+  when:
+    - zabbix_agent_version_change | default(false) or not zabbix_agent2
+    - zabbix_agent_2_service_exist | default(false)
+
+- name: "Windows | Removing Zabbix Directory"
   win_file:
     path: '{{ zabbix_win_install_dir }}'
     state: absent
-  when:
-    - update_zabbix_agent | default(False) | bool
-    - agent_file_info.stat.exists
-    - remove_zabbix_directory | default(False) | bool
+  when: ((zabbix_agent_version_change | default(false) or zabbix_agent2) and zabbix_agent_1_binary_exist | default(false)) or
+        ((zabbix_agent_version_change | default(false) or not zabbix_agent2) and zabbix_agent_2_binary_exist | default(false))
+
+###################
+# install section #
+###################
 
 - name: "Windows | Create directory structure"
   win_file:
@@ -129,10 +168,24 @@
     - zabbix_agent_tlspsk_secret is defined
   notify: restart win zabbix agent
 
-- name: "Windows | Check if file is already downloaded"
+- name: "Windows | Set installation settings (agent 2)"
+  set_fact:
+    zabbix_win_package: "{{ zabbix2_win_package }}"
+    zabbix_win_download_link: "{{ zabbix2_win_download_link }}"
+    zabbix_win_exe_path: "{{ zabbix2_win_exe_path }}"
+    zabbix_win_config_name: "{{ zabbix2_win_config_name }}"
+    zabbix_win_svc_name: "{{ zabbix2_win_svc_name }}"
+  when: zabbix_agent2 | bool
+
+- name: "Windows | Check if agent file is already downloaded"
   win_stat:
     path: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
   register: file_info
+
+- name: "Windows | Check if agent binaries in place"
+  win_stat:
+    path: "{{ zabbix_win_exe_path }}"
+  register: zabbix_windows_binaries
 
 - name: "Windows | Download Zabbix Agent Zip file"
   win_get_url:
@@ -145,7 +198,9 @@
     proxy_url: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
     validate_certs: "{{ zabbix_download_validate_certs | default(False) | bool }}"
     timeout: "{{ zabbix_download_timeout | default(120) | int }}"
-  when: not file_info.stat.exists
+  when:
+    - not file_info.stat.exists
+    - not zabbix_windows_binaries.stat.exists
   register: zabbix_agent_win_download_zip
   until: zabbix_agent_win_download_zip is succeeded
   throttle: "{{ zabbix_download_throttle | default(5) | int }}"
@@ -154,7 +209,7 @@
   win_unzip:
     src: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
     dest: "{{ zabbix_win_install_dir }}"
-    creates: '{{ zabbix_win_exe_path }}'
+    creates: "{{ zabbix_win_exe_path }}"
 
 - name: "Windows | Cleanup downloaded Zabbix Agent Zip file"
   win_file:
@@ -165,41 +220,18 @@
 
 - name: "Windows | Configure zabbix-agent"
   win_template:
-    src: zabbix_agentd.conf.j2
-    dest: '{{ zabbix_win_install_dir }}\zabbix_agentd.conf'
+    src:  "{{ zabbix_win_config_name }}.j2"
+    dest: "{{ zabbix_win_install_dir }}\\{{ zabbix_win_config_name }}"
   notify: restart win zabbix agent
-  when:
-    - not zabbix_agent2
 
-- name: "Windows | Configure zabbix-agent2"
-  win_template:
-    src: zabbix_agent2.conf.j2
-    dest: '{{ zabbix_win_install_dir }}\zabbix_agent2.conf'
-  notify: restart win zabbix agent
-  when:
-    - zabbix_agent2 | bool
+- name: "Windows | Check if windows service exist"
+  win_service:
+    name: "{{ zabbix_win_svc_name }}"
+  register: zabbix_windows_service
 
 - name: "Windows | Register Service"
-  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agentd.conf" --install'
-  register: zabbix_windows_install
-  args:
-    creates: '{{ zabbix_win_install_dir }}\.installed'
-  when:
-    - not zabbix_agent2
-
-- name: "Windows | Register Service (agent 2)"
-  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\zabbix_agent2.conf" --install'
-  register: zabbix_windows_install
-  args:
-    creates: '{{ zabbix_win_install_dir }}\.installed'
-  when:
-    - zabbix_agent2 | bool
-
-- name: "Windows | Create done file so it won't register itself again"
-  win_file:
-    path: '{{ zabbix_win_install_dir }}\.installed'
-    state: touch
-  when: zabbix_windows_install is changed
+  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix_win_config_name }}" --install'
+  when: not zabbix_windows_service.exists
 
 - name: "Windows | Set service startup mode to auto and ensure it is started"
   win_service:
@@ -212,13 +244,20 @@
   register: svc_recovery
   changed_when: false
   check_mode: false
-  when: zabbix_agent_win_svc_recovery
+  when:
+    - zabbix_agent_win_svc_recovery
 
 - name: "Windows | Setting Zabbix Service Recovery"
   win_shell: 'sc.exe failure "{{ zabbix_win_svc_name }}" actions= restart/5000/restart/10000/restart/20000 reset= 86400'
   when:
     - "'RESTART -- Delay' not in svc_recovery.stdout"
     - zabbix_agent_win_svc_recovery
+
+- name: "Windows | Check firewall service"
+  ansible.windows.win_service_info:
+    name: MpsSvc
+  register: firewall_info
+  when: zabbix_win_firewall_management
 
 - name: "Windows | Firewall rule"
   win_firewall_rule:
@@ -229,4 +268,6 @@
     protocol: tcp
     state: present
     enabled: yes
-  when: firewall_info.state == 'started'
+  when:
+    - zabbix_win_firewall_management
+    - firewall_info.services[0].state == 'started' or firewall_info.services[0].start_mode == 'auto'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added zabbix agent 2 support
Added migration from 1 to 2 and vice versa.
Fixed agent 2 log path in j2 template
Fixed issue with windows firewall on windows server 2016\2019

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Windows.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Added agent2 support (upgrade and downgrade covered)
Change upgrade rule, now it checks exe version and in mismatch =>  reinstall
Fixed agent2 log path in jinja template
Fixed win firewall issue on 2016\2019 (win_service not working anymore, due to missing permissions on admins\users) 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
