### PR TITLE
Set the PostgreSQL version to use for testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   zabbix-db:
-    image: postgres:latest
+    image: postgres:13
     environment:
       POSTGRES_DB: "zabbix"
       POSTGRES_USER: "zabbix"

--- a/molecule/zabbix_proxy/prepare.yml
+++ b/molecule/zabbix_proxy/prepare.yml
@@ -22,7 +22,7 @@
     - name: "Create postgresql Container"
       docker_container:
         name: postgresql-host
-        image: postgres
+        image: postgres:13
         state: started
         recreate: yes
         networks:

--- a/molecule/zabbix_server/prepare.yml
+++ b/molecule/zabbix_server/prepare.yml
@@ -22,7 +22,7 @@
     - name: "Create postgresql Container"
       docker_container:
         name: postgresql-host
-        image: postgres
+        image: postgres:13
         state: started
         recreate: yes
         networks:

--- a/molecule/zabbix_web/prepare.yml
+++ b/molecule/zabbix_web/prepare.yml
@@ -22,7 +22,7 @@
     - name: "Create postgresql Container"
       docker_container:
         name: postgresql-host
-        image: postgres
+        image: postgres:13
         state: started
         recreate: yes
         networks:


### PR DESCRIPTION
##### SUMMARY

PG13 is defined here instead of nothing, which in turn uses latest,
which is PG14 now, and PG14 does SHA instead of MD5 by default.

Thus the issue.

NOTE: the collection won't work with PostgreSQL 14 as is. Fixes are
required.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

molecule

##### ADDITIONAL INFORMATION

If it passes regression tests as expected, it should allow other PRs to re-run tests....
