### PR TITLE
typo error correction

### DIFF
--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -212,7 +212,7 @@
   register: zabbix_windows_service
 
 - name: "Windows | Register Service"
-  ansible.windows.win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix_win_config_name }}" --install'
+  ansible.windows.win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\conf\{{ zabbix_win_config_name }}" --install'
   when: not zabbix_windows_service.exists
 
 - name: "Windows | Set service startup mode to auto, ensure it is started and set auto-recovery"

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -213,7 +213,7 @@
 
 - name: "Windows | Register Service"
   ansible.windows.win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix_win_config_name }}" --install'
-  when: falset zabbix_windows_service.exists
+  when: not zabbix_windows_service.exists
 
 - name: "Windows | Set service startup mode to auto, ensure it is started and set auto-recovery"
   ansible.windows.win_service:

--- a/roles/zabbix_agent/tasks/tlspsk_auto_agent2_windows.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_agent2_windows.yml
@@ -8,8 +8,10 @@
   ansible.windows.win_stat:
     path: "{{ zabbix_agent2_tlspskfile }}"
   register: zabbix_agent2_tlspskcheck
+  become: true
 
 - name: AutoPSK | Check for existing TLS PSK identity (Windows)
   ansible.windows.win_stat:
     path: "{{ zabbix_agent2_tlspskidentity_file }}"
   register: zabbix_agent2_tlspskidentity_check
+  become: true

--- a/roles/zabbix_agent/tasks/tlspsk_auto_agent2_windows.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_agent2_windows.yml
@@ -8,10 +8,8 @@
   ansible.windows.win_stat:
     path: "{{ zabbix_agent2_tlspskfile }}"
   register: zabbix_agent2_tlspskcheck
-  become: true
 
 - name: AutoPSK | Check for existing TLS PSK identity (Windows)
   ansible.windows.win_stat:
     path: "{{ zabbix_agent2_tlspskidentity_file }}"
   register: zabbix_agent2_tlspskidentity_check
-  become: true

--- a/roles/zabbix_agent/tasks/tlspsk_auto_windows.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_windows.yml
@@ -8,10 +8,8 @@
   ansible.windows.win_stat:
     path: "{{ zabbix_agent_tlspskfile }}"
   register: zabbix_agent_tlspskcheck
-  become: true
 
 - name: AutoPSK | Check for existing TLS PSK identity (Windows)
   ansible.windows.win_stat:
     path: "{{ zabbix_agent_tlspskidentity_file }}"
   register: zabbix_agent_tlspskidentity_check
-  become: true


### PR DESCRIPTION
fix for the typo error replacing "falset" by "not" for fixing zabbix-agent installation

##### SUMMARY
fix for the typo error replacing "falset" by "not" for fixing zabbix-agent installation, there are no issues created about this

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
windows's zabbix agent installation

