### PR TITLE
zabbix_agent_ip was set in a wrong place

### DIFF
--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -54,7 +54,6 @@
 - name: "Get IP of agent_listeninterface when no agent_listenip specified"
   set_fact:
     zabbix_agent_listenip: "{{ hostvars[inventory_hostname][network_interface]['ipv4'].address | default('0.0.0.0') }}"
-    zabbix_agent_ip: "{{ hostvars[inventory_hostname][network_interface]['ipv4'].address | default('0.0.0.0') }}"
   when:
     - (zabbix_agent_listeninterface)
     - not zabbix_agent_listenip


### PR DESCRIPTION
##### SUMMARY

it was in the task to set zabbix_agent_listenip, probably by mistake.


##### ISSUE TYPE

- Bugfix Pull Request

Probably fixing:
https://github.com/ansible-collections/community.zabbix/issues/41

##### COMPONENT NAME

role zabbix_agent

