### PR TITLE
Bugfix: ZABBIX_VALIDATE_CERTS defined under wrong option

### DIFF
--- a/changelogs/fragments/512-inventory-bugfix.yaml
+++ b/changelogs/fragments/512-inventory-bugfix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  zabbix inventory - Moved ZABBIX_VALIDATE_CERTS to correct option, validate_certs.

--- a/changelogs/fragments/512-inventory-bugfix.yaml
+++ b/changelogs/fragments/512-inventory-bugfix.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  zabbix inventory - Moved ZABBIX_VALIDATE_CERTS to correct option, validate_certs.
+  - zabbix inventory - Moved ZABBIX_VALIDATE_CERTS to correct option, validate_certs.

--- a/plugins/inventory/zabbix_inventory.py
+++ b/plugins/inventory/zabbix_inventory.py
@@ -220,13 +220,13 @@ options:
        - If set to False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
       type: bool
       default: true
+      env:
+        - name: ZABBIX_VALIDATE_CERTS
     add_zabbix_groups:
       description:
        - If set to True, hosts will be added to groups based on their zabbix groups
       type: bool
       default: false
-      env:
-        - name: ZABBIX_VALIDATE_CERTS
 extends_documentation_fragment:
     - constructed
     - inventory_cache


### PR DESCRIPTION
##### SUMMARY
I had apparently added `ZABBIX_VALIDATE_CERTS` environment variable option under `add_zabbix_groups` instead of `validate_certs`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory

##### ADDITIONAL INFORMATION
My bad, sorry!

