### PR TITLE
Update zabbix_maintenance.py

### DIFF
--- a/plugins/modules/zabbix_maintenance.py
+++ b/plugins/modules/zabbix_maintenance.py
@@ -383,7 +383,7 @@ def main():
                 msg="At least one host_name or host_group must be defined for each created maintenance.")
 
         now = datetime.datetime.now().replace(second=0)
-        start_time = time.mktime(now.timetuple())
+        start_time = int(time.mktime(now.timetuple()))
         period = 60 * int(minutes)  # N * 60 seconds
 
         if host_groups:


### PR DESCRIPTION
Change to int casting as discussed here https://github.com/ansible-collections/community.zabbix/issues/637

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Failed to create maintenance on Zabix 6 and Python3.9
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #637 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Zabbix maintenance

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Creating Zabbix maintenance this error happens
```
fatal: [server]: FAILED! => {"changed": false, "msg": "Failed to create maintenance: (u'Error -32602: Invalid params., Invalid parameter \"/1/active_since\": an unsigned integer is expected. while sending {\"params\": {\"maintenance_type\": 0, \"active_since\": \"1645364880.0\", \"active_till\": \"1645365660.0\", \"groupids\": [\"32\"], \"timeperiods\": [{\"timeperiod_type\": \"0\", \"start_date\": \"1645365060.0\", \"period\": \"600\"}], \"description\": \"Created by Ansible\", \"hostids\": [], \"name\": \"Test\"}, \"jsonrpc\": \"2.0\", \"method\": \"maintenance.create\", \"auth\": \"dd0f5d574072ce6bc66d511b\", \"id\": 4}', -32602)"}
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
