### PR TITLE
rename calling list.iteritems() to list.items() to switch python3

### DIFF
--- a/roles/zabbix_web/templates/zabbix.conf.php.j2
+++ b/roles/zabbix_web/templates/zabbix.conf.php.j2
@@ -35,7 +35,7 @@ $DB['DOUBLE_IEEE754']   = true;
 {% endif %}
 
 {% if zabbix_web_env is defined %}
-{% for env,val in zabbix_web_env.iteritems() %}
+{% for env,val in zabbix_web_env.items() %}
 putenv("{{env}}={{val}}");
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
zabbix-web role is failed at "Configure zabbix-web" step when parameter zabbix_web_env is setted.
this problem caused by obsoluting "list.iteritems()" method of python list object.
list.iteritems() was obsoluted from python3, and using list.items() method is recommended.

This PR change method calling of "list.iteritems()" to "list.items()".

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #238

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

zabbix-web role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
