### PR TITLE
zabbix_agent_logtype can be defined, just as zabbix_agent2_logtype.

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -168,7 +168,7 @@ Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
 * `zabbix_agent(2)_pidfile`: name of pid file.
 * `zabbix_agent(2)_logfile`: name of log file.
 * `zabbix_agent(2)_logfilesize`: maximum size of log file in mb.
-* `zabbix_agent2_logtype`: Specifies where log messages are written to
+* `zabbix_agent(2)_logtype`: Specifies where log messages are written to
 * `zabbix_agent(2)_debuglevel`: specifies debug level
 * `zabbix_agent(2)_sourceip`: source ip address for outgoing connections.
 * `zabbix_agent_enableremotecommands`: whether remote commands from zabbix server are allowed.

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -98,6 +98,7 @@ zabbix_agent_firewall_chain: INPUT
 zabbix_agent_firewalld_zone:
 # Zabbix configuration variables
 zabbix_agent_pidfile: /var/run/zabbix/zabbix_agentd.pid
+zabbix_agent_logtype: file
 zabbix_agent_logfile: /var/log/zabbix/zabbix_agentd.log
 zabbix_agent_logfilesize: 100
 zabbix_agent_debuglevel: 3

--- a/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
@@ -11,6 +11,19 @@
 PidFile={{ zabbix_agent_pidfile }}
 {% endif %}
 
+{% if zabbix_agent_version is version('3.0', '>=') %}
+### Option: LogType
+#	Specifies where log messages are written to:
+#		system  - syslog
+#		file    - file specified with LogFile parameter
+#		console - standard output
+#
+# Mandatory: no
+# Default:
+
+LogType={{ zabbix_agent_logtype }}
+{% endif %}
+
 ### option: logfile
 #       name of log file.
 #       if not set, syslog is used.


### PR DESCRIPTION
##### SUMMARY
In zabbix_agent role, added the zabbix_agent_logtype variable, with default to "file".
So it can be set by users to system or console as specified in zabbix agent documentation.
It was already possible for the agent2 so it's juste extended to agent.
DOC updated, zabbix_agent_version checked as this option is only usable for agent >= 3.0

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
roles/zabbix_agent/default/main.yml 
roles/zabbix_agent/templates/zabbix_agentd.conf.j2
docs/ZABBIX_AGENT_ROLE.md 
