### PR TITLE
Set Zabbix 6.0 as default

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         molecule_distro:
           - container: centos8
-            image: geerlingguy/docker-centos8-ansible:latest
+            image: geerlingguy/docker-rockylinux8-ansible:latest
           - container: centos7
             image: geerlingguy/docker-centos7-ansible:latest
           - container: fedora32

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -34,8 +34,6 @@ jobs:
             image: geerlingguy/docker-debian10-ansible
           - container: debian9
             image: geerlingguy/docker-debian9-ansible
-          - container: debian8
-            image: geerlingguy/docker-debian8-ansible
         scenario_name:
           - default
           - autopsk

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         molecule_distro:
           - container: mysql-centos
-            image: geerlingguy/docker-centos8-ansible:latest
+            image: geerlingguy/docker-rockylinux8-ansible:latest
             group: mysql
           - container: pgsql-centos
-            image: geerlingguy/docker-centos8-ansible:latest
+            image: geerlingguy/docker-rockylinux8-ansible:latest
             group: postgresql
           - container: sqlite-centos
-            image: geerlingguy/docker-centos8-ansible:latest
+            image: geerlingguy/docker-rockylinux8-ansible:latest
             group: sqlite3
           - container: mysql-ubuntu
             image: geerlingguy/docker-ubuntu2004-ansible

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         molecule_distro:
           - container: mysql-centos
-            image: geerlingguy/docker-centos8-ansible:latest
+            image: geerlingguy/docker-rockylinux8-ansible:latest
             group: mysql
           - container: pgsql-centos
-            image: geerlingguy/docker-centos8-ansible:latest
+            image: geerlingguy/docker-rockylinux8-ansible:latest
             group: postgresql
           - container: mysql-ubuntu
             image: geerlingguy/docker-ubuntu2004-ansible

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         molecule_distro:
           - container: mysql-centos8
-            image: geerlingguy/docker-centos8-ansible:latest
+            image: geerlingguy/docker-rockylinux8-ansible:latest
             group: mysql
           - container: pgsql-centos8
-            image: geerlingguy/docker-centos8-ansible:latest
+            image: geerlingguy/docker-rockylinux8-ansible:latest
             group: postgresql
           - container: mysql-ubuntu18
             image: geerlingguy/docker-ubuntu1804-ansible

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -135,7 +135,7 @@ The following is an overview of all available configuration default for this rol
 
 ### Overall Zabbix
 
-* `zabbix_agent_version`: This is the version of zabbix. Default: 5.2. Can be overridden to 5.0, 4.4, 4.0, 3.4, 3.2, 3.0, 2.4, or 2.2. Previously the variable `zabbix_version` was used directly but it could cause [some inconvenience](https://github.com/dj-wasabi/ansible-zabbix-agent/pull/303). That variable is maintained by retrocompativility.
+* `zabbix_agent_version`: This is the version of zabbix. Default: 6.0. Can be overridden to 5.4, 5.2 5.0, 4.4, 4.0, 3.4, 3.2, 3.0, 2.4, or 2.2. Previously the variable `zabbix_version` was used directly but it could cause [some inconvenience](https://github.com/dj-wasabi/ansible-zabbix-agent/pull/303). That variable is maintained by retrocompativility.
 * `zabbix_agent_version_minor`: When you want to specify a minor version to be installed. Is also used for `zabbix_sender` and `zabbix_get`. RedHat only. Default set to: `*` (latest available)
 * `zabbix_repo`: Default: `zabbix`
   * `epel`: install agent from EPEL repo

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -98,7 +98,7 @@ The following is an overview of all available configuration default for this rol
 
 ### Overall Zabbix
 
-* `zabbix_proxy_version`: This is the version of zabbix. Default: 5.2. Can be overridden to 5.0, 4.4, 4.0, 3.4, 3.2, 3.0, 2.4, or 2.2. Previously the variable `zabbix_version` was used directly but it could cause [some inconvenience](https://github.com/dj-wasabi/ansible-zabbix-agent/pull/303). That variable is maintained by retrocompativility.
+* `zabbix_proxy_version`: This is the version of zabbix. Default: 6.0. Can be overridden to 5.4, 5.2, 5.0, 4.4, 4.0, 3.4, 3.2, 3.0, 2.4, or 2.2. Previously the variable `zabbix_version` was used directly but it could cause [some inconvenience](https://github.com/dj-wasabi/ansible-zabbix-agent/pull/303). That variable is maintained by retrocompativility.
 * `zabbix_proxy_version_minor`: When you want to specify a minor version to be installed. RedHat only. Default set to: `*` (latest available)
 * `zabbix_repo`: Default: `zabbix`
   * `epel`: install agent from EPEL repo

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -110,7 +110,7 @@ The following is an overview of all available configuration default for this rol
 
 ### Overall Zabbix
 
-* `zabbix_server_version`: This is the version of zabbix. Default: 5.2. Can be overridden to 5.0, 4.4, 4.0, 3.4, 3.2, 3.0, 2.4, or 2.2. Previously the variable `zabbix_version` was used directly but it could cause [some inconvenience](https://github.com/dj-wasabi/ansible-zabbix-agent/pull/303). That variable is maintained by retrocompativility.
+* `zabbix_server_version`: This is the version of zabbix. Default: 6.0. Can be overridden to 5.4, 5.2, 5.0, 4.4, 4.0, 3.4, 3.2, 3.0, 2.4, or 2.2. Previously the variable `zabbix_version` was used directly but it could cause [some inconvenience](https://github.com/dj-wasabi/ansible-zabbix-agent/pull/303). That variable is maintained by retrocompativility.
 * `zabbix_server_version_minor`: When you want to specify a minor version to be installed. RedHat only. Default set to: `*` (latest available)
 * `zabbix_repo`: Default: `zabbix`
   * `epel`: install agent from EPEL repo

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -92,7 +92,7 @@ The following is an overview of all available configuration defaults for this ro
 
 ### Overall Zabbix
 
-* `zabbix_web_version`: This is the version of zabbix. Default: 5.2. Can be overridden to 5.0, 4.4, 4.0, 3.4, 3.2, 3.0, 2.4, or 2.2. Previously the variable `zabbix_version` was used directly but it could cause [some inconvenience](https://github.com/dj-wasabi/ansible-zabbix-agent/pull/303). That variable is maintained by retrocompativility.
+* `zabbix_web_version`: This is the version of zabbix. Default: 6.0. Can be overridden to 5.4, 5.2, 5.0, 4.4, 4.0, 3.4, 3.2, 3.0, 2.4, or 2.2. Previously the variable `zabbix_version` was used directly but it could cause [some inconvenience](https://github.com/dj-wasabi/ansible-zabbix-agent/pull/303). That variable is maintained by retrocompativility.
 * `zabbix_web_version_minor`: When you want to specify a minor version to be installed. RedHat only. Default set to: `*` (latest available)
 * `zabbix_repo`: Default: `zabbix`
   * `epel`: install agent from EPEL repo

--- a/molecule/zabbix_agent_tests/common/tests/common/test_agent.py
+++ b/molecule/zabbix_agent_tests/common/tests/common/test_agent.py
@@ -41,6 +41,6 @@ def test_zabbix_package(host, zabbix_agent_package):
     assert zabbix_agent_package.is_installed
 
     if host.system_info.distribution == "debian":
-        assert zabbix_agent_package.version.startswith("1:5.4")
+        assert zabbix_agent_package.version.startswith("1:6.0")
     if host.system_info.distribution == "centos":
-        assert zabbix_agent_package.version.startswith("5.4")
+        assert zabbix_agent_package.version.startswith("6.0")

--- a/molecule/zabbix_proxy/prepare.yml
+++ b/molecule/zabbix_proxy/prepare.yml
@@ -7,7 +7,7 @@
     - name: "Create MySQL Container"
       docker_container:
         name: mysql-host
-        image: mysql:5.7
+        image: mysql:8.0
         state: started
         recreate: true
         networks:

--- a/molecule/zabbix_proxy/tests/test_default.py
+++ b/molecule/zabbix_proxy/tests/test_default.py
@@ -26,11 +26,10 @@ def test_zabbix_package(host, proxy):
     zabbixhost = zabbixhost.replace("-ubuntu", "")
 
     if zabbixhost == proxy:
+        zabbix_proxy = host.package(proxy)
         if host.system_info.distribution in ['debian', 'ubuntu']:
-            zabbix_proxy = host.package(proxy)
             assert zabbix_proxy.version.startswith("1:6.0")
         elif host.system_info.distribution == 'centos':
-            zabbix_proxy = host.package(proxy)
             assert zabbix_proxy.version.startswith("6.0")
         assert zabbix_proxy.is_installed
 

--- a/molecule/zabbix_proxy/tests/test_default.py
+++ b/molecule/zabbix_proxy/tests/test_default.py
@@ -28,10 +28,10 @@ def test_zabbix_package(host, proxy):
     if zabbixhost == proxy:
         if host.system_info.distribution in ['debian', 'ubuntu']:
             zabbix_proxy = host.package(proxy)
-            assert zabbix_proxy.version.startswith("1:5.4")
+            assert zabbix_proxy.version.startswith("1:6.0")
         elif host.system_info.distribution == 'centos':
             zabbix_proxy = host.package(proxy)
-            assert zabbix_proxy.version.startswith("5.4")
+            assert zabbix_proxy.version.startswith("6.0")
         assert zabbix_proxy.is_installed
 
 

--- a/molecule/zabbix_server/prepare.yml
+++ b/molecule/zabbix_server/prepare.yml
@@ -7,7 +7,7 @@
     - name: "Create MySQL Container"
       docker_container:
         name: mysql-host
-        image: mysql:5.7
+        image: mysql:8.0
         state: started
         recreate: true
         networks:

--- a/molecule/zabbix_server/tests/test_default.py
+++ b/molecule/zabbix_server/tests/test_default.py
@@ -28,10 +28,10 @@ def test_zabbix_package(host, server):
     if zabbixhost == server:
         if host.system_info.distribution in ['debian', 'ubuntu']:
             zabbix_server = host.package(server)
-            assert zabbix_server.version.startswith("1:5.4")
+            assert zabbix_server.version.startswith("1:6.0")
         elif host.system_info.distribution == 'centos':
             zabbix_server = host.package(server)
-            assert zabbix_server.version.startswith("5.4")
+            assert zabbix_server.version.startswith("6.0")
         assert zabbix_server.is_installed
 
 

--- a/molecule/zabbix_server/tests/test_default.py
+++ b/molecule/zabbix_server/tests/test_default.py
@@ -26,11 +26,10 @@ def test_zabbix_package(host, server):
     zabbixhost = zabbixhost.replace("-ubuntu", "")
 
     if zabbixhost == server:
+        zabbix_server = host.package(server)
         if host.system_info.distribution in ['debian', 'ubuntu']:
-            zabbix_server = host.package(server)
             assert zabbix_server.version.startswith("1:6.0")
         elif host.system_info.distribution == 'centos':
-            zabbix_server = host.package(server)
             assert zabbix_server.version.startswith("6.0")
         assert zabbix_server.is_installed
 

--- a/molecule/zabbix_web/prepare.yml
+++ b/molecule/zabbix_web/prepare.yml
@@ -7,7 +7,7 @@
     - name: "Create MySQL Container"
       docker_container:
         name: mysql-host
-        image: mysql:5.7
+        image: mysql:8.0
         state: started
         recreate: true
         networks:

--- a/molecule/zabbix_web/tests/test_default.py
+++ b/molecule/zabbix_web/tests/test_default.py
@@ -21,10 +21,10 @@ def test_zabbix_package(host, server, redhat, debian):
     if host == server:
         if host.system_info.distribution in ['debian', 'ubuntu']:
             zabbix_web = host.package(debian)
-            assert zabbix_web.version.startswith("1:5.4")
+            assert zabbix_web.version.startswith("1:6.0")
         elif host.system_info.distribution == 'centos':
             zabbix_web = host.package(redhat)
-            assert zabbix_web.version.startswith("5.4")
+            assert zabbix_web.version.startswith("6.0")
         assert zabbix_web.is_installed
 
 

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for zabbix_agent
 
 zabbix_agent2: false
-zabbix_agent_version: 5.4
+zabbix_agent_version: 6.0
 zabbix_agent_version_minor: "*"
 zabbix_version: "{{ zabbix_agent_version }}"
 zabbix_version_patch: 0

--- a/roles/zabbix_agent/vars/zabbix.yml
+++ b/roles/zabbix_agent/vars/zabbix.yml
@@ -1,6 +1,6 @@
 ---
 sign_keys:
-  "55":
+  "60":
     bullseye:
       sign_key: E709712C
     buster:

--- a/roles/zabbix_agent/vars/zabbix.yml
+++ b/roles/zabbix_agent/vars/zabbix.yml
@@ -5,6 +5,8 @@ sign_keys:
       sign_key: E709712C
     buster:
       sign_key: E709712C
+    jessie:
+      sign_key: E709712C
     stretch:
       sign_key: E709712C
     focal:

--- a/roles/zabbix_agent/vars/zabbix.yml
+++ b/roles/zabbix_agent/vars/zabbix.yml
@@ -5,8 +5,6 @@ sign_keys:
       sign_key: E709712C
     buster:
       sign_key: E709712C
-    jessie:
-      sign_key: E709712C
     stretch:
       sign_key: E709712C
     focal:

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for zabbix_javagateway
 
-zabbix_javagateway_version: 5.4
+zabbix_javagateway_version: 6.0
 zabbix_version: "{{ zabbix_javagateway_version }}"
 zabbix_javagateway_package_state: present
 zabbix_selinux: false

--- a/roles/zabbix_javagateway/vars/zabbix.yml
+++ b/roles/zabbix_javagateway/vars/zabbix.yml
@@ -1,6 +1,6 @@
 ---
 sign_keys:
-  "55":
+  "60":
     bullseye:
       sign_key: E709712C
     buster:

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for zabbix_proxy
 
-zabbix_proxy_version: 5.4
+zabbix_proxy_version: 6.0
 zabbix_proxy_version_minor: "*"
 zabbix_version: "{{ zabbix_proxy_version }}"
 zabbix_selinux: false

--- a/roles/zabbix_proxy/tasks/sqlite3.yml
+++ b/roles/zabbix_proxy/tasks/sqlite3.yml
@@ -26,7 +26,15 @@
   become_user: zabbix
   shell: |
     set -o pipefail
-    zcat {{ datafiles_path }}/schema.sql.gz | sqlite3 {{ zabbix_proxy_dbname }}
+    FILE={{ 'schema.sql' if zabbix_version is version('6.0', '<') else 'proxy.sql' }}
+    cd {{ datafiles_path }}
+    if [ -f ${FILE}.gz ]
+      then zcat ${FILE}.gz > /tmp/schema.sql
+    else
+      cp ${FILE} /tmp/schema.sql
+    fi
+    cat /tmp/schema.sql | sqlite3 {{ zabbix_proxy_dbname }}
+    rm -f /tmp/schema.sql
   args:
     creates: "{{ zabbix_proxy_dbname }}"
     executable: /bin/bash

--- a/roles/zabbix_proxy/vars/zabbix.yml
+++ b/roles/zabbix_proxy/vars/zabbix.yml
@@ -1,6 +1,6 @@
 ---
 sign_keys:
-  "55":
+  "60":
     bullseye:
       sign_key: E709712C
     buster:

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for zabbix_server
 
-zabbix_server_version: 5.4
+zabbix_server_version: 6.0
 zabbix_server_version_minor: "*"
 zabbix_version: "{{ zabbix_server_version }}"
 zabbix_repo: zabbix

--- a/roles/zabbix_server/vars/zabbix.yml
+++ b/roles/zabbix_server/vars/zabbix.yml
@@ -1,6 +1,6 @@
 ---
 sign_keys:
-  "55":
+  "60":
     bullseye:
       sign_key: E709712C
     buster:

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for zabbix-web
 
-zabbix_web_version: 5.4
+zabbix_web_version: 6.0
 zabbix_web_version_minor: "*"
 zabbix_version: "{{ zabbix_web_version }}"
 zabbix_repo: zabbix

--- a/roles/zabbix_web/vars/zabbix.yml
+++ b/roles/zabbix_web/vars/zabbix.yml
@@ -1,6 +1,6 @@
 ---
 sign_keys:
-  "55":
+  "60":
     bullseye:
       sign_key: E709712C
     buster:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Set Zabbix 6.0 as default version to be installed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
