### PR TITLE
Add error message for application condition type of zabbix action

### DIFF
--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -72,6 +72,7 @@ options:
             type:
                 description:
                     - Type (label) of the condition.
+                    - C(application) is available only with <= Zabbix 5.2.
                     - 'Possible values when I(event_source=trigger):'
                     - ' - C(host_group)'
                     - ' - C(host)'
@@ -1383,6 +1384,11 @@ class Filter(Zapi):
         Returns:
             str: constructed condition type data
         """
+        # application is disabled is disabled for condition type since 5.4 version.
+        if (LooseVersion(self._zbx_api_version) >= LooseVersion('5.4')
+                and _condition['type'] == 'application'):
+            self._module.fail_json(msg="'%s' is disabled for condition type since 5.4 version." % _condition['type'])
+
         try:
             return to_numeric_value([
                 "host_group",

--- a/tests/integration/targets/test_zabbix_action/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_action/tasks/main.yml
@@ -282,9 +282,6 @@
         - type: trigger_severity
           operator: '>='
           value: Average
-        - type: application
-          operator: like
-          value: AnsibleTest
         - type: event_tag_value
           value: MyTag
           operator: '='
@@ -306,9 +303,6 @@
         - type: trigger_severity
           operator: '>='
           value: Average
-        - type: application
-          operator: like
-          value: AnsibleTest
         - type: event_tag_value
           value: MyTag
           operator: '='
@@ -327,9 +321,6 @@
         - type: host_group
           operator: '='
           value: Linux servers
-        - type: application
-          operator: like
-          value: AnsibleTest
         - type: event_tag_value
           value: MyTag
           operator: '='
@@ -351,9 +342,6 @@
         - type: host_group
           operator: '='
           value: Linux servers
-        - type: application
-          operator: like
-          value: AnsibleTest
         - type: event_tag_value
           value: MyTag
           operator: '='
@@ -372,9 +360,6 @@
         - type: host_group
           operator: '<>'
           value: Linux servers
-        - type: application
-          operator: not like
-          value: AnsibleTest
         - type: event_tag_value
           value: MyTag
           operator: '<>'
@@ -393,9 +378,6 @@
         - type: host_group
           operator: '<>'
           value: Linux servers
-        - type: application
-          operator: not like
-          value: AnsibleTest
         - type: event_tag_value
           value: MyTag
           operator: '<>'
@@ -415,9 +397,6 @@
         - type: host_group
           operator: '<>'
           value: Linux servers
-        - type: application
-          operator: not like
-          value: AnsibleTest
         - type: event_tag_value
           value: MyTag
           operator: '<>'
@@ -932,9 +911,6 @@
   - name: test - create new internal action
     zabbix_action:
       conditions:
-        - type: application
-          operator: like
-          value: zabbix
         - type: host_template
           operator: '='
           value: ExampleTemplateForActionModule
@@ -949,9 +925,6 @@
   - name: test - create new internal action (again)
     zabbix_action:
       conditions:
-        - type: application
-          operator: like
-          value: zabbix
         - type: host_template
           operator: '='
           value: ExampleTemplateForActionModule
@@ -966,9 +939,6 @@
   - name: test - update internal action conditions
     zabbix_action:
       conditions:
-        - type: application
-          operator: like
-          value: zabbix
         - type: host_template
           operator: '='
           value: ExampleTemplateForActionModule
@@ -986,9 +956,6 @@
   - name: test - update internal action conditions (again)
     zabbix_action:
       conditions:
-        - type: application
-          operator: like
-          value: zabbix
         - type: host_template
           operator: '='
           value: ExampleTemplateForActionModule
@@ -1148,6 +1115,46 @@
 
   - assert:
       that: zbxaction_delete.changed is sameas True
+
+- name: test - Output error message when user sets application to conditions with >= Zabbix 5.4
+  community.zabbix.zabbix_action:
+    server_url: "{{ zabbix_api_server_url }}"
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    name: ExampleApplicationAction
+    event_source: trigger
+    esc_period: 60
+    conditions:
+      - type: application
+        operator: like
+        value: AnsibleTest
+    operations:
+      - type: send_message
+        subject: ExampleSubject
+        message: ExampleMessage
+        media_type: ExampleMediaTypeForActionModule
+        send_to_users:
+          - Admin
+  ignore_errors: true
+  register: zbxaction_application
+
+- assert:
+    that: zbxaction_delete.changed is sameas True
+  when: zabbix_version is version('5.4', '<')
+
+- assert:
+    that:
+      - zbxaction_application.failed is sameas True
+      - zbxaction_application.msg == "'application' is disabled for condition type since 5.4 version."
+  when: zabbix_version is version('5.4', '>=')
+
+- name: delete ExampleApplicationAction action
+  community.zabbix.zabbix_action:
+    server_url: "{{ zabbix_api_server_url }} "
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    name: ExampleApplicationAction
+    state: absent
 
 - name: test - cleanup example template for zabbix_action module
   zabbix_template:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #586 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_action
##### ADDITIONAL INFORMATION
To output error message with fail when user sets application to condition type with >= Zabbix 5.4.

Some integration tests about zabbix_action fail on Zabbix 5.4. 
Therefore, I have tested tasks which I added on Zabbix 5.4. 
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
