### PR TITLE
zabbix_agent(2)_tlspskidentity right value needs to be between {{}}

### DIFF
--- a/roles/zabbix_agent/tasks/tlspsk_auto.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto.yml
@@ -48,10 +48,12 @@
 - name: AutoPSK | Generate new TLS PSK identity
   set_fact:
     zabbix_agent_tlspskidentity: >
-      zabbix_agent_visible_hostname
-      | ((zabbix_agent2 == True) | default(ternary(zabbix_agent2_hostname, zabbix_agent_hostname)))
-      + '_'
-      + lookup('password', '/dev/null chars=hexdigits length=4')
+      {{
+        zabbix_agent_visible_hostname
+        | ((zabbix_agent2 == True) | default(ternary(zabbix_agent2_hostname, zabbix_agent_hostname)))
+        + '_'
+        + lookup('password', '/dev/null chars=hexdigits length=4')
+      }}
   when: not zabbix_agent_tlspskidentity_check.stat.exists
   no_log: "{{ ansible_verbosity < 3 }}"
 

--- a/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
@@ -48,10 +48,12 @@
 - name: AutoPSK | Generate new TLS PSK identity
   set_fact:
     zabbix_agent2_tlspskidentity: >
-      zabbix_agent_visible_hostname
-      | ((zabbix_agent2 == True) | default(ternary(zabbix_agent2_hostname, zabbix_agent_hostname)))
-      + '_'
-      + lookup('password', '/dev/null chars=hexdigits length=4')
+      {{
+        zabbix_agent_visible_hostname
+        | ((zabbix_agent2 == True) | default(ternary(zabbix_agent2_hostname, zabbix_agent_hostname)))
+        + '_'
+        + lookup('password', '/dev/null chars=hexdigits length=4')
+      }}
   when: not zabbix_agent2_tlspskidentity_check.stat.exists
   no_log: "{{ ansible_verbosity < 3 }}"
 


### PR DESCRIPTION
##### SUMMARY
The last commits splitted the setting line for a variable into several lines, and removed the {{}} around the code. It's not evaluated any more.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent role, tlspsk_auto* files

##### ADDITIONAL INFORMATION
Fixes https://github.com/ansible-collections/community.zabbix/issues/501
