### PR TITLE
Fix typo in zabbix_map.py

### DIFF
--- a/plugins/modules/zabbix_map.py
+++ b/plugins/modules/zabbix_map.py
@@ -22,7 +22,7 @@ description:
     - "The following extra node attributes are supported:
         C(zbx_host) contains name of the host in Zabbix. Use this if desired type of map element is C(host).
         C(zbx_group) contains name of the host group in Zabbix. Use this if desired type of map element is C(host group).
-        C(zbx_map) contains name of the map in Zabbix. Use this if desired type of map element is C(map).
+        C(zbx_sysmap) contains name of the map in Zabbix. Use this if desired type of map element is C(map).
         C(zbx_label) contains label of map element.
         C(zbx_image) contains name of the image used to display the element in default state.
         C(zbx_image_disabled) contains name of the image used to display disabled map element.


### PR DESCRIPTION
##### SUMMARY
Fixes typo in documentation of zbx_map dot attribute. Correct name is zbx_sysmap

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zabbix_map

##### ADDITIONAL INFORMATION
Attribute zbx_map is ignored. Usage of zbx_sysmap makes correct zabbix map.
