### PR TITLE
Support zabbix_agent >= 6.0 for Ubuntu 22.04

### DIFF
--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -11,6 +11,15 @@
   tags:
     - always
 
+- name: "Reset zabbix_agent_version for Ubuntu 22.03 to 6.0"
+  set_fact:
+    zabbix_version: 6.0
+    zabbix_agent_version: 6.0
+  when:
+    - ansible_distribution_release == "jammy"
+    - ( zabbix_agent_version is version ('6.0','lt') or
+        zabbix_version is version ('6.0','lt') )
+
 - name: "Fix facts for linuxmint - distribution release"
   set_fact:
     zabbix_agent_distribution_release: xenial

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -11,7 +11,8 @@
   tags:
     - always
 
-- name: "Reset zabbix_agent_version for Ubuntu 22.03 to 6.0"
+- name: "Reset zabbix_agent_version for Ubuntu 22.04 to 6.0"
+  # README https://support.zabbix.com/browse/ZBXNEXT-7624
   set_fact:
     zabbix_version: 6.0
     zabbix_agent_version: 6.0

--- a/roles/zabbix_agent/vars/zabbix.yml
+++ b/roles/zabbix_agent/vars/zabbix.yml
@@ -7,6 +7,8 @@ sign_keys:
       sign_key: E709712C
     stretch:
       sign_key: E709712C
+    jammy:
+      sign_key: E709712C
     focal:
       sign_key: E709712C
     bionic:
@@ -23,6 +25,8 @@ sign_keys:
     jessie:
       sign_key: E709712C
     stretch:
+      sign_key: E709712C
+    jammy:
       sign_key: E709712C
     focal:
       sign_key: E709712C
@@ -42,6 +46,8 @@ sign_keys:
       sign_key: E709712C
     stretch:
       sign_key: E709712C
+    jammy:
+      sign_key: E709712C
     focal:
       sign_key: E709712C
     bionic:
@@ -60,6 +66,8 @@ sign_keys:
     jessie:
       sign_key: E709712C
     stretch:
+      sign_key: E709712C
+    jammy:
       sign_key: E709712C
     focal:
       sign_key: E709712C


### PR DESCRIPTION
##### SUMMARY
Fixes #674 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_agent

##### ADDITIONAL INFORMATION
Only supports agent as upstream's web frontend doesn't yet run on PHP8.1
