### PR TITLE
test_zabbix_action: increase timeout on test template deletion to 20 s.

### DIFF
--- a/tests/integration/targets/test_zabbix_action/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_action/tasks/main.yml
@@ -1339,6 +1339,7 @@
     login_user: "{{ zabbix_api_login_user }}"
     login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleTemplateForActionModule
+    timeout: 20
     state: absent
   register: zbxaction_prep_template
 


### PR DESCRIPTION
##### SUMMARY
Fixes #700 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_action tests