### PR TITLE
Fix sqlite package for Debian

### DIFF
--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -245,7 +245,7 @@
 
 - name: "Debian | Install sqlite3"
   apt:
-    name: sqlite
+    name: sqlite3
     state: present
   environment:
     http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"


### PR DESCRIPTION
##### SUMMARY

Use sqlite3 not sqlite, available in all Debian flavour supported by this collection

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- role `zabbix_proxy`

##### ADDITIONAL INFORMATION

[Debian sqlite3 package tracker](https://tracker.debian.org/pkg/sqlite3)
