### PR TITLE
fix windows service auto-recovery setting problem

### DIFF
--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -233,25 +233,19 @@
   win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix_win_config_name }}" --install'
   when: not zabbix_windows_service.exists
 
-- name: "Windows | Set service startup mode to auto and ensure it is started"
+- name: "Windows | Set service startup mode to auto, ensure it is started and set auto-recovery"
   win_service:
     name: "{{ zabbix_win_svc_name }}"
     start_mode: auto
     state: started
-
-- name: "Windows | Getting Zabbix Service Recovery Settings"
-  win_shell: 'sc.exe qfailure "{{ zabbix_win_svc_name }}" 1100'
-  register: svc_recovery
-  changed_when: false
-  check_mode: false
-  when:
-    - zabbix_agent_win_svc_recovery
-
-- name: "Windows | Setting Zabbix Service Recovery"
-  win_shell: 'sc.exe failure "{{ zabbix_win_svc_name }}" actions= restart/5000/restart/10000/restart/20000 reset= 86400'
-  when:
-    - "'RESTART -- Delay' not in svc_recovery.stdout"
-    - zabbix_agent_win_svc_recovery
+    failure_actions:
+    - type: restart
+      delay_ms: 5000
+    - type: restart
+      delay_ms: 10000
+    - type: restart
+      delay_ms: 20000
+    failure_reset_period_sec: 86400
 
 - name: "Windows | Check firewall service"
   ansible.windows.win_service_info:


### PR DESCRIPTION
##### SUMMARY

Previously windows service auto-recovery settings task used two steps: 
1) Get service info using 'win_shell' module and command-line utility 'sc.exe'
2) Tweaks auato-recovery settings using same utility 'sc.exe' when some key string is found in registered output in step 1

Problems:
1) This design leads to throwing an error (The error was: error while evaluating conditional ('RESTART -- Delay' not in svc_recovery.stdout): 'dict object' has no attribute 'stdout')
2) It just can not work in different than English OS locales by design - in that locales 'sc.exe' returns different strings.
3) It is bad practice to use win_shell and command-line tools to make things that can be done idempotent way using buit-in Ansible modules

So this fix just reimplement this task by using 'win_service' capabilities to set auto-recovery settings.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tasks/Windows.yml

##### ADDITIONAL INFORMATION
To reproduce 1st problem:
Use Windows Server 2019 LTSC
Add role to play using vars:
    vars:
      zabbix_agent_version: 5.4
      zabbix_agent_server: 10.7.0.3
      zabbix_agent_serveractive: 10.7.0.3
      zabbix_agent2: true
      zabbix_win_firewall_management: False
      zabbix_agent2_hostmetadata: windows
      zabbix_version_long: 5.4.4

Before
```
TASK [community.zabbix.zabbix_agent : Windows | Setting Zabbix Service Recovery] **************************************************************************
fatal: [servername]: FAILED! => {"msg": "The conditional check ''RESTART -- Delay' not in svc_recovery.stdout' failed. The error was: error while evaluating conditional ('RESTART -- Delay' not in svc_recovery.stdout): 'dict object' has no attribute 'stdout'\n\nThe error appears to be in '/usr/local/lib/python3.8/dist-packages/ansible_collections/community/zabbix/roles/zabbix_agent/tasks/Windows.yml': line 250, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Windows | Setting Zabbix Service Recovery\"\n  ^ here\n"}
```
After:
```
TASK [community.zabbix.zabbix_agent : Windows | Set service startup mode to auto and ensure it is started] ************************************************
changed: [servername]
```