### PR TITLE
Fix example for installing `community.postgresql`

### DIFF
--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -68,7 +68,7 @@ ansible-galaxy collection install community.mysql
 When you are a PostgreSQL user and using Ansible 2.10 or newer, then there is a dependency on the collection named `community.postgresql`. This collections are needed as the `postgresql_` modules are now part of collections and not standard in Ansible anymmore. Installing the collection:
 
 ```sh
-ansible-galaxy collection install community.mysql
+ansible-galaxy collection install community.postgresql
 ```
 
 ## Zabbix Versions


### PR DESCRIPTION
##### SUMMARY
Fixes the example for installing `community.postgresql` as it currently incorrectly references `community.mysql`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Docs for `zabbix_server` role
