### PR TITLE
skip sanity tests for unsupported combo ansible2.12 and py37

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -36,6 +36,8 @@ jobs:
         exclude:
           - ansible: devel
             python: 3.7
+          - ansible: devel
+            python: 2.7
 
     steps:
       - name: Check out code

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -25,7 +25,6 @@ jobs:
           - version: "5.0"
           - version: "5.2"
         ansible:
-          # - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
           - stable-2.11
           - devel
@@ -34,6 +33,9 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+        exclude:
+          - ansible: devel
+            python: 3.7
 
     steps:
       - name: Check out code

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -56,6 +56,8 @@ jobs:
         exclude:
           - ansible: devel
             python: 3.7
+          - ansible: devel
+            python: 2.7
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -45,7 +45,6 @@ jobs:
         ansible:
           # It's important that Sanity is tested against all stable-X.Y branches
           # Testing against `devel` may fail as new tests are added.
-        # - stable-2.9 # Only if your collection supports Ansible 2.9
           - stable-2.10
           - stable-2.11
           - devel
@@ -54,6 +53,9 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+        exclude:
+          - ansible: devel
+            python: 3.7
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
##### SUMMARY
Fix failing CI for ansible 2.12 and py3.7 as that is not supported combo

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/workflows/
