### PR TITLE
[BUGFIX] Using FQCN instead of old filter name

### DIFF
--- a/roles/zabbix_agent/tasks/Darwin.yml
+++ b/roles/zabbix_agent/tasks/Darwin.yml
@@ -9,13 +9,13 @@
 
 - name: "Get Total Private IP Addresses"
   set_fact:
-    total_private_ip_addresses: "{{ ansible_all_ipv4_addresses | ipaddr('private') | length }}"
+    total_private_ip_addresses: "{{ ansible_all_ipv4_addresses | ansible.netcommon.ipaddr('private') | length }}"
   when:
     - ansible_all_ipv4_addresses is defined
 
 - name: "Set first public ip address for zabbix_agent_ip"
   set_fact:
-    zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ipaddr('public') | first }}"
+    zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ansible.netcommon.ipaddr('public') | first }}"
     zabbix_agent_server: "{{ zabbix_agent_server_public_ip | default(zabbix_agent_server) }}"
     zabbix_agent_serveractive: "{{ zabbix_agent_serveractive_public_ip | default(zabbix_agent_serveractive) }}"
     zabbix_agent2_server: "{{ zabbix_agent_server_public_ip | default(zabbix_agent2_server) }}"
@@ -27,7 +27,7 @@
 
 - name: "Set first private ip address for zabbix_agent_ip"
   set_fact:
-    zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ipaddr('private') | first }}"
+    zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ansible.netcommon.ipaddr('private') | first }}"
   when:
     - zabbix_agent_ip is not defined
     - total_private_ip_addresses is defined

--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -9,14 +9,14 @@
 
 - name: "Get Total Private IP Addresses"
   set_fact:
-    total_private_ip_addresses: "{{ ansible_all_ipv4_addresses | ipaddr('private') | length }}"
+    total_private_ip_addresses: "{{ ansible_all_ipv4_addresses | ansible.netcommon.ipaddr('private') | length }}"
   when:
     - ansible_all_ipv4_addresses is defined
     - not (zabbix_agent_dont_detect_ip)
 
 - name: "Set first public ip address for zabbix_agent_ip"
   set_fact:
-    zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ipaddr('public') | first }}"
+    zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ansible.netcommon.ipaddr('public') | first }}"
     zabbix_agent_server: "{{ zabbix_agent_server_public_ip | default(zabbix_agent_server) }}"
     zabbix_agent_serveractive: "{{ zabbix_agent_serveractive_public_ip | default(zabbix_agent_serveractive) }}"
     zabbix_agent2_server: "{{ zabbix_agent_server_public_ip | default(zabbix_agent2_server) }}"
@@ -28,7 +28,7 @@
 
 - name: "Set first private ip address for zabbix_agent_ip"
   set_fact:
-    zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ipaddr('private') | first }}"
+    zabbix_agent_ip: "{{ ansible_all_ipv4_addresses | ansible.netcommon.ipaddr('private') | first }}"
   when:
     - zabbix_agent_ip is not defined
     - total_private_ip_addresses is defined

--- a/roles/zabbix_web/templates/nginx_vhost.conf.j2
+++ b/roles/zabbix_web/templates/nginx_vhost.conf.j2
@@ -31,7 +31,7 @@ server {
     ssl_session_cache {{ zabbix_nginx_tls_session_cache }};
     ssl_session_tickets {{ zabbix_nginx_tls_session_tickets }};
     ssl_dhparam {{ zabbix_nginx_tls_dhparam }};
- 
+
     ssl_protocols {{ zabbix_nginx_tls_protocols }};
     ssl_ciphers {{ zabbix_nginx_tls_ciphers }};
     ssl_prefer_server_ciphers off;
@@ -43,7 +43,7 @@ server {
 {% if zabbix_web_allowlist_ips is defined and zabbix_web_allowlist_ips %}
     # Allow list IPs via zabbix_web_allowlist_ips
     satisfy any;
-{% for ip in zabbix_web_allowlist_ips | ipaddr %}
+{% for ip in zabbix_web_allowlist_ips | ansible.netcommon.ipaddr %}
     allow {{ ip }};
 {% endfor %}
     deny all;


### PR DESCRIPTION
##### SUMMARY
Refers to: ansible/ansible#68399
Fixes: ansible-collections/community.zabbix#643

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Using FQCN for ansible.netcommon.ipaddr