### PR TITLE
Add Debian 11 bullseye

### DIFF
--- a/roles/zabbix_agent/vars/zabbix.yml
+++ b/roles/zabbix_agent/vars/zabbix.yml
@@ -20,9 +20,9 @@ sign_keys:
       sign_key: E709712C
     buster:
       sign_key: E709712C
-    stretch:
-      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -38,9 +38,9 @@ sign_keys:
     # bullseye: not available upstream
     buster:
       sign_key: E709712C
-    stretch:
-      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -57,9 +57,9 @@ sign_keys:
       sign_key: E709712C
     buster:
       sign_key: E709712C
-    stretch:
-      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -72,6 +72,12 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "44":
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     focal:
       sign_key: A14FE591
     eoan:
@@ -84,19 +90,17 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "42":
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     eoan:
       sign_key: A14FE591
     cosmic:
@@ -107,19 +111,19 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "40":
+    bullseye:
+      sign_key: A14FE591
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     focal:
       sign_key: A14FE591
     bionic:
@@ -128,71 +132,61 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "34":
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: A14FE591
     bionic:
       sign_key: A14FE591
     sonya:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "32":
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: 79EA5ED4
     bionic:
       sign_key: A14FE591
     sonya:
       sign_key: 79EA5ED4
     serena:
-      sign_key: 79EA5ED4
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: 79EA5ED4
-    jessie:
       sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "30":
-    bionic:
+    buster:
       sign_key: A14FE591
-    wheezy:
-      sign_key: 79EA5ED4
     jessie:
       sign_key: 79EA5ED4
     stretch:
       sign_key: A14FE591
-    buster:
+    wheezy:
+      sign_key: 79EA5ED4
+    bionic:
       sign_key: A14FE591
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "24":
-    wheezy:
-      sign_key: 79EA5ED4
     jessie:
+      sign_key: 79EA5ED4
+    wheezy:
       sign_key: 79EA5ED4
     precise:
       sign_key: 79EA5ED4
@@ -201,7 +195,7 @@ sign_keys:
   "22":
     squeeze:
       sign_key: 79EA5ED4
-    jessie:
+    wheezy:
       sign_key: 79EA5ED4
     precise:
       sign_key: 79EA5ED4

--- a/roles/zabbix_javagateway/vars/zabbix.yml
+++ b/roles/zabbix_javagateway/vars/zabbix.yml
@@ -1,11 +1,28 @@
 ---
 sign_keys:
-  "54":
+  "55":
+    bullseye:
+      sign_key: E709712C
     buster:
       sign_key: E709712C
     stretch:
       sign_key: E709712C
+    focal:
+      sign_key: E709712C
+    bionic:
+      sign_key: E709712C
+    xenial:
+      sign_key: E709712C
+    trusty:
+      sign_key: E709712C
+  "54":
+    bullseye:
+      sign_key: E709712C
+    buster:
+      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -18,11 +35,12 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "52":
+    # bullseye: not available upstream
     buster:
       sign_key: E709712C
-    stretch:
-      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -35,11 +53,13 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "50":
+    bullseye:
+      sign_key: E709712C
     buster:
       sign_key: E709712C
-    stretch:
-      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -52,6 +72,12 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "44":
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     focal:
       sign_key: A14FE591
     eoan:
@@ -64,19 +90,17 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "42":
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     eoan:
       sign_key: A14FE591
     cosmic:
@@ -87,19 +111,19 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "40":
+    bullseye:
+      sign_key: A14FE591
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     focal:
       sign_key: A14FE591
     bionic:
@@ -108,71 +132,61 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "34":
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: A14FE591
     bionic:
       sign_key: A14FE591
     sonya:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "32":
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: 79EA5ED4
     bionic:
       sign_key: A14FE591
     sonya:
       sign_key: 79EA5ED4
     serena:
-      sign_key: 79EA5ED4
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: 79EA5ED4
-    jessie:
       sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "30":
-    bionic:
+    buster:
       sign_key: A14FE591
-    wheezy:
-      sign_key: 79EA5ED4
     jessie:
       sign_key: 79EA5ED4
     stretch:
       sign_key: A14FE591
-    buster:
+    wheezy:
+      sign_key: 79EA5ED4
+    bionic:
       sign_key: A14FE591
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "24":
-    wheezy:
-      sign_key: 79EA5ED4
     jessie:
+      sign_key: 79EA5ED4
+    wheezy:
       sign_key: 79EA5ED4
     precise:
       sign_key: 79EA5ED4
@@ -181,7 +195,7 @@ sign_keys:
   "22":
     squeeze:
       sign_key: 79EA5ED4
-    jessie:
+    wheezy:
       sign_key: 79EA5ED4
     precise:
       sign_key: 79EA5ED4

--- a/roles/zabbix_proxy/vars/zabbix.yml
+++ b/roles/zabbix_proxy/vars/zabbix.yml
@@ -1,11 +1,28 @@
 ---
 sign_keys:
-  "54":
+  "55":
+    bullseye:
+      sign_key: E709712C
     buster:
       sign_key: E709712C
     stretch:
       sign_key: E709712C
+    focal:
+      sign_key: E709712C
+    bionic:
+      sign_key: E709712C
+    xenial:
+      sign_key: E709712C
+    trusty:
+      sign_key: E709712C
+  "54":
+    bullseye:
+      sign_key: E709712C
+    buster:
+      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -18,11 +35,12 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "52":
+    # bullseye: not available upstream
     buster:
       sign_key: E709712C
-    stretch:
-      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -35,11 +53,13 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "50":
+    bullseye:
+      sign_key: E709712C
     buster:
       sign_key: E709712C
-    stretch:
-      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -52,6 +72,12 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "44":
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     focal:
       sign_key: A14FE591
     eoan:
@@ -64,20 +90,16 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "42":
-    focal:
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
       sign_key: A14FE591
     eoan:
       sign_key: A14FE591
@@ -89,19 +111,19 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "40":
+    bullseye:
+      sign_key: A14FE591
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     focal:
       sign_key: A14FE591
     bionic:
@@ -110,71 +132,61 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "34":
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: A14FE591
     bionic:
       sign_key: A14FE591
     sonya:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "32":
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: 79EA5ED4
     bionic:
       sign_key: A14FE591
     sonya:
       sign_key: 79EA5ED4
     serena:
-      sign_key: 79EA5ED4
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: 79EA5ED4
-    jessie:
       sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "30":
-    bionic:
+    buster:
       sign_key: A14FE591
-    wheezy:
-      sign_key: 79EA5ED4
     jessie:
       sign_key: 79EA5ED4
     stretch:
       sign_key: A14FE591
-    buster:
+    wheezy:
+      sign_key: 79EA5ED4
+    bionic:
       sign_key: A14FE591
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "24":
-    wheezy:
-      sign_key: 79EA5ED4
     jessie:
+      sign_key: 79EA5ED4
+    wheezy:
       sign_key: 79EA5ED4
     precise:
       sign_key: 79EA5ED4
@@ -183,7 +195,7 @@ sign_keys:
   "22":
     squeeze:
       sign_key: 79EA5ED4
-    jessie:
+    wheezy:
       sign_key: 79EA5ED4
     precise:
       sign_key: 79EA5ED4

--- a/roles/zabbix_server/vars/zabbix.yml
+++ b/roles/zabbix_server/vars/zabbix.yml
@@ -1,6 +1,23 @@
 ---
 sign_keys:
+  "55":
+    bullseye:
+      sign_key: E709712C
+    buster:
+      sign_key: E709712C
+    stretch:
+      sign_key: E709712C
+    focal:
+      sign_key: E709712C
+    bionic:
+      sign_key: E709712C
+    xenial:
+      sign_key: E709712C
+    trusty:
+      sign_key: E709712C
   "54":
+    bullseye:
+      sign_key: E709712C
     buster:
       sign_key: E709712C
     stretch:

--- a/roles/zabbix_web/vars/Debian-11.yml
+++ b/roles/zabbix_web/vars/Debian-11.yml
@@ -1,0 +1,3 @@
+---
+
+_zabbix_php_version: 7.4

--- a/roles/zabbix_web/vars/zabbix.yml
+++ b/roles/zabbix_web/vars/zabbix.yml
@@ -1,11 +1,28 @@
 ---
 sign_keys:
-  "54":
+  "55":
+    bullseye:
+      sign_key: E709712C
     buster:
       sign_key: E709712C
     stretch:
       sign_key: E709712C
+    focal:
+      sign_key: E709712C
+    bionic:
+      sign_key: E709712C
+    xenial:
+      sign_key: E709712C
+    trusty:
+      sign_key: E709712C
+  "54":
+    bullseye:
+      sign_key: E709712C
+    buster:
+      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -18,11 +35,12 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "52":
+    # bullseye: not available upstream
     buster:
       sign_key: E709712C
-    stretch:
-      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -35,11 +53,13 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "50":
+    bullseye:
+      sign_key: E709712C
     buster:
       sign_key: E709712C
-    stretch:
-      sign_key: E709712C
     jessie:
+      sign_key: E709712C
+    stretch:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -52,6 +72,12 @@ sign_keys:
     tricia:
       sign_key: E709712C
   "44":
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     focal:
       sign_key: A14FE591
     eoan:
@@ -64,19 +90,17 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "42":
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     eoan:
       sign_key: A14FE591
     cosmic:
@@ -87,19 +111,19 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "40":
+    bullseye:
+      sign_key: A14FE591
+    buster:
+      sign_key: A14FE591
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
     focal:
       sign_key: A14FE591
     bionic:
@@ -108,71 +132,61 @@ sign_keys:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "34":
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: A14FE591
     bionic:
       sign_key: A14FE591
     sonya:
       sign_key: A14FE591
     serena:
       sign_key: A14FE591
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "32":
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: 79EA5ED4
     bionic:
       sign_key: A14FE591
     sonya:
       sign_key: 79EA5ED4
     serena:
-      sign_key: 79EA5ED4
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: 79EA5ED4
-    jessie:
       sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "30":
-    bionic:
+    buster:
       sign_key: A14FE591
-    wheezy:
-      sign_key: 79EA5ED4
     jessie:
       sign_key: 79EA5ED4
     stretch:
       sign_key: A14FE591
-    buster:
+    wheezy:
+      sign_key: 79EA5ED4
+    bionic:
       sign_key: A14FE591
     trusty:
       sign_key: 79EA5ED4
     xenial:
       sign_key: E709712C
   "24":
-    wheezy:
-      sign_key: 79EA5ED4
     jessie:
+      sign_key: 79EA5ED4
+    wheezy:
       sign_key: 79EA5ED4
     precise:
       sign_key: 79EA5ED4
@@ -181,7 +195,7 @@ sign_keys:
   "22":
     squeeze:
       sign_key: 79EA5ED4
-    jessie:
+    wheezy:
       sign_key: 79EA5ED4
     precise:
       sign_key: 79EA5ED4


### PR DESCRIPTION
##### SUMMARY

* Checked upstream repo related to Debian and updated our lists
* Added the sig keys for debian11
* Update version for php-fpm
* Sort the keys in the var files, debian first.
* Remove old keys in the var files: some flavour are not available
  upstream anymore. (only debian)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

all roles

