### PR TITLE
Limit template.get output to templateid

### DIFF
--- a/plugins/modules/zabbix_template_info.py
+++ b/plugins/modules/zabbix_template_info.py
@@ -162,7 +162,7 @@ class TemplateInfo(ZabbixBase):
     def get_template_id(self, template_name):
         template_id = []
         try:
-            template_list = self._zapi.template.get({'output': 'extend',
+            template_list = self._zapi.template.get({'output': ['templateid'],
                                                      'filter': {'host': template_name}})
         except Exception as e:
             self._module.fail_json(msg='Failed to get template: %s' % e)


### PR DESCRIPTION
##### SUMMARY
Saves a few bytes in the template.get response, mostly when template description is long. Only templateid is used in this function, so there is no need to retrieve all properties.

##### ISSUE TYPE
- Optimization Pull Request

##### COMPONENT NAME
zabbix_template_info.py