### PR TITLE
Let's Encrypt fix: don't hardcode webroot mode

### DIFF
--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -61,6 +61,7 @@ zabbix_nginx_tls_ciphers: ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA
 
 zabbix_letsencrypt: false
 zabbix_letsencrypt_webroot_path: /var/www/letsencrypt
+zabbix_letsencrypt_webroot_mode: 0755
 
 zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https

--- a/roles/zabbix_web/tasks/nginx.yml
+++ b/roles/zabbix_web/tasks/nginx.yml
@@ -76,7 +76,7 @@
 - name: "Let's Encrypt | Create directory for certbot webroot if not exist"
   file:
     path: "{{ zabbix_letsencrypt_webroot_path }}"
-    mode: 0755
+    mode: "{{ zabbix_letsencrypt_webroot_mode }}"
     state: directory
   when:
     - zabbix_letsencrypt


### PR DESCRIPTION
##### SUMMARY
Fix potential breakage from #677 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_web

##### ADDITIONAL INFORMATION
When we originally contributed the NGINX part we assumed Let's Encrypt externally managed.  
Now we're moving towards managing parts of Let's Encrypt and hence should not hardcode.
