### PR TITLE
zabbix_web: allow to configure web frontent for ha setup in zabbix 6 …

### DIFF
--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -122,6 +122,7 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_htpasswd_file`: Default: `/etc/zabbix/web/htpasswd`. Allows the change the default path to the htpasswd file.
 * `zabbix_web_htpasswd_users`: (Optional) Dictionary for creating users via `htpasswd_user` and passphrases via `htpasswd_pass` in htpasswd file.
 * `zabbix_web_allowlist_ips`: (Optional) Allow web access at webserver level to a list of defined IPs or CIDR.
+* `zabbix_web_connect_ha_backend`: (Optional) Default: `false`. When set to `true` values for Zabbix server will not be written and frontend gets values from database to connect to active cluster node. Set `true` when operating Zabbix servers in a cluste (only >=6.0).
 * `zabbix_saml_idp_crt`: (Optional) The path to the certificate of the Identity Provider used for SAML authentication
 * `zabbix_saml_sp_crt`: (Optional) The path to the public certificate of Zabbix as Service Provider
 * `zabbix_saml_sp_key`: (Optional) The path to the private certificate of Zabbix as Service Provider

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -11,6 +11,7 @@ zabbix_web_rhel_release: true
 zabbix_selinux: false
 zabbix_web_doubleprecision: false
 zabbix_web_conf_mode: "0640"
+zabbix_web_connect_ha_backend: false 
 
 zabbix_url: zabbix.example.com                 # Will be deprecated in 2.0.0
 zabbix_api_server_url: "{{ zabbix_url }}"

--- a/roles/zabbix_web/templates/zabbix.conf.php.j2
+++ b/roles/zabbix_web/templates/zabbix.conf.php.j2
@@ -17,9 +17,10 @@ $DB['VERIFY_HOST'] = {{ 'true' if zabbix_server_dbverifyhost else 'false'  }};
 
 // Schema name. Used for IBM DB2 and PostgreSQL.
 $DB['SCHEMA'] = '{{ zabbix_server_dbschema }}';
-
+{% if not zabbix_web_connect_ha_backend %}
 $ZBX_SERVER      = '{{ zabbix_server_hostname }}';
 $ZBX_SERVER_PORT = '{{ zabbix_server_listenport }}';
+{% endif %}
 $ZBX_SERVER_NAME = '{{ zabbix_server_name }}';
 
 $IMAGE_FORMAT_DEFAULT = IMAGE_FORMAT_PNG;


### PR DESCRIPTION
…environments

##### SUMMARY
Currently Zabbix-Web role doesn't allow configuration for HA setup with Zabbix 6. This patch introduces a new boolean which allows to omit Zabbix server configuration in Zabbix.php is set true.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
role Zabbix-web template Zabbix.conf.php.j2

##### ADDITIONAL INFORMATION
The following values have to be omitted if web frontend is connecting to a HA Backend
```
$ZBX_SERVER      = '{{ zabbix_server_hostname }}';
$ZBX_SERVER_PORT = '{{ zabbix_server_listenport }}';
```

Introducing variable: `zabbix_web_connect_ha_backend` to allow to omit writing these values in web config.