### PR TITLE
win zabbix2 agent var re-use, template log path

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -208,9 +208,9 @@ zabbix_win_download_url: https://cdn.zabbix.com/zabbix/binaries/stable
 zabbix_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_agent_version }}/{{ zabbix_version_long }}/{{ zabbix_win_package }}"
 zabbix2_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_agent_version }}/{{ zabbix_version_long }}/{{ zabbix2_win_package }}"
 zabbix_win_install_dir: 'C:\Zabbix'
-zabbix_agent_win_logfile: 'C:\Zabbix\zabbix_agentd.log'
-zabbix_agent_win_include: 'C:\Zabbix\zabbix_agent.d\'
-zabbix_agent2_win_logfile: 'C:\Zabbix\zabbix_agent2.log'
+zabbix_agent_win_logfile: "{{ zabbix_win_install_dir }}\\zabbix_agentd.log"
+zabbix_agent_win_include: "{{ zabbix_win_install_dir }}\\zabbix_agent.d\\"
+zabbix_agent2_win_logfile: "{{ zabbix_win_install_dir }}\\zabbix_agent2.log"
 zabbix_agent_win_svc_recovery: True
 zabbix_win_firewall_management: True
 

--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -32,6 +32,12 @@ LogType={{ zabbix_agent2_logtype }}
 
 LogFile={{ zabbix_agent2_logfile }}
 
+{% if zabbix_agent_os_family == "Windows" %}
+LogFile={{ zabbix_agent2_win_logfile }}
+{% else %}
+LogFile={{ zabbix_agent2_logfile }}
+{% endif %}
+
 ### Option: LogFileSize
 #	Maximum size of log file in MB.
 #	0 - disable automatic log rotation.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Add re-use of zabbix_win_install_dir var in other vars ( exclude bulk vars override in case changing installation dir )
Add if/else statement depends on os for agent2 log path 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_agent

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
