### PR TITLE
Trivial patch when deploying several proxy at once

### DIFF
--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -102,6 +102,7 @@
   register: zabbix_api_package_installed
   until: zabbix_api_package_installed is succeeded
   delegate_to: localhost
+  run_once: true
   become: "{{ zabbix_proxy_become_on_localhost }}"
   when:
     - zabbix_install_pip_packages | bool


### PR DESCRIPTION
##### SUMMARY

in zabbix_proxy, we need to install zabbix API on localhost, add a
`run_once` to the delegated task (to localhost) so it is run by all
proxies...

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

role zabbix_proxy

