### PR TITLE
[wip]delete temporary extraction file "schema.sql" for permission problem

### DIFF
--- a/roles/zabbix_proxy/tasks/postgresql.yml
+++ b/roles/zabbix_proxy/tasks/postgresql.yml
@@ -71,12 +71,9 @@
 
 - name: "PostgreSQL | Importing schema file"
   shell: |
-    cd {{ datafiles_path }}
-    if [ -f schema.sql.gz ]
-      then gunzip schema.sql.gz
-    fi
-    psql -h '{{ zabbix_proxy_dbhost }}' -U '{{ zabbix_proxy_dbuser }}' \
-    -d '{{ zabbix_proxy_dbname }}' -f schema.sql && touch /etc/zabbix/schema.done
+    set -o pipefail
+    zcat {{ datafiles_path }}/schema.sql.gz | psql -h '{{ zabbix_proxy_dbhost }}' -U '{{ zabbix_proxy_dbuser }}' \
+    -d '{{ zabbix_proxy_dbname }}' && touch /etc/zabbix/schema.done
   args:
     creates: /etc/zabbix/schema.done
   environment:

--- a/roles/zabbix_server/tasks/postgresql.yml
+++ b/roles/zabbix_server/tasks/postgresql.yml
@@ -151,13 +151,12 @@
 
 - name: "PostgreSQL | Importing schema file"
   shell: >
-    cd {{ datafiles_path }} &&
-    if [ -f schema.sql.gz ]; then gunzip schema.sql.gz ; fi &&
-    psql -h '{{ zabbix_server_dbhost }}'
+    set -o pipefail
+    zcat {{ datafiles_path }}/schema.sql.gz | psql -h '{{ zabbix_server_dbhost }}'
     -U '{{ zabbix_server_dbuser }}'
     -d '{{ zabbix_server_dbname }}'
     -p '{{ zabbix_server_dbport }}'
-    -f schema.sql && touch /etc/zabbix/schema.done
+    && touch /etc/zabbix/schema.done
   args:
     creates: /etc/zabbix/schema.done
     warn: no


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I change command of PostgreSQL schema.sql execution
 from "extraction /usr/share/doc/zabbix-proxy-pgsql/schema.sql"
 to using pipe. 

This PR resolves the permission error of extracting schema.sql.gz by using pipe.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
https://github.com/ansible-collections/community.zabbix/issues/463

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_proxy role
zabbix_server role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
