### PR TITLE
Make sure PostgreSQL password variable is used consistently across all plays.

### DIFF
--- a/changelogs/fragments/postgresql_fixpasswordvariable.yaml
+++ b/changelogs/fragments/postgresql_fixpasswordvariable.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - zabbix_server - PostgreSQL - Make sure PostgreSQL password variable is used consistently across all plays.

--- a/roles/zabbix_server/tasks/postgresql.yml
+++ b/roles/zabbix_server/tasks/postgresql.yml
@@ -13,6 +13,10 @@
   when:
     - not zabbix_server_dbhost_run_install
 
+- name: "Set a password fact to insure consistent usage."
+  set_fact:
+    zabbix_real_dbpassword: "md5{{ (zabbix_server_dbpassword + zabbix_server_dbuser)|hash('md5') }}"
+
 - name: "PostgreSQL | Delegated"
   block:
     - name: "PostgreSQL | Delegated | Create database"
@@ -24,7 +28,7 @@
       community.postgresql.postgresql_user:
         db: "{{ zabbix_server_dbname }}"
         name: "{{ zabbix_server_dbuser }}"
-        password: "md5{{ (zabbix_server_dbpassword + zabbix_server_dbuser)|hash('md5') }}"
+        password: "{{ zabbix_real_dbpassword }}"
         port: "{{ zabbix_server_dbport }}"
         priv: ALL
         state: present
@@ -62,7 +66,7 @@
         login_password: "{{ zabbix_server_pgsql_login_password | default(omit) }}"
         db: "{{ zabbix_server_dbname }}"
         name: "{{ zabbix_server_dbuser }}"
-        password: "md5{{ (zabbix_server_dbpassword + zabbix_server_dbuser)|hash('md5') }}"
+        password: "{{ zabbix_real_dbpassword }}"
         port: "{{ zabbix_server_dbport }}"
         priv: ALL
         state: present
@@ -104,7 +108,7 @@
     executable: /bin/bash
     warn: false
   environment:
-    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
+    PGPASSWORD: "{{ zabbix_real_dbpassword }}"
   when:
     - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload
@@ -128,7 +132,7 @@
     executable: /bin/bash
     warn: false
   environment:
-    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
+    PGPASSWORD: "{{ zabbix_real_dbpassword }}"
   when:
     - zabbix_version is version('3.0', '>=')
     - zabbix_database_timescaledb
@@ -176,7 +180,7 @@
     executable: /bin/bash
     warn: false
   environment:
-    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
+    PGPASSWORD: "{{ zabbix_real_dbpassword }}"
   when:
     - (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
@@ -195,7 +199,7 @@
     creates: /etc/zabbix/images.done
     warn: false
   environment:
-    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
+    PGPASSWORD: "{{ zabbix_real_dbpassword }}"
   when: (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server
@@ -213,7 +217,7 @@
     creates: /etc/zabbix/data.done
     warn: false
   environment:
-    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
+    PGPASSWORD: "{{ zabbix_real_dbpassword }}"
   when: (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server

--- a/roles/zabbix_server/tasks/postgresql.yml
+++ b/roles/zabbix_server/tasks/postgresql.yml
@@ -15,7 +15,7 @@
 
 - name: "Set a password fact to insure consistent usage."
   set_fact:
-    zabbix_real_dbpassword: "md5{{ (zabbix_server_dbpassword + zabbix_server_dbuser)|hash('md5') }}"
+    zabbix_real_dbpassword: "{{ (zabbix_server_dbpassword + zabbix_server_dbuser) | hash('md5') }}"
 
 - name: "PostgreSQL | Delegated"
   block:

--- a/roles/zabbix_server/tasks/postgresql.yml
+++ b/roles/zabbix_server/tasks/postgresql.yml
@@ -13,10 +13,6 @@
   when:
     - not zabbix_server_dbhost_run_install
 
-- name: "Set a password fact to insure consistent usage."
-  set_fact:
-    zabbix_real_dbpassword: "{{ (zabbix_server_dbpassword + zabbix_server_dbuser) | hash('md5') }}"
-
 - name: "PostgreSQL | Delegated"
   block:
     - name: "PostgreSQL | Delegated | Create database"
@@ -28,7 +24,7 @@
       community.postgresql.postgresql_user:
         db: "{{ zabbix_server_dbname }}"
         name: "{{ zabbix_server_dbuser }}"
-        password: "{{ zabbix_real_dbpassword }}"
+        password: "md5{{ zabbix_server_dbpassword | hash('md5') }}"
         port: "{{ zabbix_server_dbport }}"
         priv: ALL
         state: present
@@ -66,7 +62,7 @@
         login_password: "{{ zabbix_server_pgsql_login_password | default(omit) }}"
         db: "{{ zabbix_server_dbname }}"
         name: "{{ zabbix_server_dbuser }}"
-        password: "{{ zabbix_real_dbpassword }}"
+        password: "md5{{ zabbix_server_dbpassword | hash('md5') }}"
         port: "{{ zabbix_server_dbport }}"
         priv: ALL
         state: present
@@ -108,7 +104,7 @@
     executable: /bin/bash
     warn: false
   environment:
-    PGPASSWORD: "{{ zabbix_real_dbpassword }}"
+    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
   when:
     - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload
@@ -132,7 +128,7 @@
     executable: /bin/bash
     warn: false
   environment:
-    PGPASSWORD: "{{ zabbix_real_dbpassword }}"
+    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
   when:
     - zabbix_version is version('3.0', '>=')
     - zabbix_database_timescaledb
@@ -180,7 +176,7 @@
     executable: /bin/bash
     warn: false
   environment:
-    PGPASSWORD: "{{ zabbix_real_dbpassword }}"
+    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
   when:
     - (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
@@ -199,7 +195,7 @@
     creates: /etc/zabbix/images.done
     warn: false
   environment:
-    PGPASSWORD: "{{ zabbix_real_dbpassword }}"
+    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
   when: (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server
@@ -217,7 +213,7 @@
     creates: /etc/zabbix/data.done
     warn: false
   environment:
-    PGPASSWORD: "{{ zabbix_real_dbpassword }}"
+    PGPASSWORD: "{{ zabbix_server_dbpassword }}"
   when: (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server


### PR DESCRIPTION
##### SUMMARY
This PR fixes the usage zabbix_server_dbpassword variable for consistency.  Currently, the playbook fails on a fresh database init because the variable isn't used consistently across all plays.

Instead of fixing all the usages of zabbix_server_dbpassword, I instead created a new fact at the top of the playbook, which is based on the zabbix_server_dbpassword variable.  This fact is then used consistently across all the remaining plays.  This should allow for modifying usage of zabbix_server_dbpassword in the future, while maintaining consistent usage.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_server - PostgreSQL

##### ADDITIONAL INFORMATION
