### PR TITLE
Review of zabbix config templates (not those related to http)

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -85,7 +85,7 @@ Example of using the role in this collection::
 - hosts: zabbix-proxy
   roles:
     - role: community.zabbix.zabbix_proxy
-      zabbix_server_host: 192.168.1.1
+      zabbix_proxy_server: 192.168.1.1
       zabbix_server_database: mysql
       zabbix_server_database_long: mysql
       zabbix_server_dbport: 3306

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -116,12 +116,12 @@ See the following list of supported Operating systems with the Zabbix releases:
 In order to get the Zabbix Agent running, you'll have to define the following properties before executing the role:
 
 * `zabbix_agent_version`
-* `zabbix_agent_server`
-* `zabbix_agent_serveractive` (When using active checks)
+* `zabbix_agent(2)_server`
+* `zabbix_agent(2)_serveractive` (When using active checks)
 
 The `zabbix_agent_version` is optional. The latest available major.minor version of Zabbix will be installed on the host(s). If you want to use an older version, please specify this in the major.minor format. Example: `zabbix_agent_version: 4.0`, `zabbix_agent_version: 3.4` or `zabbix_agent_version: 2.2`.
 
-The `zabbix_agent_server` (and `zabbix_agent_serveractive`) should contain the ip or fqdn of the host running the Zabbix Server.
+The `zabbix_agent(2)_server` (and `zabbix_agent(2)_serveractive`) should contain the ip or fqdn of the host running the Zabbix Server.
 
 ## Issues
 
@@ -153,8 +153,6 @@ The following is an overview of all available configuration default for this rol
 
 * `zabbix_agent_ip`: The IP address of the host. When not provided, it will be determined via the `ansible_default_ipv4` fact.
 * `zabbix_agent2`: Default: `False`. When you want to install the `Zabbix Agent2` instead of the "old" `Zabbix Agent`.
-* `zabbix_agent_server`: The ip address for the zabbix-server or zabbix-proxy.
-* `zabbix_agent_serveractive`: The ip address for the zabbix-server or zabbix-proxy for active checks.
 * `zabbix_agent_listeninterface`: Interface zabbix-agent listens on. Leave blank for all.
 * `zabbix_agent_package_remove`: If `zabbix_agent2: True` and you want to remove the old installation. Default: `False`.
 * `zabbix_agent_package`: The name of the zabbix-agent package. Default: `zabbix-agent`. In case for EPEL, it is automatically renamed.
@@ -174,8 +172,6 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_agent_apt_priority`: Add a weight (`Pin-Priority`) for the APT repository.
 * `zabbix_agent_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 * `zabbix_agent_dont_detect_ip`: Default `false`. When set to `true`, it won't detect available ip addresses on the host and no need for the Python module `netaddr` to be installed.
-* `zabbix_agent_allow_key`: list of AllowKey configurations.
-* `zabbix_agent_deny_key`: list of DenyKey configurations.
 
 ### Zabbix Agent vs Zabbix Agent 2 configuration
 
@@ -183,6 +179,10 @@ The following provides an overview of all the properties that can be set in the 
 
 Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
 
+* `zabbix_agent(2)_server`: The ip address for the zabbix-server or zabbix-proxy.
+* `zabbix_agent(2)_serveractive`: The ip address for the zabbix-server or zabbix-proxy for active checks.
+* `zabbix_agent(2)_allow_key`: list of AllowKey configurations.
+* `zabbix_agent(2)_deny_key`: list of DenyKey configurations.
 * `zabbix_agent(2)_pidfile`: name of pid file.
 * `zabbix_agent(2)_logfile`: name of log file.
 * `zabbix_agent(2)_logfilesize`: maximum size of log file in mb.

--- a/docs/ZABBIX_JAVAGATEWAY_ROLE.md
+++ b/docs/ZABBIX_JAVAGATEWAY_ROLE.md
@@ -103,7 +103,7 @@ or when using the zabbix-proxy:
 ```yaml
   roles:
     - role: community.zabbix.zabbix_proxy
-      zabbix_server_host: 192.168.1.1
+      zabbix_proxy_server: 192.168.1.1
       zabbix_proxy_javagateway: 192.168.1.2
 ```
 

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -115,8 +115,8 @@ The following is an overview of all available configuration default for this rol
 ### Zabbix Proxy
 
 * `zabbix_proxy_ip`: The IP address of the host. When not provided, it will be determined via the `ansible_default_ipv4` fact.
-* `zabbix_server_host`: The ip or dns name for the zabbix-server machine.
-* `zabbix_server_port`: The port on which the zabbix-server is running. Default: 10051
+* `zabbix_proxy_server`: The ip or dns name for the zabbix-server machine.
+* `zabbix_proxy_serverport`: The port on which the zabbix-server is running. Default: 10051
 * `*zabbix_proxy_package_state`: Default: `present`. Can be overridden to `latest` to update packages
 * `zabbix_proxy_install_database_client`: Default: `True`. False does not install database client.
 * `zabbix_proxy_become_on_localhost`: Default: `True`. Set to `False` if you don't need to elevate privileges on localhost to install packages locally with pip.
@@ -340,7 +340,7 @@ Including an example of how to use your role (for instance, with variables passe
   - hosts: zabbix-proxy
     roles:
       - role: community.zabbix.zabbix_proxy
-        zabbix_server_host: 192.168.1.1
+        zabbix_proxy_server: 192.168.1.1
         zabbix_proxy_database: mysql
         zabbix_proxy_database_long: mysql
 ```

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -13,6 +13,8 @@ zabbix_get_package: zabbix-get
 zabbix_agent_package_state: present
 zabbix_agent_server:
 zabbix_agent_serveractive:
+zabbix_agent2_server: "{{ zabbix_agent_server }}"
+zabbix_agent2_serveractive: "{{ zabbix_agent_serveractive }}"
 zabbix_selinux: False
 zabbix_agent_src_reinstall: False
 zabbix_agent_apt_priority:
@@ -20,6 +22,8 @@ zabbix_agent_conf_mode: "0644"
 zabbix_agent_dont_detect_ip: False
 zabbix_agent_allow_key: []
 zabbix_agent_deny_key: []
+zabbix_agent2_allow_key: "{{ zabbix_agent_allow_key }}"
+zabbix_agent2_deny_key: "{{ zabbix_agent_deny_key }}"
 
 # Selinux related vars
 selinux_allow_zabbix_run_sudo: False

--- a/roles/zabbix_agent/tasks/Darwin.yml
+++ b/roles/zabbix_agent/tasks/Darwin.yml
@@ -18,6 +18,8 @@
     zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ipaddr('public') | first }}"
     zabbix_agent_server: "{{ zabbix_agent_server_public_ip | default(zabbix_agent_server) }}"
     zabbix_agent_serveractive: "{{ zabbix_agent_serveractive_public_ip | default(zabbix_agent_serveractive) }}"
+    zabbix_agent2_server: "{{ zabbix_agent_server_public_ip | default(zabbix_agent2_server) }}"
+    zabbix_agent2_serveractive: "{{ zabbix_agent_serveractive_public_ip | default(zabbix_agent2_serveractive) }}"
   when:
     - zabbix_agent_ip is not defined
     - total_private_ip_addresses is defined

--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -19,6 +19,8 @@
     zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ipaddr('public') | first }}"
     zabbix_agent_server: "{{ zabbix_agent_server_public_ip | default(zabbix_agent_server) }}"
     zabbix_agent_serveractive: "{{ zabbix_agent_serveractive_public_ip | default(zabbix_agent_serveractive) }}"
+    zabbix_agent2_server: "{{ zabbix_agent_server_public_ip | default(zabbix_agent2_server) }}"
+    zabbix_agent2_serveractive: "{{ zabbix_agent_serveractive_public_ip | default(zabbix_agent2_serveractive) }}"
   when:
     - zabbix_agent_ip is not defined
     - total_private_ip_addresses is defined

--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -86,7 +86,7 @@ SourceIP={{ zabbix_agent2_sourceip }}
 # Mandatory: yes, if StartAgents is not explicitly set to 0
 # Default:
 
-Server={{ zabbix_agent_server }}
+Server={{ zabbix_agent2_server }}
 
 ### Option: ListenPort
 #	Agent will listen on this port for connections from the server.
@@ -132,7 +132,7 @@ StatusPort={{ zabbix_agent2_statusport }}
 # Default:
 # ServerActive=
 
-ServerActive={{ zabbix_agent_serveractive }}
+ServerActive={{ zabbix_agent2_serveractive }}
 
 ### Option: Hostname
 #	Unique, case sensitive hostname.
@@ -217,8 +217,8 @@ HostInterfaceItem={{ zabbix_agent2_hostinterfaceitem }}
 # 	Multiple key matching rules may be defined in combination with DenyKey.
 # 	The parameters are processed one by one according to their appearance order.
 
-{% if zabbix_agent_allow_key is defined and zabbix_agent_allow_key %}
-{% for item in zabbix_agent_allow_key %}
+{% if zabbix_agent2_allow_key is defined and zabbix_agent2_allow_key %}
+{% for item in zabbix_agent2_allow_key %}
 AllowKey={{ item }}
 {% endfor %}
 {% endif %}
@@ -235,8 +235,8 @@ AllowKey={{ item }}
 # Default:
 # DenyKey=system.run[*]
 
-{% if zabbix_agent_deny_key is defined and zabbix_agent_deny_key %}
-{% for item in zabbix_agent_deny_key %}
+{% if zabbix_agent2_deny_key is defined and zabbix_agent2_deny_key %}
+{% for item in zabbix_agent2_deny_key %}
 DenyKey={{ item }}
 {% endfor %}
 {% endif %}

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -41,8 +41,10 @@ zabbix_repo_yum:
 zabbix_proxy_username: zabbix
 zabbix_proxy_groupname: zabbix
 
-zabbix_server_host: 192.168.1.1
-zabbix_server_port: 10051
+zabbix_server_host: 192.168.1.1          # Will be deprecated in 2.0.0
+zabbix_proxy_server: "{{ zabbix_server_host }}"
+zabbix_server_port: 10051          # Will be deprecated in 2.0.0
+zabbix_proxy_serverport: "{{ zabbix_server_port }}"
 zabbix_database_creation: True
 zabbix_database_sqlload: True
 zabbix_proxy_dbtlsconnect:
@@ -82,8 +84,10 @@ zabbix_proxy_dbsocket:
 zabbix_proxy_dbport: 5432
 zabbix_proxy_dbhost_run_install: true
 zabbix_proxy_privileged_host: localhost
-zabbix_proxy_localbuffer: 0
-zabbix_proxy_offlinebuffer: 1
+zabbix_proxy_localbuffer: 0          # Will be deprecated in 2.0.0
+zabbix_proxy_proxylocalbuffer: "{{ zabbix_proxy_localbuffer }}"
+zabbix_proxy_offlinebuffer: 1          # Will be deprecated in 2.0.0
+zabbix_proxy_proxyofflinebuffer:  "{{ zabbix_proxy_offlinebuffer }}"
 zabbix_proxy_heartbeatfrequency: 60
 zabbix_proxy_configfrequency: 3600
 zabbix_proxy_datasenderfrequency: 1

--- a/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
+++ b/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
@@ -16,13 +16,13 @@ ProxyMode={{ zabbix_proxy_mode }}
 #	Active proxy will get configuration data from the server.
 #	For a proxy in the passive mode this parameter will be ignored.
 #
-Server={{ zabbix_server_host }}
+Server={{ zabbix_proxy_server }}
 
 ### Option: ServerPort
 #	Port of Zabbix trapper on Zabbix server.
 #	For a proxy in the passive mode this parameter will be ignored.
 #
-ServerPort={{ zabbix_server_port }}
+ServerPort={{ zabbix_proxy_serverport }}
 
 ### Option: Hostname
 #	Unique, case sensitive Proxy name. Make sure the Proxy name is known to the server!
@@ -141,13 +141,13 @@ DBPort={{ zabbix_proxy_dbport }}
 #	Proxy will keep data locally for N hours, even if the data have already been synced with the server.
 #	This parameter may be used if local data will be used by third party applications.
 #
-ProxyLocalBuffer={{ zabbix_proxy_localbuffer }}
+ProxyLocalBuffer={{ zabbix_proxy_proxylocalbuffer }}
 
 ### Option: ProxyOfflineBuffer
 #	Proxy will keep data for N hours in case if no connectivity with Zabbix Server.
 #	Older data will be lost.
 #
-ProxyOfflineBuffer={{ zabbix_proxy_offlinebuffer }}
+ProxyOfflineBuffer={{ zabbix_proxy_proxyofflinebuffer }}
 
 ### Option: HeartbeatFrequency
 #	Frequency of heartbeat messages in seconds.


### PR DESCRIPTION
##### SUMMARY

Update variable name and use the same decision:

each variable name use in the configuration templates is named from
`config_filename + _ + config_parameter_name|lower`

Old variables not removed in order to not produce regression.

##### ISSUE TYPE

- Imrovement  Pull Request

##### COMPONENT NAME

role zabbix _agent and zabbix_proxy

##### ADDITIONAL INFORMATION

I have defined the new variable from the old variables (`newvar: "{{ old_var }}"`). I hope it's enough to not have to bump major version ?

Looks like I managed to push all doc UPGRADE in a single commit, in the other PR about API review.