### PR TITLE
LogFile option was set twice. Removed the 1st setting.

### DIFF
--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -30,8 +30,6 @@ LogType={{ zabbix_agent2_logtype }}
 # Mandatory: yes, if LogType is set to file, otherwise no
 # Default:
 
-LogFile={{ zabbix_agent2_logfile }}
-
 {% if zabbix_agent_os_family == "Windows" %}
 LogFile={{ zabbix_agent2_win_logfile }}
 {% else %}


### PR DESCRIPTION
##### SUMMARY
Remove the 1st setting of LogFile option in zabbix_agent2.conf.j2
##### ISSUE TYPE
- Bug [#503](https://github.com/ansible-collections/community.zabbix/issues/503) fix Pull Request 

##### COMPONENT NAME
zabbix_agent role
