### PR TITLE
Fix variable name in server template

### DIFF
--- a/roles/zabbix_server/templates/zabbix_server.conf.j2
+++ b/roles/zabbix_server/templates/zabbix_server.conf.j2
@@ -553,7 +553,7 @@ LoadModulePath={{ zabbix_server_loadmodulepath }}
 #	it is allowed to include multiple loadmodule parameters.
 #
 {% if zabbix_server_loadmodule is defined and zabbix_server_loadmodule %}
-LoadModule = {{ loadmodule }}
+LoadModule = {{ zabbix_server_loadmodule }}
 {% endif %}
 
 {% if zabbix_version is version('3.0', '>=') %}


### PR DESCRIPTION
##### SUMMARY

"loadmodule" was used instead of "zabbix_server_loadmodule"

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

role zabbix_server

##### ADDITIONAL INFORMATION

no test added...maybe we can add a dummy module for testing...
