### PR TITLE
remove old versions in tests

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -20,11 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         zabbix_container:
-          - version: "3.0"
           - version: "4.0"
-          - version: "4.4"
           - version: "5.0"
-          - version: "5.2"
         ansible:
           - stable-2.10
           - stable-2.11
@@ -32,16 +29,11 @@ jobs:
           - devel
         python:
           - 2.7
-          - 3.7
           - 3.8
           - 3.9
         exclude:
           - ansible: devel
-            python: 3.7
-          - ansible: devel
             python: 2.7
-          - ansible: stable-2.12
-            python: 3.7
           - ansible: stable-2.12
             python: 2.7
 

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -28,14 +28,18 @@ jobs:
           - stable-2.12
           - devel
         python:
-          - 2.7
-          - 3.8
+          - 2.7 # required by Ansible see https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#python-compatibility
+          - 3.6 # required by Ansible see https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#python-compatibility
           - 3.9
         exclude:
           - ansible: devel
             python: 2.7
+          - ansible: devel
+            python: 3.6
           - ansible: stable-2.12
             python: 2.7
+          - ansible: stable-2.12
+            python: 3.6
 
     steps:
       - name: Check out code

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -50,14 +50,18 @@ jobs:
           - stable-2.12
           - devel
         python:
-          - 2.7
-          - 3.8
+          - 2.7 # required by Ansible see https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#python-compatibility
+          - 3.6 # required by Ansible see https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#python-compatibility
           - 3.9
         exclude:
           - ansible: devel
             python: 2.7
+          - ansible: devel
+            python: 3.6
           - ansible: stable-2.12
             python: 2.7
+          - ansible: stable-2.12
+            python: 3.6
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         python:
           - 2.7
-          - 3.7
           - 3.8
           - 3.9
     runs-on: ubuntu-latest
@@ -52,16 +51,11 @@ jobs:
           - devel
         python:
           - 2.7
-          - 3.7
           - 3.8
           - 3.9
         exclude:
           - ansible: devel
-            python: 3.7
-          - ansible: devel
             python: 2.7
-          - ansible: stable-2.12
-            python: 3.7
           - ansible: stable-2.12
             python: 2.7
     runs-on: ubuntu-latest

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         python:
-          - 2.7
-          - 3.8
+          - 2.7 # required by Ansible see https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#python-compatibility
+          - 3.6 # required by Ansible see https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#python-compatibility
           - 3.9
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
##### SUMMARY
Removed python 3.7 in sanity and integration tests
Removed Zabbix 3.0, 4.4, 5.2

Would fix #576 partially - readding 5.4 in separate branch/PR afterwards

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
sanity tests
integration tests
