### PR TITLE
Check the 'zabbix_server_install_database_client' variable in RedHat tasks.

### DIFF
--- a/changelogs/fragments/654-check-zabbix_server_install_database_client-rhel.yml
+++ b/changelogs/fragments/654-check-zabbix_server_install_database_client-rhel.yml
@@ -1,0 +1,4 @@
+---
+
+minor_changes:
+  - zabbix_server - Check the 'zabbix_server_install_database_client' variable in RedHat tasks.

--- a/roles/zabbix_server/tasks/RedHat.yml
+++ b/roles/zabbix_server/tasks/RedHat.yml
@@ -223,6 +223,7 @@
   become: true
   when:
     - zabbix_server_database == 'mysql'
+    - zabbix_server_install_database_client
     - ansible_distribution_major_version == "8"
   tags:
     - zabbix-server
@@ -241,6 +242,7 @@
   become: true
   when:
     - zabbix_server_database == 'mysql'
+    - zabbix_server_install_database_client
     - ansible_distribution_major_version == "7"
   tags:
     - zabbix-server
@@ -259,6 +261,7 @@
   become: true
   when:
     - zabbix_server_database == 'mysql'
+    - zabbix_server_install_database_client
     - ansible_distribution_major_version == "6" or ansible_distribution_major_version == "5"
   tags:
     - zabbix-server
@@ -275,6 +278,7 @@
   become: true
   when:
     - zabbix_server_database == 'pgsql'
+    - zabbix_server_install_database_client
   tags:
     - zabbix-server
 


### PR DESCRIPTION
##### SUMMARY
`zabbix_server_install_database_client` is checked by `when` statements in Debian tasks but ignored in RedHat tasks.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_server role
