### PR TITLE
Enable usage of environment variables in modules

### DIFF
--- a/changelogs/fragments/508-zabbix-env-vars.yml
+++ b/changelogs/fragments/508-zabbix-env-vars.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Enabled usage of environment variables for modules by adding a fallback
+    lookup in the module_utils/helpers.py - zabbix_common_argument_spec

--- a/plugins/doc_fragments/zabbix.py
+++ b/plugins/doc_fragments/zabbix.py
@@ -13,17 +13,20 @@ options:
         description:
             - URL of Zabbix server, with protocol (http or https).
               C(url) is an alias for C(server_url).
+            - If not set the environment variable C(ZABBIX_SERVER) will be used.
         required: true
         type: str
         aliases: [ url ]
     login_user:
         description:
             - Zabbix user name.
+            - If not set the environment variable C(ZABBIX_USERNAME) will be used.
         type: str
         required: true
     login_password:
         description:
             - Zabbix user password.
+            - If not set the environment variable C(ZABBIX_PASSWORD) will be used.
         type: str
         required: true
     http_login_user:
@@ -42,6 +45,7 @@ options:
     validate_certs:
       description:
        - If set to False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+       - If not set the environment variable C(ZABBIX_VALIDATE_CERTS) will be used.
       type: bool
       default: true
 notes:

--- a/plugins/module_utils/helpers.py
+++ b/plugins/module_utils/helpers.py
@@ -6,6 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
+from ansible.module_utils.basic import env_fallback
 
 
 def zabbix_common_argument_spec():
@@ -14,13 +15,43 @@ def zabbix_common_argument_spec():
     The options are commonly used by most of Zabbix modules.
     """
     return dict(
-        server_url=dict(type='str', required=True, aliases=['url']),
-        login_user=dict(type='str', required=True),
-        login_password=dict(type='str', required=True, no_log=True),
-        http_login_user=dict(type='str', required=False, default=None),
-        http_login_password=dict(type='str', required=False, default=None, no_log=True),
-        timeout=dict(type='int', default=10),
-        validate_certs=dict(type='bool', required=False, default=True),
+        server_url=dict(
+            type='str',
+            required=True,
+            aliases=['url'],
+            fallback=(env_fallback, ['ZABBIX_SERVER'])
+        ),
+        login_user=dict(
+            type='str', required=True,
+            fallback=(env_fallback, ['ZABBIX_USERNAME'])
+        ),
+        login_password=dict(
+            type='str',
+            required=True,
+            no_log=True,
+            fallback=(env_fallback, ['ZABBIX_PASSWORD'])
+        ),
+        http_login_user=dict(
+            type='str',
+            required=False,
+            default=None
+        ),
+        http_login_password=dict(
+            type='str',
+            required=False,
+            default=None,
+            no_log=True
+        ),
+        timeout=dict(
+            type='int',
+            default=10
+        ),
+        validate_certs=dict(
+            type='bool',
+            required=False,
+            default=True,
+            fallback=(env_fallback, ['ZABBIX_VALIDATE_CERTS'])
+        ),
     )
 
 

--- a/tests/integration/targets/test_zabbix_host_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_host_info/tasks/main.yml
@@ -42,8 +42,8 @@
     ZABBIX_VALIDATE_CERTS: false
 
 - assert:
-  that:
-    - env_vars_usage.hosts[0].name == "ExampleHostForHostInfoModule"
+    that:
+      - env_vars_usage.hosts[0].name == "ExampleHostForHostInfoModule"
 
 - name: "test - Set default parameters to zabbix_host_info"
   module_defaults:

--- a/tests/integration/targets/test_zabbix_host_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_host_info/tasks/main.yml
@@ -31,6 +31,20 @@
     that:
       - prepare_host_result.changed is sameas true
 
+- name: "test - Gather zabbix host facts using environment variables"
+  community.zabbix.zabbix_host_info:
+    host_name: ExampleHostForHostInfoModule
+  register: env_vars_usage
+  environment:
+    ZABBIX_SERVER: "{{ zabbix_api_server_url }}"
+    ZABBIX_USERNAME: "{{ zabbix_api_login_user }}"
+    ZABBIX_PASSWORD: "{{ zabbix_api_login_pass }}"
+    ZABBIX_VALIDATE_CERTS: false
+
+- assert:
+  that:
+    - env_vars_usage.hosts[0].name == "ExampleHostForHostInfoModule"
+
 - name: "test - Set default parameters to zabbix_host_info"
   module_defaults:
     community.zabbix.zabbix_host_info:

--- a/tests/integration/targets/test_zabbix_host_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_host_info/tasks/main.yml
@@ -43,7 +43,7 @@
 
 - assert:
     that:
-      - env_vars_usage.hosts[0].name == "ExampleHostForHostInfoModule"
+      - env_vars_usage.hosts[0].name == "ExampleHostForHostInfoModuleName"
 
 - name: "test - Set default parameters to zabbix_host_info"
   module_defaults:


### PR DESCRIPTION
##### SUMMARY
Enable usage of environment variables in modules for,
- `server_url` - `ZABBIX_SERVER`
- `login_user` - `ZABBIX_USERNAME`
- `login_password` - `ZABBIX_PASSWORD`
- `validate_certs` - `ZABBIX_VALIDATE_CERTS`

If the above options is not set as module options, the corresponding environment variable will be used as fallback.

Fixes #423 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
helpers
modules

##### ADDITIONAL INFORMATION

n/a
