### PR TITLE
feat: Update roles to use collections for Ansible 2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,14 @@ For the majority of modules, however, you can get away with just:
 ```bash
 pip install zabbix-api
 ```
+#### Ansible 2.10 and higher
 
+With the release of Ansible 2.10, modules have been moved into collections.  With the exception of ansible.builtin modules, this means additonal collections must be installed in order to use modules such as seboolean (now ansible.posix.seboolean).  The following collections are now frequently required: `ansible.posix` and `community.general`.  Installing the collections:
+
+```bash
+ansible-galaxy collection install ansible.posix
+ansible-galaxy collection install community.general
+```
 ### Installing the Collection from Ansible Galaxy
 
 Before using the Zabbix collection, you need to install it with the Ansible Galaxy CLI:
@@ -88,13 +95,17 @@ Before using the Zabbix collection, you need to install it with the Ansible Gala
 ansible-galaxy collection install community.zabbix
 ```
 
-You can also include it in a `requirements.yml` file and install it via `ansible-galaxy collection install -r requirements.yml`, using the format:
+You can also include it in a `requirements.yml` file along with other required collections and install them via `ansible-galaxy collection install -r requirements.yml`, using the format:
 
 ```yaml
 ---
 collections:
   - name: community.zabbix
     version: 1.4.0
+  - name: ansible.posix
+    version: 1.3.0
+  - name: community.general
+    version: 3.7.0
 ```
 
 ### Upgrading collection

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -54,12 +54,30 @@ This role will work on the following operating systems:
 So, you'll need one of those operating systems.. :-)
 Please send Pull Requests or suggestions when you want to use this role for other Operating systems.
 
+## Ansible 2.10 and higher
+
+With the release of Ansible 2.10, modules have been moved into collections.  With the exception of ansible.builtin modules, this means additonal collections must be installed in order to use modules such as seboolean (now ansible.posix.seboolean).  The following collections are now required: `ansible.posix`and `community.general`.  Installing the collections:
+
+```sh
+ansible-galaxy collection install ansible.posix
+ansible-galaxy collection install community.general
+```
+
+### Docker
+
+When you are a Docker user and using Ansible 2.10 or newer, then there is a dependency on the collection named `community.docker`. This collection is needed as the `docker_` modules are now part of collections and not standard in Ansible anymmore. Installing the collection:
+
+```sh
+ansible-galaxy collection install community.docker
+```
+
 ### Windows
 
-When you are a Windows user and using Ansible 2.10 or newer, then there is a dependency on a collection named `ansible.windows`. This collection is needed as the `win_service` is part of this collection and not standard in Ansible anymmore. Installing the collection:
+When you are a Windows user and using Ansible 2.10 or newer, then there are dependencies on collections named `ansible.windows` and `community.windows`. These collections are needed as the `win_` modules are now part of collections and not standard in Ansible anymmore. Installing the collections:
 
 ```sh
 ansible-galaxy collection install ansible.windows
+ansible-galaxy collection install community.windows
 ```
 
 For more information, see: https://github.com/ansible-collections/community.zabbix/issues/236

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -42,6 +42,31 @@ This role will work on the following operating systems:
 So, you'll need one of those operating systems.. :-)
 Please send Pull Requests or suggestions when you want to use this role for other Operating systems.
 
+# Requirements
+## Ansible 2.10 and higher
+
+With the release of Ansible 2.10, modules have been moved into collections.  With the exception of ansible.builtin modules, this means additonal collections must be installed in order to use modules such as seboolean (now ansible.posix.seboolean).  The following collection is now required: `ansible.posix`.  Installing the collection:
+
+```sh
+ansible-galaxy collection install ansible.posix
+```
+
+### MySQL
+
+When you are a MySQL user and using Ansible 2.10 or newer, then there is a dependency on the collection named `community.mysql`. This collections are needed as the `mysql_` modules are now part of collections and not standard in Ansible anymmore. Installing the collection:
+
+```sh
+ansible-galaxy collection install community.mysql
+```
+
+### PostgreSQL
+
+When you are a PostgreSQL user and using Ansible 2.10 or newer, then there is a dependency on the collection named `community.postgresql`. This collections are needed as the `postgresql_` modules are now part of collections and not standard in Ansible anymmore. Installing the collection:
+
+```sh
+ansible-galaxy collection install community.mysql
+```
+
 ## Zabbix Versions
 
 See the following list of supported Operating systems with the Zabbix releases.

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -47,6 +47,30 @@ This role will work on the following operating systems:
 So, you'll need one of those operating systems.. :-)
 Please send Pull Requests or suggestions when you want to use this role for other Operating systems.
 
+## Ansible 2.10 and higher
+
+With the release of Ansible 2.10, modules have been moved into collections.  With the exception of ansible.builtin modules, this means additonal collections must be installed in order to use modules such as seboolean (now ansible.posix.seboolean).  The following collection is now required: `ansible.posix`.  Installing the collection:
+
+```sh
+ansible-galaxy collection install ansible.posix
+```
+
+### MySQL
+
+When you are a MySQL user and using Ansible 2.10 or newer, then there is a dependency on the collection named `community.mysql`. This collections are needed as the `mysql_` modules are now part of collections and not standard in Ansible anymmore. Installing the collection:
+
+```sh
+ansible-galaxy collection install community.mysql
+```
+
+### PostgreSQL
+
+When you are a PostgreSQL user and using Ansible 2.10 or newer, then there is a dependency on the collection named `community.postgresql`. This collections are needed as the `postgresql_` modules are now part of collections and not standard in Ansible anymmore. Installing the collection:
+
+```sh
+ansible-galaxy collection install community.mysql
+```
+
 ## Zabbix Versions
 
 See the following list of supported Operating systems with the Zabbix releases:

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -41,6 +41,15 @@ This role will work on the following operating systems:
 So, you'll need one of those operating systems.. :-)
 Please send Pull Requests or suggestions when you want to use this role for other Operating systems.
 
+## Ansible 2.10 and higher
+
+With the release of Ansible 2.10, modules have been moved into collections.  With the exception of ansible.builtin modules, this means additonal collections must be installed in order to use modules such as seboolean (now ansible.posix.seboolean).  The following collections are now required: `ansible.posix`.  The `community.general` collection is required when defining the `zabbix_web_htpasswd` variable (see variable section below).  Installing the collections:
+
+```sh
+ansible-galaxy collection install ansible.posix
+ansible-galaxy collection install community.general
+```
+
 ## Zabbix Versions
 
 See the following list of supported Operating Systems with the Zabbix releases.

--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -174,7 +174,7 @@ EXAMPLES = r'''
     server_url: http://127.0.0.1
     login_user: username
     login_password: password
-    template_xml: "{{ lookup('file', 'zabbix_apache2.json') }}"
+    template_xml: "{{ lookup('file', 'zabbix_apache2.xml') }}"
     state: present
 
 - name: Import Zabbix template from Ansible dict variable

--- a/roles/zabbix_agent/tasks/Docker.yml
+++ b/roles/zabbix_agent/tasks/Docker.yml
@@ -16,7 +16,7 @@
     - zabbix_agent_tlspskfile is defined
 
 - name: "Ensure Zabbix Docker container is running"
-  docker_container:
+  community.docker.docker_container:
     name: "{{ zabbix_agent_docker_name }}"
     image: "{{ zabbix_agent_docker_image }}:{{ zabbix_agent_docker_image_tag }}"
     state: "{{ zabbix_agent_docker_state }}"

--- a/roles/zabbix_agent/tasks/Suse.yml
+++ b/roles/zabbix_agent/tasks/Suse.yml
@@ -5,7 +5,7 @@
   include_vars: zabbix.yml
 
 - name: "Install zypper repo dependency"
-  zypper:
+  community.general.zypper:
     name: ["python-libxml2", "python-xml"]
     state: present
   environment:
@@ -16,7 +16,7 @@
   until: zabbix_agent_package_dependency is succeeded
 
 - name: "Suse | Install basic repo file"
-  zypper_repository:
+  community.general.zypper_repository:
     repo: "{{ suse[ansible_distribution][zabbix_agent_distribution_major_version]['url'] }}"
     name: "{{ suse[ansible_distribution][zabbix_agent_distribution_major_version]['name'] }}"
     state: present
@@ -38,7 +38,7 @@
     - zabbix_agent_install_agent_only
 
 - name: "Suse | Install zabbix-agent"
-  zypper:
+  community.general.zypper:
     name: "{{ zabbix_agent_packages }}"
     state: "{{ zabbix_agent_package_state }}"
     disable_gpg_check: yes

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -32,7 +32,7 @@
     - zabbix_version_long is version('4.0.0', '>=')
 
 - name: "Windows | Check if Zabbix agent is present"
-  win_stat:
+  ansible.windows.win_stat:
     path: '{{ item }}'
   with_items:
     - "{{ zabbix_win_exe_path }}"
@@ -40,7 +40,7 @@
   register: agent_file_info
 
 - name: "Windows | Get Installed Zabbix Agent Version"
-  win_file_version:
+  community.windows.win_file_version:
     path: "{{ item.item }}"
   register: zabbix_win_exe_info
   when:
@@ -68,7 +68,7 @@
     - zabbix_win_exe_info.results[1].win_file_version.product_version
 
 - name: "Windows | Check Zabbix service"
-  win_service:
+  ansible.windows.win_service:
     name: "{{ (item.item.stat.path == zabbix_win_exe_path ) | ternary(zabbix_win_svc_name,zabbix2_win_svc_name) }}"
   register: zabbix_service_info
   when: item.item.stat.exists
@@ -103,7 +103,7 @@
 ##################
 
 - name: "Windows | Stop Zabbix agent v1"
-  win_service:
+  ansible.windows.win_service:
     name: "{{ zabbix_win_svc_name }}"
     start_mode: auto
     state: stopped
@@ -112,7 +112,7 @@
     - zabbix_agent_1_service_exist | default(false)
 
 - name: "Windows | Stop Zabbix agent v2"
-  win_service:
+  ansible.windows.win_service:
     name: "{{ zabbix2_win_svc_name }}"
     start_mode: auto
     state: stopped
@@ -121,19 +121,19 @@
     - zabbix_agent_2_service_exist | default(false)
 
 - name: "Windows | Uninstall Zabbix v1"
-  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix_win_config_name }}" --uninstall'
+  ansible.windows.win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix_win_config_name }}" --uninstall'
   when:
     - zabbix_agent_version_change | default(false) or zabbix_agent2
     - zabbix_agent_1_service_exist | default(false)
 
 - name: "Windows | Uninstall Zabbix v2"
-  win_command: '"{{ zabbix2_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix2_win_config_name }}" --uninstall'
+  ansible.windows.win_command: '"{{ zabbix2_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix2_win_config_name }}" --uninstall'
   when:
     - zabbix_agent_version_change | default(false) or not zabbix_agent2
     - zabbix_agent_2_service_exist | default(false)
 
 - name: "Windows | Removing Zabbix Directory"
-  win_file:
+  ansible.windows.win_file:
     path: '{{ zabbix_win_install_dir }}'
     state: absent
   when: ((zabbix_agent_version_change | default(false) or zabbix_agent2) and zabbix_agent_1_binary_exist | default(false)) or
@@ -144,14 +144,14 @@
 ###################
 
 - name: "Windows | Create directory structure"
-  win_file:
+  ansible.windows.win_file:
     path: "{{ item }}"
     state: directory
   with_items:
     - "{{ zabbix_win_install_dir }}"
 
 - name: "Windows | Create directory structure, includes"
-  win_file:
+  ansible.windows.win_file:
     path: "{{ item }}"
     state: directory
   with_items:
@@ -160,7 +160,7 @@
     - ('.conf' not in zabbix_agent_win_include)
 
 - name: "Windows | Place TLS-PSK file"
-  win_copy:
+  ansible.windows.win_copy:
     content: "{{ zabbix_agent_tlspsk_secret }}"
     dest: "{{ zabbix_agent_tlspskfile }}"
   when:
@@ -178,17 +178,17 @@
   when: zabbix_agent2 | bool
 
 - name: "Windows | Check if agent file is already downloaded"
-  win_stat:
+  ansible.windows.win_stat:
     path: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
   register: file_info
 
 - name: "Windows | Check if agent binaries in place"
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ zabbix_win_exe_path }}"
   register: zabbix_windows_binaries
 
 - name: "Windows | Download Zabbix Agent Zip file"
-  win_get_url:
+  ansible.windows.win_get_url:
     url: "{{ zabbix_win_download_link }}"
     dest: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
     url_username: "{{zabbix_download_user|default(omit)}}"
@@ -206,35 +206,35 @@
   throttle: "{{ zabbix_download_throttle | default(5) | int }}"
 
 - name: "Windows | Unzip file"
-  win_unzip:
+  community.windows.win_unzip:
     src: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
     dest: "{{ zabbix_win_install_dir }}"
     creates: "{{ zabbix_win_exe_path }}"
 
 - name: "Windows | Cleanup downloaded Zabbix Agent Zip file"
-  win_file:
+  ansible.windows.win_file:
     path: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
     state: absent
   when:
     - zabbix_agent_win_download_zip.changed
 
 - name: "Windows | Configure zabbix-agent"
-  win_template:
+  ansible.windows.win_template:
     src:  "{{ zabbix_win_config_name }}.j2"
     dest: "{{ zabbix_win_install_dir }}\\{{ zabbix_win_config_name }}"
   notify: restart win zabbix agent
 
 - name: "Windows | Check if windows service exist"
-  win_service:
+  ansible.windows.win_service:
     name: "{{ zabbix_win_svc_name }}"
   register: zabbix_windows_service
 
 - name: "Windows | Register Service"
-  win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix_win_config_name }}" --install'
+  ansible.windows.win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix_win_config_name }}" --install'
   when: not zabbix_windows_service.exists
 
 - name: "Windows | Set service startup mode to auto, ensure it is started and set auto-recovery"
-  win_service:
+  ansible.windows.win_service:
     name: "{{ zabbix_win_svc_name }}"
     start_mode: auto
     state: started
@@ -254,7 +254,7 @@
   when: zabbix_win_firewall_management
 
 - name: "Windows | Firewall rule"
-  win_firewall_rule:
+  community.windows.win_firewall_rule:
     name: "{{ zabbix_win_svc_name }}"
     localport: "{{ zabbix_agent_listenport }}"
     action: allow

--- a/roles/zabbix_agent/tasks/firewall.yml
+++ b/roles/zabbix_agent/tasks/firewall.yml
@@ -26,7 +26,7 @@
     - zabbix_agent_jmx_listenport | bool
 
 - name: "Firewall | Configure firewalld (zabbix_agent_listenport)"
-  firewalld:
+  ansible.posix.firewalld:
     rich_rule: 'rule family="ipv4" source address="{{ zabbix_agent_firewalld_source }}" port protocol="tcp" port="{{ zabbix_agent_listenport }}" accept'
     zone: "{{ zabbix_agent_firewalld_zone }}"
     permanent: true
@@ -39,7 +39,7 @@
   tags: zabbix_agent_firewalld_enable
 
 - name: "Firewall | Configure firewalld (zabbix_agent_jmx_listenport)"
-  firewalld:
+  ansible.posix.firewalld:
     rich_rule: 'rule family="ipv4" source address="{{ zabbix_agent_firewalld_source }}" port protocol="tcp" port="{{ zabbix_agent_jmx_listenport }}" accept'
     zone: "{{ zabbix_agent_firewalld_zone }}"
     permanent: true

--- a/roles/zabbix_agent/tasks/selinux.yml
+++ b/roles/zabbix_agent/tasks/selinux.yml
@@ -86,13 +86,13 @@
     - 'getenforce_bin.stat.exists and ("Enforcing" in sestatus.stdout or "Permissive" in sestatus.stdout)'
 
 - name: "SELinux | Allow zabbix_agent to start (SELinux)"
-  selinux_permissive:
+  community.general.selinux_permissive:
     name: zabbix_agent_t
     permissive: true
   become: yes
 
 - name: "SELinux | Allow zabbix to run sudo commands (SELinux)"
-  seboolean:
+  ansible.posix.seboolean:
     name: zabbix_run_sudo
     persistent: yes
     state: yes

--- a/roles/zabbix_agent/tasks/tlspsk_auto_agent2_windows.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_agent2_windows.yml
@@ -5,13 +5,13 @@
     zabbix_agent2_tlspskidentity_file: "{{ zabbix_win_install_dir }}\\tls_psk_auto.identity.txt"
 
 - name: AutoPSK | Check for existing TLS PSK file (Windows)
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ zabbix_agent2_tlspskfile }}"
   register: zabbix_agent2_tlspskcheck
   become: yes
 
 - name: AutoPSK | Check for existing TLS PSK identity (Windows)
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ zabbix_agent2_tlspskidentity_file }}"
   register: zabbix_agent2_tlspskidentity_check
   become: yes

--- a/roles/zabbix_agent/tasks/tlspsk_auto_windows.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_windows.yml
@@ -5,13 +5,13 @@
     zabbix_agent_tlspskidentity_file: "{{ zabbix_win_install_dir }}\\tls_psk_auto.identity.txt"
 
 - name: AutoPSK | Check for existing TLS PSK file (Windows)
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ zabbix_agent_tlspskfile }}"
   register: zabbix_agent_tlspskcheck
   become: yes
 
 - name: AutoPSK | Check for existing TLS PSK identity (Windows)
-  win_stat:
+  ansible.windows.win_stat:
     path: "{{ zabbix_agent_tlspskidentity_file }}"
   register: zabbix_agent_tlspskidentity_check
   become: yes

--- a/roles/zabbix_agent/tasks/userparameter.yml
+++ b/roles/zabbix_agent/tasks/userparameter.yml
@@ -1,7 +1,7 @@
 ---
 - block:
   - name: "Windows | Installing user-defined userparameters"
-    win_template:
+    ansible.windows.win_template:
       src: "{{ zabbix_agent_userparameters_templates_src }}/{{ item.name }}.j2"
       dest: '{{ zabbix_agent_win_include }}\{{ item.name }}.conf'
     notify:
@@ -9,7 +9,7 @@
     with_items: "{{ zabbix_agent_userparameters }}"
   
   - name: "Windows | Installing user-defined scripts"
-    win_copy:
+    ansible.windows.win_copy:
       src: "{{ zabbix_agent_userparameters_scripts_src }}/{{ item.scripts_dir }}"
       dest: '{{ zabbix_win_install_dir }}\scripts\'
     notify:

--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -68,7 +68,7 @@
     - restart zabbix-proxy
 
 - name: "Allow zabbix-proxy to open connections (SELinux)"
-  seboolean:
+  ansible.posix.seboolean:
     name: zabbix_can_network
     persistent: yes
     state: yes
@@ -77,7 +77,7 @@
   tags: selinux
 
 - name: "Allow zabbix-proxy to connect to zabbix_proxy_preprocessing.sock (SELinux)"
-  seboolean:
+  ansible.posix.seboolean:
     name: daemons_enable_cluster_mode
     persistent: yes
     state: yes

--- a/roles/zabbix_proxy/tasks/mysql.yml
+++ b/roles/zabbix_proxy/tasks/mysql.yml
@@ -18,7 +18,7 @@
   when: zabbix_proxy_real_dbhost | default(false)
 
 - name: "MySQL | Create database"
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ zabbix_proxy_dbname }}"
     encoding: "{{ zabbix_proxy_dbencoding }}"
     collation: "{{ zabbix_proxy_dbcollation }}"
@@ -37,7 +37,7 @@
     - skip_ansible_lint
 
 - name: "MySQL | Create database user"
-  mysql_user:
+  community.mysql.mysql_user:
     login_host: "{{ zabbix_proxy_mysql_login_host | default(omit) }}"
     login_user: "{{ zabbix_proxy_mysql_login_user | default(omit) }}"
     login_password: "{{ zabbix_proxy_mysql_login_password | default(omit) }}"
@@ -87,7 +87,7 @@
   become: true
 
 - name: "MySQL | Set innodb_default_row_format to dynamic"
-  mysql_variables:
+  community.mysql.mysql_variables:
     variable: innodb_default_row_format
     value: dynamic
     login_host: "{{ zabbix_proxy_mysql_login_host | default(omit) }}"
@@ -107,7 +107,7 @@
     - database
 
 - name: "MySQL | Create database and import file"
-  mysql_db:
+  community.mysql.mysql_db:
     login_host: "{{ zabbix_proxy_mysql_login_host | default(omit) }}"
     login_user: "{{ zabbix_proxy_mysql_login_user | default(omit) }}"
     login_password: "{{ zabbix_proxy_mysql_login_password | default(omit) }}"
@@ -128,7 +128,7 @@
     - database
 
 - name: "MySQL | Revert innodb_default_row_format to previous value"
-  mysql_variables:
+  community.mysql.mysql_variables:
     variable: innodb_default_row_format
     value: '{{ mysql_innodb_default_row_format.stdout }}'
     login_host: "{{ zabbix_proxy_mysql_login_host | default(omit) }}"

--- a/roles/zabbix_proxy/tasks/postgresql.yml
+++ b/roles/zabbix_proxy/tasks/postgresql.yml
@@ -16,7 +16,7 @@
 - name: "PostgreSQL | Delegated"
   block:
     - name: "PostgreSQL | Delegated | Create database"
-      postgresql_db:
+      community.postgresql.postgresql_db:
         name: "{{ zabbix_proxy_dbname }}"
         port: "{{ zabbix_proxy_dbport }}"
         state: present
@@ -42,7 +42,7 @@
 - name: "PostgreSQL | Remote"
   block:
     - name: "PostgreSQL | Remote | Create database"
-      postgresql_db:
+      community.postgresql.postgresql_db:
         login_host: "{{ zabbix_proxy_pgsql_login_host | default(omit) }}"
         login_user: "{{ zabbix_proxy_pgsql_login_user | default(omit) }}"
         login_password: "{{ zabbix_proxy_pgsql_login_password | default(omit) }}"

--- a/roles/zabbix_server/tasks/mysql.yml
+++ b/roles/zabbix_server/tasks/mysql.yml
@@ -18,7 +18,7 @@
   when: zabbix_server_real_dbhost | default(false)
 
 - name: "MySQL | Create database"
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ zabbix_server_dbname }}"
     encoding: "{{ zabbix_server_dbencoding }}"
     collation: "{{ zabbix_server_dbcollation }}"
@@ -37,7 +37,7 @@
     - skip_ansible_lint
 
 - name: "MySQL | Create database user"
-  mysql_user:
+  community.mysql.mysql_user:
     login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
     login_user: "{{ zabbix_server_mysql_login_user | default(omit) }}"
     login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
@@ -96,7 +96,7 @@
   become: true
 
 - name: "MySQL | Set innodb_default_row_format to dynamic"
-  mysql_variables:
+  community.mysql.mysql_variables:
     variable: innodb_default_row_format
     value: dynamic
     login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
@@ -116,7 +116,7 @@
     - database
 
 - name: "MySQL | Disable InnoDB Strict Mode"
-  mysql_variables:
+  community.mysql.mysql_variables:
     variable: innodb_strict_mode
     value: 0
     login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
@@ -158,7 +158,7 @@
     - mysql_schema_empty
 
 - name: "MySQL | Create database and import file >= 3.0"
-  mysql_db:
+  community.mysql.mysql_db:
     login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
     login_user: "{{ zabbix_server_mysql_login_user | default(omit) }}"
     login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
@@ -180,7 +180,7 @@
     - database
 
 - name: "MySQL | Revert innodb_default_row_format to previous value"
-  mysql_variables:
+  community.mysql.mysql_variables:
     variable: innodb_default_row_format
     value: '{{ mysql_innodb_default_row_format.stdout }}'
     login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
@@ -251,7 +251,7 @@
     - database
 
 - name: "MySQL | Create database and import files < 3.0"
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ zabbix_server_dbname }}"
     encoding: "{{ zabbix_server_dbencoding }}"
     collation: "{{ zabbix_server_dbcollation }}"

--- a/roles/zabbix_server/tasks/selinux.yml
+++ b/roles/zabbix_server/tasks/selinux.yml
@@ -59,7 +59,7 @@
     - zabbix-server
 
 - name: "SELinux | RedHat | Enable httpd_can_connect_zabbix SELinux boolean"
-  seboolean:
+  ansible.posix.seboolean:
     name: httpd_can_connect_zabbix
     state: yes
     persistent: yes
@@ -70,7 +70,7 @@
     - zabbix-server
 
 - name: "SELinux | RedHat | Enable zabbix_can_network SELinux boolean"
-  seboolean:
+  ansible.posix.seboolean:
     name: zabbix_can_network
     state: yes
     persistent: yes

--- a/roles/zabbix_web/tasks/access.yml
+++ b/roles/zabbix_web/tasks/access.yml
@@ -17,7 +17,7 @@
     - zabbix_web_htpasswd_users is defined
 
 - name: "htpasswd | manage HTTP authentication controls"
-  htpasswd:
+  community.general.htpasswd:
     path: "{{ zabbix_web_htpasswd_file }}"
     name: "{{ item.value.htpasswd_user }}"
     password: "{{ item.value.htpasswd_pass }}"

--- a/roles/zabbix_web/tasks/selinux.yml
+++ b/roles/zabbix_web/tasks/selinux.yml
@@ -37,7 +37,7 @@
     - zabbix-web
 
 - name: "SELinux | RedHat | Enable zabbix_can_network SELinux boolean"
-  seboolean:
+  ansible.posix.seboolean:
     name: zabbix_can_network
     state: yes
     persistent: yes
@@ -49,7 +49,7 @@
     - zabbix-web
 
 - name: "SELinux | Allow httpd to connect to db (SELinux)"
-  seboolean:
+  ansible.posix.seboolean:
     name: httpd_can_network_connect_db
     persistent: yes
     state: yes
@@ -60,7 +60,7 @@
   tags: selinux
 
 - name: "SELinux | Allow httpd to connect to zabbix (SELinux)"
-  seboolean:
+  ansible.posix.seboolean:
     name: httpd_can_connect_zabbix
     persistent: yes
     state: yes
@@ -71,7 +71,7 @@
   tags: selinux
 
 - name: "SELinux | Allow httpd to connect to ldap (SELinux)"
-  seboolean:
+  ansible.posix.seboolean:
     name: httpd_can_connect_ldap
     persistent: yes
     state: yes


### PR DESCRIPTION
##### SUMMARY
Most of the roles do not function properly when using Ansible 2.10 due to the transition of modules into separate collections.  For example, `seboolean` is not part of the `ansible.posix` collection, and this module is used in nearly every role.  Likewise, there are modules such as `mysql_` and `win_` that are now par of `community.mysql/windows` collections.  

I have updated the roles to call modules from their respective collections and updated the documentation for each role (and the overall package) to note what is required.

Additionally, I made a minor fix to the documentation of the `zabbix_template` module, correcting the example for importing a .xml template.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
zabbix_agent role
zabbix_proxy role
zabbix_server role
zabbix_web role
zabbix_template module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

