### PR TITLE
agent 5.0 on deb11/bullseye

### DIFF
--- a/roles/zabbix_agent/vars/zabbix.yml
+++ b/roles/zabbix_agent/vars/zabbix.yml
@@ -35,6 +35,7 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "52":
+    # bullseye: not available upstream
     buster:
       sign_key: E709712C
     stretch:
@@ -52,6 +53,8 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "50":
+    bullseye:
+      sign_key: E709712C
     buster:
       sign_key: E709712C
     stretch:


### PR DESCRIPTION
##### SUMMARY

tested agent install on debian11.

Fixes #443 (partially)
