### PR TITLE
zabbix_action.py: fixes for recovery_operations (Zabbix 6.0)

### DIFF
--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -1320,10 +1320,17 @@ class RecoveryOperations(Operations):
             }
 
             # Send Message type
-            if constructed_operation['operationtype'] in ('0', '11'):
+            if constructed_operation['operationtype'] == '0':
                 constructed_operation['opmessage'] = self._construct_opmessage(op)
                 constructed_operation['opmessage_usr'] = self._construct_opmessage_usr(op)
                 constructed_operation['opmessage_grp'] = self._construct_opmessage_grp(op)
+                if LooseVersion(self._zbx_api_version) >= LooseVersion('6.0'):
+                    constructed_operation['opmessage'].pop('mediatypeid')
+
+            if constructed_operation['operationtype'] == '11':
+                constructed_operation['opmessage'] = self._construct_opmessage(op)
+                if LooseVersion(self._zbx_api_version) >= LooseVersion('6.0'):
+                    constructed_operation['opmessage'].pop('mediatypeid')
 
             # Send Command type
             if constructed_operation['operationtype'] == '1':

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -143,21 +143,20 @@ options:
                     - Condition operator.
                     - When I(type) is set to C(time_period), the choices are C(in), C(not in).
                     - C(matches), C(does not match), C(Yes) and C(No) condition operators work only with >= Zabbix 4.0
+                    - When I(type) is set to C(maintenance_status), the choices are C(Yes) and C(No) for Zabbix >= 6.0
                 choices:
-                    - 'When I(type!=maintenance_status), the choices are in (for Zabbix >= 6.0):'
-                      - '='
-                      - '<>'
-                      - 'like'
-                      - 'not like'
-                      - 'in'
-                      - '>='
-                      - '<='
-                      - 'not in'
-                      - 'matches'
-                      - 'does not match'
-                    - 'When I(type=maintenance_status), the choices are in (for Zabbix >= 6.0):'
-                      - 'Yes'
-                      - 'No'
+                    - '='
+                    - '<>'
+                    - 'like'
+                    - 'not like'
+                    - 'in'
+                    - '>='
+                    - '<='
+                    - 'not in'
+                    - 'matches'
+                    - 'does not match'
+                    - 'Yes'
+                    - 'No'
             formulaid:
                 description:
                     - Arbitrary unique ID that is used to reference the condition from a custom expression.

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -530,9 +530,6 @@ class Zapi(ZapiWrapper):
             if LooseVersion(self._zbx_api_version) >= LooseVersion('6.0'):
                 _params['selectUpdateOperations'] = _params.pop('selectAcknowledgeOperations', 'extend')
             _action = self._zapi.action.get(_params)
-            if len(_action) > 0:
-                _action[0]['recovery_operations'] = _action[0].pop('recoveryOperations', [])
-                _action[0]['acknowledge_operations'] = _action[0].pop('acknowledgeOperations', [])
             return _action
         except Exception as e:
             self._module.fail_json(msg="Failed to check if action '%s' exists: %s" % (name, e))

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -918,6 +918,9 @@ class Action(ZabbixBase):
                 if isinstance(_params.get('update_operations', None), type(None)) or len(_params.get('update_operations', [])) == 0:
                     _params.pop('update_operations')
 
+            if _params['eventsource'] not in ['trigger', 'internal']:
+                _params.pop('esc_period')
+
         return _params
 
     def check_difference(self, **kwargs):

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -529,6 +529,9 @@ class Zapi(ZapiWrapper):
             if LooseVersion(self._zbx_api_version) >= LooseVersion('6.0'):
                 _params['selectUpdateOperations'] = _params.pop('selectAcknowledgeOperations', 'extend')
             _action = self._zapi.action.get(_params)
+            if len(_action) > 0 and LooseVersion(self._zbx_api_version) < LooseVersion('6.0'):
+                _action[0]['recovery_operations'] = _action[0].pop('recoveryOperations', [])
+                _action[0]['acknowledge_operations'] = _action[0].pop('acknowledgeOperations', [])
             return _action
         except Exception as e:
             self._module.fail_json(msg="Failed to check if action '%s' exists: %s" % (name, e))

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -900,6 +900,7 @@ class Action(ZabbixBase):
             _params.pop('ack_shortdata', None)
 
         if LooseVersion(self._zbx_api_version) >= LooseVersion('6.0'):
+            _params['update_operations'] = kwargs.get('update_operations')
             if 'update_operations' in _params and not isinstance(_params.get('update_operations', None), type(None)):
                 _params.pop('acknowledge_operations', None)
             elif isinstance(_params.get('acknowledge_operations', None), list):
@@ -1392,10 +1393,17 @@ class AcknowledgeOperations(Operations):
             }
 
             # Send Message type
-            if constructed_operation['operationtype'] in ('0', '11'):
+            if constructed_operation['operationtype'] == '0':
                 constructed_operation['opmessage'] = self._construct_opmessage(op)
                 constructed_operation['opmessage_usr'] = self._construct_opmessage_usr(op)
                 constructed_operation['opmessage_grp'] = self._construct_opmessage_grp(op)
+                if LooseVersion(self._zbx_api_version) >= LooseVersion('6.0'):
+                    constructed_operation['opmessage'].pop('mediatypeid')
+
+            if constructed_operation['operationtype'] == '12':
+                constructed_operation['opmessage'] = self._construct_opmessage(op)
+                if LooseVersion(self._zbx_api_version) >= LooseVersion('6.0'):
+                    constructed_operation['opmessage'].pop('mediatypeid')
 
             # Send Command type
             if constructed_operation['operationtype'] == '1':

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -1106,13 +1106,13 @@ class Operations(Zapi):
                 }
             else:
                 # In 6.0 opcommand is an opbject with just one key 'scriptid'
-                command = {
+                opcommand = {
                     'scriptid': self._zapi_wrapper.get_script_by_script_name(
                         operation.get('script_name')
                     ).get('scriptid')
                 }
 
-            return command
+            return opcommand
 
         except Exception as e:
             self._module.fail_json(msg="Failed to construct operation command. The error was: %s" % e)

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -2133,7 +2133,7 @@ def main():
                 recovery_default_subject=recovery_default_subject,
                 acknowledge_default_message=acknowledge_default_message,
                 acknowledge_default_subject=acknowledge_default_subject,
-                operations=ops.construct_the_data(operations),
+                operations=ops.construct_the_data(operations, event_source),
                 recovery_operations=recovery_ops.construct_the_data(recovery_operations),
                 conditions=fltr.construct_the_data(eval_type, formula, conditions)
             )

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -681,22 +681,22 @@ class Zapi(ZapiWrapper):
         try:
             discovery_rule_name, dcheck_type = discovery_check_name.split(': ')
             dcheck_type_to_number = {
-              'SSH': '0',
-              'LDAP': '1',
-              'SMTP': '2',
-              'FTP': '3',
-              'HTTP': '4',
-              'POP': '5',
-              'NNTP': '6',
-              'IMAP': '7',
-              'TCP': '8',
-              'Zabbix agent': '9',
-              'SNMPv1 agent': '10',
-              'SNMPv2 agent': '11',
-              'ICMP ping': '12',
-              'SNMPv3 agent': '13',
-              'HTTPS': '14',
-              'Telnet': '15'
+                'SSH': '0',
+                'LDAP': '1',
+                'SMTP': '2',
+                'FTP': '3',
+                'HTTP': '4',
+                'POP': '5',
+                'NNTP': '6',
+                'IMAP': '7',
+                'TCP': '8',
+                'Zabbix agent': '9',
+                'SNMPv1 agent': '10',
+                'SNMPv2 agent': '11',
+                'ICMP ping': '12',
+                'SNMPv3 agent': '13',
+                'HTTPS': '14',
+                'Telnet': '15'
             }
             if dcheck_type not in dcheck_type_to_number:
                 self._module.fail_json(msg="Discovery check type: %s does not exist" % dcheck_type)
@@ -1237,7 +1237,6 @@ class Operations(Zapi):
 
                 if LooseVersion(self._zbx_api_version) < LooseVersion('6.0'):
                     constructed_operation['opconditions'] = self._construct_opconditions(op)
-
 
             # Send Command type
             if constructed_operation['operationtype'] == '1':

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -144,18 +144,20 @@ options:
                     - When I(type) is set to C(time_period), the choices are C(in), C(not in).
                     - C(matches), C(does not match), C(Yes) and C(No) condition operators work only with >= Zabbix 4.0
                 choices:
-                    - '='
-                    - '<>'
-                    - 'like'
-                    - 'not like'
-                    - 'in'
-                    - '>='
-                    - '<='
-                    - 'not in'
-                    - 'matches'
-                    - 'does not match'
-                    - 'Yes'
-                    - 'No'
+                    - 'When I(type!=maintenance_status), the choices are in (for Zabbix >= 6.0):'
+                      - '='
+                      - '<>'
+                      - 'like'
+                      - 'not like'
+                      - 'in'
+                      - '>='
+                      - '<='
+                      - 'not in'
+                      - 'matches'
+                      - 'does not match'
+                    - 'When I(type=maintenance_status), the choices are in (for Zabbix >= 6.0):'
+                      - 'Yes'
+                      - 'No'
             formulaid:
                 description:
                     - Arbitrary unique ID that is used to reference the condition from a custom expression.
@@ -1594,6 +1596,13 @@ class Filter(Zapi):
                 )
             if conditiontype == '13':
                 return self._zapi_wrapper.get_template_by_template_name(value)['templateid']
+            if LooseVersion(self._zapi_wrapper._zbx_api_version) >= LooseVersion('6.0'):
+                # maintenance_status
+                if conditiontype == '16':
+                    return to_numeric_value([
+                        "Yes",
+                        "No"], value
+                    )
             if conditiontype == '18':
                 return self._zapi_wrapper.get_discovery_rule_by_discovery_rule_name(value)['druleid']
             if conditiontype == '19':
@@ -1802,7 +1811,7 @@ def main():
                 formulaid=dict(type='str', required=False),
                 operator=dict(type='str', required=True),
                 type=dict(type='str', required=True),
-                value=dict(type='str', required=True),
+                value=dict(type='str', required=False),
                 value2=dict(type='str', required=False)
             ),
             required_if=[

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -679,14 +679,40 @@ class Zapi(ZapiWrapper):
 
         """
         try:
-            discovery_check_list = self._zapi.dcheck.get({
-                'output': 'extend',
-                'filter': {'key_': [discovery_check_name]}
+            discovery_rule_name, dcheck_type = discovery_check_name.split(': ')
+            dcheck_type_to_number = {
+              'SSH': '0',
+              'LDAP': '1',
+              'SMTP': '2',
+              'FTP': '3',
+              'HTTP': '4',
+              'POP': '5',
+              'NNTP': '6',
+              'IMAP': '7',
+              'TCP': '8',
+              'Zabbix agent': '9',
+              'SNMPv1 agent': '10',
+              'SNMPv2 agent': '11',
+              'ICMP ping': '12',
+              'SNMPv3 agent': '13',
+              'HTTPS': '14',
+              'Telnet': '15'
+            }
+            if dcheck_type not in dcheck_type_to_number:
+                self._module.fail_json(msg="Discovery check type: %s does not exist" % dcheck_type)
+
+            discovery_rule_list = self._zapi.drule.get({
+                'output': ['dchecks'],
+                'filter': {'name': [discovery_rule_name]},
+                'selectDChecks': 'extend'
             })
-            if len(discovery_check_list) < 1:
+            if len(discovery_rule_list) < 1:
                 self._module.fail_json(msg="Discovery check not found: %s" % discovery_check_name)
-            else:
-                return discovery_check_list[0]
+
+            for dcheck in discovery_rule_list[0]['dchecks']:
+                if dcheck_type_to_number[dcheck_type] == dcheck['type']:
+                    return dcheck
+            self._module.fail_json(msg="Discovery check not found: %s" % discovery_check_name)
         except Exception as e:
             self._module.fail_json(msg="Failed to get discovery check '%s': %s" % (discovery_check_name, e))
 

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -1078,31 +1078,42 @@ class Operations(Zapi):
             list: constructed operation command
         """
         try:
-            return {
-                'type': to_numeric_value([
-                    'custom_script',
-                    'ipmi',
-                    'ssh',
-                    'telnet',
-                    'global_script'], operation.get('command_type', 'custom_script')),
-                'command': operation.get('command'),
-                'execute_on': to_numeric_value([
-                    'agent',
-                    'server',
-                    'proxy'], operation.get('execute_on', 'server')),
-                'scriptid': self._zapi_wrapper.get_script_by_script_name(
-                    operation.get('script_name')
-                ).get('scriptid'),
-                'authtype': to_numeric_value([
-                    'password',
-                    'public_key'
-                ], operation.get('ssh_auth_type')),
-                'privatekey': operation.get('ssh_privatekey_file'),
-                'publickey': operation.get('ssh_publickey_file'),
-                'username': operation.get('username'),
-                'password': operation.get('password'),
-                'port': operation.get('port')
-            }
+            if LooseVersion(self._zbx_api_version) < LooseVersion('6.0'):
+                opcommand = {
+                    'type': to_numeric_value([
+                        'custom_script',
+                        'ipmi',
+                        'ssh',
+                        'telnet',
+                        'global_script'], operation.get('command_type', 'custom_script')),
+                    'command': operation.get('command'),
+                    'execute_on': to_numeric_value([
+                        'agent',
+                        'server',
+                        'proxy'], operation.get('execute_on', 'server')),
+                    'scriptid': self._zapi_wrapper.get_script_by_script_name(
+                        operation.get('script_name')
+                    ).get('scriptid'),
+                    'authtype': to_numeric_value([
+                        'password',
+                        'public_key'
+                    ], operation.get('ssh_auth_type')),
+                    'privatekey': operation.get('ssh_privatekey_file'),
+                    'publickey': operation.get('ssh_publickey_file'),
+                    'username': operation.get('username'),
+                    'password': operation.get('password'),
+                    'port': operation.get('port')
+                }
+            else:
+                # In 6.0 opcommand is an opbject with just one key 'scriptid'
+                command = {
+                    'scriptid': self._zapi_wrapper.get_script_by_script_name(
+                        operation.get('script_name')
+                    ).get('scriptid')
+                }
+
+            return command
+
         except Exception as e:
             self._module.fail_json(msg="Failed to construct operation command. The error was: %s" % e)
 

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -1200,7 +1200,7 @@ class Operations(Zapi):
             }]
         return []
 
-    def construct_the_data(self, operations):
+    def construct_the_data(self, operations, event_source):
         """Construct the operation data using helper methods.
 
         Args:
@@ -1227,12 +1227,17 @@ class Operations(Zapi):
                 if LooseVersion(self._zbx_api_version) < LooseVersion('6.0'):
                     constructed_operation['opconditions'] = self._construct_opconditions(op)
 
+
             # Send Command type
             if constructed_operation['operationtype'] == '1':
                 constructed_operation['opcommand'] = self._construct_opcommand(op)
                 constructed_operation['opcommand_hst'] = self._construct_opcommand_hst(op)
                 constructed_operation['opcommand_grp'] = self._construct_opcommand_grp(op)
-                constructed_operation['opconditions'] = self._construct_opconditions(op)
+                if LooseVersion(self._zbx_api_version) < LooseVersion('6.0'):
+                    constructed_operation['opconditions'] = self._construct_opconditions(op)
+                elif event_source == 'trigger':
+                    # opconditions valid only for 'trigger' action
+                    constructed_operation['opconditions'] = self._construct_opconditions(op)
 
             # Add to/Remove from host group
             if constructed_operation['operationtype'] in ('4', '5'):
@@ -2081,7 +2086,7 @@ def main():
                 recovery_default_subject=recovery_default_subject,
                 acknowledge_default_message=acknowledge_default_message,
                 acknowledge_default_subject=acknowledge_default_subject,
-                operations=ops.construct_the_data(operations),
+                operations=ops.construct_the_data(operations, event_source),
                 recovery_operations=recovery_ops.construct_the_data(recovery_operations),
                 conditions=fltr.construct_the_data(eval_type, formula, conditions)
             )


### PR DESCRIPTION
##### SUMMARY
#661 
In Zabbix 6.0 for zabbix_action:
- mediatypeid must not exist in recovery_operations and update_operations
- in recovery_operations if operationtype='notify_all_involved' then opmessage_usr and opmessage_grp must not be used
- in update_operations if operationtype='notify_all_involved' then opmessage_usr and opmessage_grp must not be used

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_action.py