### PR TITLE
Modify referring key in zabbix_action.py

### DIFF
--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -1080,7 +1080,7 @@ class Operations(Zapi):
         if operation.get('run_on_groups') is None:
             return None
         return [{
-            'groupid': self._zapi_wrapper.get_hostgroup_by_hostgroup_name(_group)['hostid']
+            'groupid': self._zapi_wrapper.get_hostgroup_by_hostgroup_name(_group)['groupid']
         } for _group in operation.get('run_on_groups')]
 
     def _construct_opgroup(self, operation):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix KeyError in zabbix_action.py
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_action
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
get_hostgroup_by_hostgroup_name function returns a dictionary about hostgroup.
The dictionary does not have hostid key but groupid key([another line](https://github.com/ansible-collections/community.zabbix/blob/main/plugins/modules/zabbix_action.py#L1096) refers groupid key). 
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
"module_stderr": "Traceback (most recent call last):\n  File \"/var/lib/awx/.ansible/tmp/ansible-tmp-1642742130.579571-829-
156426998767059/AnsiballZ_zabbix_action.py\", line 102, in <module>\n    _ansiballz_main()\n  File 
\"/var/lib/awx/.ansible/tmp/ansible-tmp-1642742130.579571-829-156426998767059/AnsiballZ_zabbix_action.py\", line 94, in 
_ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/var/lib/awx/.ansible/tmp/ansible-
tmp-1642742130.579571-829-156426998767059/AnsiballZ_zabbix_action.py\", line 40, in invoke_module\n    
runpy.run_module(mod_name='ansible_collections.community.zabbix.plugins.modules.zabbix_action', init_globals=None, 
run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\n    return 
_run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in 
_run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File \"/usr/lib64/python3.6/runpy.py\", line 85, in 
_run_code\n    exec(code, run_globals)\n  File 
\"/tmp/ansible_community.zabbix.zabbix_action_payload_88hk6x1l/ansible_community.zabbix.zabbix_action_payload.zip/ansible_
collections/community/zabbix/plugins/modules/zabbix_action.py\", line 2058, in <module>\n  File 
\"/tmp/ansible_community.zabbix.zabbix_action_payload_88hk6x1l/ansible_community.zabbix.zabbix_action_payload.zip/ansible_
collections/community/zabbix/plugins/modules/zabbix_action.py\", line 2049, in main\n  File 
\"/tmp/ansible_community.zabbix.zabbix_action_payload_88hk6x1l/ansible_community.zabbix.zabbix_action_payload.zip/ansible_
collections/community/zabbix/plugins/modules/zabbix_action.py\", line 1178, in construct_the_data\n  File 
\"/tmp/ansible_community.zabbix.zabbix_action_payload_88hk6x1l/ansible_community.zabbix.zabbix_action_payload.zip/ansible_
collections/community/zabbix/plugins/modules/zabbix_action.py\", line 1083, in _construct_opcommand_grp\n  File 
\"/tmp/ansible_community.zabbix.zabbix_action_payload_88hk6x1l/ansible_community.zabbix.zabbix_action_payload.zip/ansible_
collections/community/zabbix/plugins/modules/zabbix_action.py\", line 1083, in <listcomp>\nKeyError: 'hostid'\n",
```
