### PR TITLE
Update zabbix.yml

### DIFF
--- a/roles/zabbix_agent/vars/zabbix.yml
+++ b/roles/zabbix_agent/vars/zabbix.yml
@@ -1,6 +1,23 @@
 ---
 sign_keys:
+  "55":
+    bullseye:
+      sign_key: E709712C
+    buster:
+      sign_key: E709712C
+    stretch:
+      sign_key: E709712C
+    focal:
+      sign_key: E709712C
+    bionic:
+      sign_key: E709712C
+    xenial:
+      sign_key: E709712C
+    trusty:
+      sign_key: E709712C
   "54":
+    bullseye:
+      sign_key: E709712C
     buster:
       sign_key: E709712C
     stretch:


### PR DESCRIPTION
Added 'sign_keys' for rel 5.5, also added 'bullseye' for rel 5.4. Removed 'jessie' and 'tricia' from rel 5.5 too.

##### SUMMARY
Update of repo sign_key metadata to enable recent releases of zabbix-agent with recent releases of Debian.

##### ISSUE TYPE
- Bugfix Pull Request
