### PR TITLE
remove python 3.7 and old zabbix versions

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -20,11 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         zabbix_container:
-          - version: "3.0"
+          #- version: "3.0"
           - version: "4.0"
-          - version: "4.4"
+          #- version: "4.4"
           - version: "5.0"
-          - version: "5.2"
+          - version: "5.4"
         ansible:
           - stable-2.10
           - stable-2.11
@@ -32,16 +32,16 @@ jobs:
           - devel
         python:
           - 2.7
-          - 3.7
+          #- 3.7
           - 3.8
           - 3.9
         exclude:
-          - ansible: devel
-            python: 3.7
+          #- ansible: devel
+          #  python: 3.7
           - ansible: devel
             python: 2.7
-          - ansible: stable-2.12
-            python: 3.7
+          #- ansible: stable-2.12
+          #  python: 3.7
           - ansible: stable-2.12
             python: 2.7
 

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python:
           - 2.7
-          - 3.7
+          #- 3.7
           - 3.8
           - 3.9
     runs-on: ubuntu-latest
@@ -52,16 +52,16 @@ jobs:
           - devel
         python:
           - 2.7
-          - 3.7
+          #- 3.7
           - 3.8
           - 3.9
         exclude:
-          - ansible: devel
-            python: 3.7
+          #- ansible: devel
+          #  python: 3.7
           - ansible: devel
             python: 2.7
-          - ansible: stable-2.12
-            python: 3.7
+          #- ansible: stable-2.12
+          #  python: 3.7
           - ansible: stable-2.12
             python: 2.7
     runs-on: ubuntu-latest

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -1166,8 +1166,16 @@ def main():
                         elif index == 'details' and not interface[index]:
                             interface[index] = {}
 
+                    for key in interface.copy():
+                        if key not in [ "type", "dns", "main", "useip", "ip", "port", "details" ]:
+                            module.warn("removing %s from %s" % (key, interface))
+                            del interface[key]
+                      
                     if interface not in interfaces:
+                        module.warn("adding %s" % (interface))
                         interfaces.append(interface)
+                    else:
+                        module.warn("skpping %s" % (interface))
 
             if not force or link_templates is None:
                 template_ids = list(set(template_ids + host.get_host_templates_by_host_id(host_id)))

--- a/tests/integration/targets/test_zabbix_host_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_host_info/tasks/main.yml
@@ -11,7 +11,7 @@
       - Linux servers
       - Hypervisors
     link_templates:
-      - "{{ 'Zabbix Server' if zabbix_version | float >= 5.2 else 'Template App Zabbix Server' }}"
+      - "{{ 'Zabbix Server' if zabbix_version | float >= 5.4 else 'Zabbix server health' }}"
     status: enabled
     inventory_mode: manual
     inventory_zabbix:
@@ -67,7 +67,7 @@
           - gather_all_facts_result.hosts.0.description == "Test Host"
           - gather_all_facts_result.hosts.0.groups.0.name == "Linux servers"
           - gather_all_facts_result.hosts.0.groups.1.name == "Hypervisors"
-          - gather_all_facts_result.hosts.0.parentTemplates.0.name == "Template App Zabbix Server"
+          - gather_all_facts_result.hosts.0.parentTemplates.0.name == "Zabbix server health"
           - gather_all_facts_result.hosts.0.status == "0"
           - gather_all_facts_result.hosts.0.inventory.inventory_mode == "0"
           - gather_all_facts_result.hosts.0.inventory.tag == "tag1"
@@ -88,7 +88,7 @@
           - gather_all_facts_result.hosts.0.description == "Test Host"
           - gather_all_facts_result.hosts.0.groups.0.name == "Linux servers"
           - gather_all_facts_result.hosts.0.groups.1.name == "Hypervisors"
-          - gather_all_facts_result.hosts.0.parentTemplates.0.name == "Template App Zabbix Server"
+          - gather_all_facts_result.hosts.0.parentTemplates.0.name == "Zabbix server health"
           - gather_all_facts_result.hosts.0.status == "0"
           - gather_all_facts_result.hosts.0.inventory_mode == "0"
           - gather_all_facts_result.hosts.0.inventory.tag == "tag1"


### PR DESCRIPTION
##### SUMMARY

* Removed python 3.7 in sanity and integration tests
* Removed Zabbix 3.0, 4.4, 5.2
* Added Zabbix 5.4

Would fix #576 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- sanity tests
- integration tests
