### PR TITLE
Fix zabbix_globalmacro module

### DIFF
--- a/plugins/modules/zabbix_globalmacro.py
+++ b/plugins/modules/zabbix_globalmacro.py
@@ -63,6 +63,10 @@ options:
             - Only updates an existing macro if set to C(yes).
         default: 'yes'
         type: bool
+
+notes:
+    - This module returns changed=true when I(macro_type=secret) with Zabbix >= 5.0.
+
 extends_documentation_fragment:
 - community.zabbix.zabbix
 '''
@@ -135,7 +139,7 @@ class GlobalMacro(ZabbixBase):
                 self._module.exit_json(changed=True, result="Successfully added global macro %s" % macro_name)
             if LooseVersion(self._zbx_api_version) >= LooseVersion('4.4.0'):
                 if LooseVersion(self._zbx_api_version) >= LooseVersion('5.0.0'):
-                    if LooseVersion(self._zbx_api_version) >= LooseVersion('5.0.0') and LooseVersion(self._zbx_api_version) < LooseVersion('5.4.0'):
+                    if LooseVersion(self._zbx_api_version) < LooseVersion('5.2.0'):
                         if macro_type == '2':
                             macro_type = '0'
                     self._zapi.usermacro.createglobal({'macro': macro_name, 'value': macro_value, 'type': macro_type, 'description': macro_description})
@@ -158,11 +162,8 @@ class GlobalMacro(ZabbixBase):
                 self._zapi.usermacro.updateglobal({'globalmacroid': global_macro_id, 'macro': macro_name, 'value': macro_value})
                 self._module.exit_json(changed=True, result="Successfully updated global macro %s" % macro_name)
             elif LooseVersion(self._zbx_api_version) >= LooseVersion('5.0.0'):
-                if LooseVersion(self._zbx_api_version) >= LooseVersion('5.4.0'):
-                    if macro_type == '1':
-                        macro_type = '0'
-                if LooseVersion(self._zbx_api_version) >= LooseVersion('5.0.0') and LooseVersion(self._zbx_api_version) < LooseVersion('5.4.0'):
-                    if macro_type == '2' or macro_type == '1':
+                if LooseVersion(self._zbx_api_version) < LooseVersion('5.2.0'):
+                    if macro_type == '2':
                         macro_type = '0'
                 if global_macro_obj['type'] == '0' or global_macro_obj['type'] == '2':
                     if (global_macro_obj['macro'] == macro_name and global_macro_obj['value'] == macro_value
@@ -217,7 +218,7 @@ def main():
     argument_spec = zabbix_utils.zabbix_common_argument_spec()
     argument_spec.update(dict(
         macro_name=dict(type='str', required=True),
-        macro_value=dict(type='str', required=False),
+        macro_value=dict(type='str', required=False, no_log=True),
         macro_type=dict(type='str', default='text', choices=['text', 'secret', 'vault']),
         macro_description=dict(type='str', default=''),
         state=dict(type='str', default='present', choices=['present', 'absent']),

--- a/tests/integration/targets/test_zabbix_globalmacro/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_globalmacro/tasks/main.yml
@@ -145,3 +145,75 @@
 - name: assert that nothing has been changed
   assert:
     that: not zbxgmacro_delete_missing is changed
+
+- name: test - attempt to create secret global macro
+  zabbix_globalmacro:
+    server_url: "{{ zabbix_api_server_url }}"
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    macro_name: zbxgmacro_test_secret
+    macro_value: 123
+    macro_type: secret
+    macro_description: Global Macro description
+  register: zbxgmacro_secret
+
+- assert:
+    that: zbxgmacro_secret.changed is sameas True
+
+- name: test - attempt to create same global macro
+  zabbix_globalmacro:
+    server_url: "{{ zabbix_api_server_url }}"
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    macro_name: zbxgmacro_test_secret
+    macro_value: 123
+    macro_type: secret
+    macro_description: Global Macro description
+  register: zbxgmacro_secret
+
+- assert:
+    that: zbxgmacro_secret.changed is sameas True
+  when: zabbix_version is version('5.0', '>=')
+
+- assert:
+    that: zbxgmacro_secret.changed is sameas False
+  when: zabbix_version is version('5.0', '<')
+
+- name: test - attempt to create vault global macro
+  zabbix_globalmacro:
+    server_url: "{{ zabbix_api_server_url }}"
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    macro_name: zbxgmacro_test_vault
+    macro_value: /path/to/vault.txt
+    macro_type: vault
+    macro_description: Global Macro description
+  register: zbxgmacro_vault
+
+- assert:
+    that: zbxgmacro_vault.changed is sameas True
+
+- name: test - attempt to create same global macro
+  zabbix_globalmacro:
+    server_url: "{{ zabbix_api_server_url }}"
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    macro_name: zbxgmacro_test_vault
+    macro_value: /path/to/vault.txt
+    macro_type: vault
+    macro_description: Global Macro description
+  register: zbxgmacro_vault
+
+- assert:
+    that: zbxgmacro_vault.changed is sameas False
+
+- name: delete all global macros
+  zabbix_globalmacro:
+    server_url: "{{ zabbix_api_server_url }}"
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    macro_name: "{{ item }}"
+    state: absent
+  loop:
+    - zbxgmacro_test_secret
+    - zbxgmacro_test_vault


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- zabbix_globalmacro  module changes type to text from secret and vault. Fix them.
- The value parameter must be not logged for the value which's type is secret.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_globalmacro
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

