### PR TITLE
Support for multiple agent config Alias entries

### DIFF
--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -312,7 +312,9 @@ PersistentBufferFile={{ zabbix_agent2_persistentbufferfile }}
 # Range:
 # Default:
 {% if zabbix_agent2_zabbix_alias is defined and zabbix_agent2_zabbix_alias %}
-Alias={{ zabbix_agent2_zabbix_alias }}
+{% for alias in zabbix_agent2_zabbix_alias %}
+Alias={{ alias }}
+{% endfor %}
 {% endif %}
 
 ### Option: Timeout

--- a/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
@@ -217,7 +217,9 @@ MaxLinesPerSecond={{ zabbix_agent_maxlinespersecond }}
 #       sets an alias for parameter. it can be useful to substitute long and complex parameter name with a smaller and simpler one.
 #
 {% if zabbix_agent_zabbix_alias is defined and zabbix_agent_zabbix_alias %}
-Alias={{ zabbix_agent_zabbix_alias }}
+{% for alias in zabbix_agent_zabbix_alias %}
+Alias={{ alias }}
+{% endfor %}
 {% endif %}
 
 ### option: timeout


### PR DESCRIPTION
##### SUMMARY
Required setup of multiple aliases, existing code gives an incorrect syntax that prevents the agent from starting. Edited this code locally to allow it to input multiple aliases in supported syntax.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent template

##### ADDITIONAL INFORMATION
Original template:
Can't define multiple alias values in yaml, passing an array passes the array into zabbix_agentd.conf wholesale which prevents the agent from starting due to invalid syntax.

Proposed changed to template:
Simple fix applied to zabbix_agent2.conf.j2 and zabbix_agentd.conf.j2 allows you to specify an array of aliases you'd like to include in your configuration.

##### USAGE
`zabbix_agent_zabbix_alias: ["alias1[*]:alias","alias2.info[*]:alias.info[*]","alias3.info[*]:alias.info[*]"]`
