### PR TITLE
Fixed use of bare vars on agent2 tasks for linux

### DIFF
--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -134,8 +134,7 @@
   become: true
   when:
     - zabbix_agent_tlspskfile is defined
-    - zabbix_agent_tlspskfile
-    - not zabbix_agent2
+    - not (zabbix_agent2 | bool)
 
 - name: "Create directory for PSK file if not exist (zabbix-agent2)"
   file:
@@ -145,8 +144,7 @@
   become: true
   when:
     - zabbix_agent2_tlspskfile is defined
-    - zabbix_agent2_tlspskfile
-    - zabbix_agent2
+    - zabbix_agent2 | bool
 
 - name: "Place TLS PSK File"
   copy:
@@ -158,9 +156,8 @@
   become: true
   when:
     - zabbix_agent_tlspskfile is defined
-    - zabbix_agent_tlspskfile
     - zabbix_agent_tlspsk_secret is defined
-    - not zabbix_agent2
+    - not (zabbix_agent2 | bool)
   notify:
     - restart zabbix-agent
 
@@ -174,9 +171,8 @@
   become: true
   when:
     - zabbix_agent2_tlspskfile is defined
-    - zabbix_agent2_tlspskfile
     - zabbix_agent2_tlspsk_secret is defined
-    - zabbix_agent2
+    - zabbix_agent2 | bool
   notify:
     - restart zabbix-agent
 
@@ -205,7 +201,7 @@
 - name: "Remove zabbix-agent installation when zabbix-agent2 is used."
   include: remove.yml
   when:
-    - zabbix_agent2
+    - zabbix_agent2 | bool
     - zabbix_agent_package_remove
 
 - name: "Make sure the zabbix-agent service is running"


### PR DESCRIPTION
- Added bool filter on zabbix_agent2 and zabbix_agent_package_remove vars
- Removed implicit conditionals on psk files vars when "is defined" should be enough

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Those tasks began to fail in my setup, and I found this note on ansible docs: "In 2.10 the default setting for conditional_bare_variables will change to false. In 2.12 the old behavior will be deprecated." (https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.8.html). The hints I found on my logs are the same on #662 and #655.

These commits resolved the issue for me.

Fixes #662 
Fixes #655

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_agent

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```yaml
when:
  - zabbix_agent2_tlspskfile is defined
  - zabbix_agent2_tlspskfile
```

I could not get exactly what was the intention of the second check. Since it is after the first "is defined" check, I assumed it was to check implicitly if it is an valid string (maybe not empty). I removed it (this second line) because I think the first check makes it safe enough and I can think a better way to ensure it is a valid filename.