### PR TITLE
Use templateid property for linking of templates

### DIFF
--- a/changelogs/fragments/523-templateid-property.yml
+++ b/changelogs/fragments/523-templateid-property.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - template - use templateid property when linking templates for ``template.create``
+    and ``template.update`` API calls.

--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -352,7 +352,7 @@ class Template(ZabbixBase):
                 continue
             else:
                 template_id = template_list[0]['templateid']
-                template_ids.append(template_id)
+                template_ids.append({'templateid': template_id})
         return template_ids
 
     def add_template(self, template_name, group_ids, link_template_ids, macros):
@@ -444,13 +444,15 @@ class Template(ZabbixBase):
 
         if template_changes:
             # If we got here we know that only one template was provided via template_name
-            template_changes.update({'templateid': template_ids[0]})
+            template_changes.update(template_ids[0])
             self._zapi.template.update(template_changes)
 
     def delete_template(self, templateids):
         if self._module.check_mode:
             self._module.exit_json(changed=True)
-        self._zapi.template.delete(templateids)
+
+        templateids_list = [t.get('templateid') for t in templateids]
+        self._zapi.template.delete(templateids_list)
 
     def ordered_json(self, obj):
         # Deep sort json dicts for comparison
@@ -462,8 +464,9 @@ class Template(ZabbixBase):
             return obj
 
     def dump_template(self, template_ids, template_type='json', omit_date=False):
+        template_ids_list = [t.get('templateid') for t in template_ids]
         try:
-            dump = self._zapi.configuration.export({'format': template_type, 'options': {'templates': template_ids}})
+            dump = self._zapi.configuration.export({'format': template_type, 'options': {'templates': template_ids_list}})
             if template_type == 'xml':
                 xmlroot = ET.fromstring(dump.encode('utf-8'))
                 # remove date field if requested

--- a/tests/integration/targets/test_zabbix_template/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template/tasks/main.yml
@@ -48,6 +48,25 @@
     that:
       - create_zabbix_template_result.changed is sameas false
 
+- name: Create a new Zabbix template with linked templates.
+  zabbix_template:
+    server_url: "{{ zabbix_api_server_url }}"
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    template_name: ExampleHostWithLinked
+    template_groups:
+      - 'Linux servers'
+      - 'Templates'
+    link_templates:
+      - "{{ 'Zabbix Proxy' if zabbix_version | float >= 5.2 else 'Template App Zabbix Proxy' }}"
+      - "{{ 'FTP Service' if zabbix_version | float >= 5.2 else 'Template App FTP Service' }}"
+    state: present
+  register: create_zabbix_template_linked_result
+
+- assert:
+    that:
+      - create_zabbix_template_linked_result.changed is sameas true
+
 - name: Gather Zabbix template infomation.
   zabbix_template_info:
     server_url: "{{ zabbix_api_server_url }}"


### PR DESCRIPTION
##### SUMMARY
Fixes "Error -32500: Application error., No permissions to referred object or it does not exist!" error on Zabbix 5.0+ when linking another template.

Currently this module is sending: `"templates": ["12345"]` which result in the above error during template.create API call on Zabbix 5.0 and newer. It worked correctly on version 4.0. There is none documented change in API, but it was already required before to send `templateid` property according to the documentation: https://www.zabbix.com/documentation/4.0/manual/api/reference/template/create

This PR changes request that it is sending: `"templates": [{"templateid": "12345"}]` which is correct way according to the documentation. This works fine on Zabbix 5.0.

It is implemented in a way that `get_template_ids` function returns list of dicts. Configuration dump and template delete still needs only list of IDs, so it is transformed to plain list of numbers for these.

A new test for template creating with linked template is included. This test currently fails on 5.0+ without changes in this PR.

Successfully tested against versions 4.0, 5.0 and 5.2. On 5.4 the template module tests currently fails due to another issue.

Fixes #519

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/zabbix_template.py