### PR TITLE
Fix tests for vault value parameter of globalmacro

### DIFF
--- a/tests/integration/targets/test_zabbix_globalmacro/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_globalmacro/tasks/main.yml
@@ -185,7 +185,7 @@
     login_user: "{{ zabbix_api_login_user }}"
     login_password: "{{ zabbix_api_login_pass }}"
     macro_name: zbxgmacro_test_vault
-    macro_value: /path/to/vault.txt
+    macro_value: path/to/vault:zabbix
     macro_type: vault
     macro_description: Global Macro description
   register: zbxgmacro_vault
@@ -199,7 +199,7 @@
     login_user: "{{ zabbix_api_login_user }}"
     login_password: "{{ zabbix_api_login_pass }}"
     macro_name: zbxgmacro_test_vault
-    macro_value: /path/to/vault.txt
+    macro_value: path/to/vault:zabbix
     macro_type: vault
     macro_description: Global Macro description
   register: zbxgmacro_vault


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Fix tests for vault value parameter of globalmacro
- I approgize for setting invalid parameter for zabbix_globalmacro module tests in a past [PR](https://github.com/ansible-collections/community.zabbix/pull/639).
- I have checked with Zabbix 5.4 and 6.0.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_globalmacro
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
