### PR TITLE
Proposal to fix Issue #530

### DIFF
--- a/roles/zabbix_agent/tasks/Windows_conf.yml
+++ b/roles/zabbix_agent/tasks/Windows_conf.yml
@@ -7,15 +7,6 @@
     - zabbix_agent_ip is not defined
     - "'ansible_ip_addresses' in hostvars[inventory_hostname]"
 
-- name: "Windows | Place TLS-PSK file"
-  ansible.windows.win_copy:
-    content: "{{ zabbix_agent_tlspsk_secret }}"
-    dest: "{{ zabbix_agent_tlspskfile }}"
-  when:
-    - zabbix_agent_tlspskfile is defined
-    - zabbix_agent_tlspsk_secret is defined
-  notify: restart win zabbix agent
-
 - name: "Windows | Configure zabbix-agent"
   ansible.windows.win_template:
     src: "{{ zabbix_win_config_name }}.j2"

--- a/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
@@ -73,7 +73,7 @@
     - restart win zabbix agent
     - restart mac zabbix agent
     
- - name: AutoPSK | Template TLS PSK secret in file
+- name: AutoPSK | Template TLS PSK secret in file
   copy:
     dest: "{{ zabbix_agent2_tlspskfile }}"
     content: "{{ zabbix_agent2_tlspsk_secret }}"

--- a/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
+++ b/roles/zabbix_agent/tasks/tlspsk_auto_agent2.yml
@@ -72,6 +72,22 @@
     - restart zabbix-agent
     - restart win zabbix agent
     - restart mac zabbix agent
+    
+ - name: AutoPSK | Template TLS PSK secret in file
+  copy:
+    dest: "{{ zabbix_agent2_tlspskfile }}"
+    content: "{{ zabbix_agent2_tlspsk_secret }}"
+    owner: zabbix
+    group: zabbix
+    mode: 0400
+  become: true
+  when:
+    - zabbix_agent2_tlspskfile is defined
+    - zabbix_agent2_tlspsk_secret is defined
+  notify:
+    - restart zabbix-agent
+    - restart win zabbix agent
+    - restart mac zabbix agent
 
 - name: AutoPSK | Default tlsaccept and tlsconnect to enforce PSK
   set_fact:


### PR DESCRIPTION
##### SUMMARY
When you install agent version 2 on windows the secret file is not created because the when condition is never filled (he is waiting for agent version 1's vars and not the agent version 2)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
PSK setting up on Windows


##### ADDITIONAL INFORMATION
See issue 
https://github.com/ansible-collections/community.zabbix/issues/530

