### PR TITLE
Fix missing config creation

### DIFF
--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -213,7 +213,7 @@
 
 - name: "Windows | Register Service"
   ansible.windows.win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\{{ zabbix_win_config_name }}" --install'
-  when: falset zabbix_windows_service.exists
+  when: not zabbix_windows_service.exists
 
 - name: "Windows | Set service startup mode to auto, ensure it is started and set auto-recovery"
   ansible.windows.win_service:

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -206,6 +206,12 @@
   when:
     - zabbix_agent_win_download_zip.changed
 
+- name: "Windows | Configure zabbix-agent"
+  win_template:
+    src:  "{{ zabbix_win_config_name }}.j2"
+    dest: "{{ zabbix_win_install_dir }}\\{{ zabbix_win_config_name }}"
+  notify: restart win zabbix agent
+
 - name: "Windows | Check if windows service exist"
   ansible.windows.win_service:
     name: "{{ zabbix_win_svc_name }}"


### PR DESCRIPTION
##### SUMMARY
This PR fixes Zabbix Agent fresh installation failure on Windows machines.
Someone for some reason deleted config creation task and it causes service registration task to fail due to config file absence.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/zabbix_agent/tasks/Windows.yml

##### ADDITIONAL INFORMATION
Before the patch running Zabbix_agent role on fresh Windows throws this error:
```fatal: [m-test-winrm]: FAILED! => {"changed": true, "cmd": "\"c:\\Zabbix\\bin\\zabbix_agent2.exe\" --config \"c:\\Zabbix\\zabbix_agent2.conf\" --install", "delta": "0:00:00.166964", "end": "2021-11-15 06:11:49.446230", "msg": "non-zero return code", "rc": 1, "start": "2021-11-15 06:11:49.279265", "stderr": "zabbix_agent2 [2748]: ERROR: cannot open configuration file: open c:\\Zabbix\\zabbix_agent2.conf: The system cannot find the file specified.\n", "stderr_lines": ["zabbix_agent2 [2748]: ERROR: cannot open configuration file: open c:\\Zabbix\\zabbix_agent2.conf: The system cannot find the file specified."], "stdout": "", "stdout_lines": []}```

After: no error