### PR TITLE
fix typo that broke entire task

### DIFF
--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -213,7 +213,7 @@
 
 - name: "Windows | Register Service"
   ansible.windows.win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix_win_config_name }}" --install'
-  when: falset zabbix_windows_service.exists
+  when: not zabbix_windows_service.exists
 
 - name: "Windows | Set service startup mode to auto, ensure it is started and set auto-recovery"
   ansible.windows.win_service:


### PR DESCRIPTION
##### SUMMARY
This PR fixes typo in Zabbix Agent role which broke role entirely for Windows hosts.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
**roles/zabbix_agent/tasks/Windows.yml** - there was a typo: "false**t**" instead of "not". Looks like someone was trying to find-and-replace all "no" with "false" to make yaml cleaner for the linter.

##### ADDITIONAL INFORMATION
Run zabbix role on any Windows host and you'll get this error:
`TASK [community.zabbix.zabbix_agent : Windows | Register Service] **************
fatal: [m-ts-lic]: FAILED! => {"msg": "The conditional check 'falset zabbix_windows_service.exists' failed. The error was: template error while templating string: expected token 'end of statement block', got 'zabbix_windows_service'. String: {% if falset zabbix_windows_service.exists %} True {% else %} False {% endif %}\n\nThe error appears to be in '/root/.ansible/collections/ansible_collections/community/zabbix/roles/zabbix_agent/tasks/Windows.yml': line 214, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Windows | Register Service\"\n  ^ here\n"}`
