### PR TITLE
Bug Fix 685 / ipaddr Module Missing

### DIFF
--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -9,7 +9,7 @@
 
 - name: "Get Total Private IP Addresses"
   set_fact:
-    total_private_ip_addresses: "{{ ansible_all_ipv4_addresses | ansible.netcommon.ipaddr('private') | length }}"
+    total_private_ip_addresses: "{{ ansible_all_ipv4_addresses | ansible.utils.ipaddr('private') | length }}"
   when:
     - ansible_all_ipv4_addresses is defined
     - not (zabbix_agent_dont_detect_ip)


### PR DESCRIPTION
##### SUMMARY

Fixes #685 .  Ipaddr was moved from nettools to utils.
##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
roles/zabbix_agent/tasks/Linux.yml

