### PR TITLE
Added dependencies for the collection

### DIFF
--- a/changelogs/fragments/367-add-dependencies.yml
+++ b/changelogs/fragments/367-add-dependencies.yml
@@ -1,0 +1,4 @@
+---
+
+minor_changes:
+  - collection - Add dependencies to other collections. This helps Ansible Galaxy automatically downloading collections that this collection relies on to run.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -16,3 +16,10 @@ repository: https://github.com/ansible-collections/community.zabbix.git
 documentation: https://github.com/ansible-collections/community.zabbix.git
 homepage: https://github.com/ansible-collections/community.zabbix
 issues: https://github.com/ansible-collections/community.zabbix/issues
+dependencies:
+  ansible.windows: "*"
+  ansible.netcommon: "*"
+  ansible.posix: "*"
+  community.general: "*"
+  community.mysql: "*"
+  community.postgresql: "*"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

As mentioned in the issue below, we add dependencies. Although we include the Windows and both the MySQL/PostgreSQL collection, the user still needs to make sure that something is running before using this collection.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #367

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
