### PR TITLE
Fix wrong key name for certificate on zabbix_proxy

### DIFF
--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -143,7 +143,7 @@ zabbix_proxy_tlspskidentity:
 zabbix_proxy_tls_config:
   no_encryption: 'no_encryption'
   psk: 'PSK'
-  certificate: 'certificate'
+  cert: 'certificate'
 
 # Zabbix API stuff
 zabbix_url: "http://zabbix.dj-wasabi.local"


### PR DESCRIPTION
##### SUMMARY

`certificate: certificate`

was used instead of

`cert: certificate`

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

role zabbix_proxy
