### PR TITLE
fix: Add no_log to PSK encryption

### DIFF
--- a/roles/zabbix_agent/tasks/tlspsk_auto.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto.yml
@@ -11,21 +11,25 @@
   register: zabbix_agent_tlspsk_base64
   become: yes
   when: zabbix_agent_tlspskcheck.stat.exists
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Save existing TLS PSK secret
   set_fact:
     zabbix_agent_tlspsk_read: "{{ zabbix_agent_tlspsk_base64['content'] | b64decode | trim }}"
   when: zabbix_agent_tlspskcheck.stat.exists
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Use existing TLS PSK secret
   set_fact:
     zabbix_agent_tlspsk_secret: "{{ zabbix_agent_tlspsk_read }}"
   when: zabbix_agent_tlspskcheck.stat.exists and zabbix_agent_tlspsk_read|length >= 32
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Generate new TLS PSK secret
   set_fact:
     zabbix_agent_tlspsk_secret: "{{ lookup('password', '/dev/null chars=hexdigits length=64') }}"
   when: not zabbix_agent_tlspskcheck.stat.exists or zabbix_agent_tlspsk_read|length < 32
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Read existing TLS PSK identity file
   slurp:
@@ -33,16 +37,19 @@
   register: zabbix_agent_tlspskidentity_base64
   become: yes
   when: zabbix_agent_tlspskidentity_check.stat.exists
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Use existing TLS PSK identity
   set_fact:
     zabbix_agent_tlspskidentity: "{{ zabbix_agent_tlspskidentity_base64['content'] | b64decode | trim }}"
   when: zabbix_agent_tlspskidentity_check.stat.exists
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Generate new TLS PSK identity
   set_fact:
     zabbix_agent_tlspskidentity: "{{ zabbix_visible_hostname | default(zabbix_agent_hostname) + '_' + lookup('password', '/dev/null chars=hexdigits length=4') }}"
   when: not zabbix_agent_tlspskidentity_check.stat.exists
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Template TLS PSK identity in file
   copy:

--- a/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
@@ -11,21 +11,25 @@
   register: zabbix_agent2_tlspsk_base64
   become: yes
   when: zabbix_agent2_tlspskcheck.stat.exists
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Save existing TLS PSK secret
   set_fact:
     zabbix_agent2_tlspsk_read: "{{ zabbix_agent2_tlspsk_base64['content'] | b64decode | trim }}"
   when: zabbix_agent2_tlspskcheck.stat.exists
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Use existing TLS PSK secret
   set_fact:
     zabbix_agent2_tlspsk_secret: "{{ zabbix_agent2_tlspsk_read }}"
   when: zabbix_agent2_tlspskcheck.stat.exists and zabbix_agent2_tlspsk_read|length >= 32
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Generate new TLS PSK secret
   set_fact:
     zabbix_agent2_tlspsk_secret: "{{ lookup('password', '/dev/null chars=hexdigits length=64') }}"
   when: not zabbix_agent2_tlspskcheck.stat.exists or zabbix_agent2_tlspsk_read|length < 32
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Read existing TLS PSK identity file
   slurp:
@@ -33,16 +37,19 @@
   register: zabbix_agent2_tlspskidentity_base64
   become: yes
   when: zabbix_agent2_tlspskidentity_check.stat.exists
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Use existing TLS PSK identity
   set_fact:
     zabbix_agent2_tlspskidentity: "{{ zabbix_agent2_tlspskidentity_base64['content'] | b64decode | trim }}"
   when: zabbix_agent2_tlspskidentity_check.stat.exists
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Generate new TLS PSK identity
   set_fact:
     zabbix_agent2_tlspskidentity: "{{ zabbix_visible_hostname | default(zabbix_agent_hostname) + '_' + lookup('password', '/dev/null chars=hexdigits length=4') }}"
   when: not zabbix_agent2_tlspskidentity_check.stat.exists
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: AutoPSK | Template TLS PSK identity in file
   copy:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The no_log attribute can be used to prevent output being sent to stdout or stderr as Ansible does by default.  By setting no_log to log nothing below ansible_verbosity level 3, we allow anyone who wants to see that output still get it with -vvv or -vvvv, but prevent it from being displayed in the case of an error.  

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_agent role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
-v BEFORE:
TASK [zabbix_agent : AutoPSK | Save existing TLS PSK secret] *****************************************************************
ok: [host] => {"ansible_facts": {"zabbix_agent_tlspsk_read": "aAFb4bE09958eF13A26FfE0d4Ebb5E38eE2FDDc7cEdafd07acC1C5df49e2AA56"}, "changed": false}

-v AFTER:
TASK [zabbix_agent : AutoPSK | Save existing TLS PSK secret] *****************************************************************
ok: [host] => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}

default (0) verbosity with a fail BEFORE:
TASK [zabbix_agent : AutoPSK | Read existing TLS PSK identity file] **********************************************************************************************************************************
fatal: [host]: FAILED! => {"changed": false, "content": "NTEuNzkuOTAuMTIzXzFkMDA=", "encoding": "base64", "failed_when_result": true, "source": "/etc/zabbix/tls_psk_auto.identity"}

default (0) verbosity with a fail AFTER:
TASK [zabbix_agent : AutoPSK | Read existing TLS PSK identity file] **********************************************************************************************************************************
fatal: [host]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
```
