### PR TITLE
Fix sqlite directory permission

### DIFF
--- a/roles/zabbix_proxy/tasks/sqlite3.yml
+++ b/roles/zabbix_proxy/tasks/sqlite3.yml
@@ -10,6 +10,7 @@
 - name: "Sqlite3 | Create database"
   file:
     name: "{{ zabbix_proxy_dbname | dirname }}"
+    mode: 0744
     owner: zabbix
     group: zabbix
     seuser: system_u


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The dir must be traversable by zabbix user otherwise db creation will fail.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_proxy

##### ADDITIONAL INFORMATION

```
fatal: [test2021]: FAILED! => {"changed": true, "cmd": "set -o pipefail\nzcat /usr/share/doc/zabbix-proxy-sqlite3/schema.sql.gz | sqlite3 /var/lib/zabbix/db.sqlite\n", "delta": "0:00:00.015782", "end": "2021-10-13 23:37:39.218890", "msg": "non-zero return code", "rc": 1, "start": "2021-10-13 23:37:39.203108", "stderr": "Error: unable to open database \"/var/lib/zabbix/db.sqlite\": unable to open database file", "stderr_lines": ["Error: unable to open database \"/var/lib/zabbix/db.sqlite\": unable to open database file"], "stdout": "", "stdout_lines": []}
```
