### PR TITLE
Fix package name [Ready to merge]

### DIFF
--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -206,7 +206,7 @@
 - name: "Debian | Install Mysql Client package"
   apt:
     name:
-      - mysql-client
+      - default-mysql-client
       - "{{ zabbix_python_prefix }}-mysqldb"
     state: present
   environment:


### PR DESCRIPTION
Update package name "mysql-client" by "default-mysql-client"
Or maybe we can update by "mariadb-client" also.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the package mysql-client because it's failed on debian 11. This package is not found.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_server tasks debian