### PR TITLE
Fix script request when description is not defined

### DIFF
--- a/plugins/modules/zabbix_script.py
+++ b/plugins/modules/zabbix_script.py
@@ -236,7 +236,7 @@ class Script(ZabbixBase):
             'groupid': groupid
         }
 
-        if description:
+        if description is not None:
             request['description'] = description
 
         if script_type == 'script':

--- a/plugins/modules/zabbix_script.py
+++ b/plugins/modules/zabbix_script.py
@@ -234,8 +234,10 @@ class Script(ZabbixBase):
                 '',
                 'manual_event_action'], scope)),
             'groupid': groupid,
-            'description': description
         }
+
+        if description:
+            request['description'] = description
 
         if script_type == 'script':
             if execute_on is None:

--- a/plugins/modules/zabbix_script.py
+++ b/plugins/modules/zabbix_script.py
@@ -233,7 +233,7 @@ class Script(ZabbixBase):
                 'manual_host_action',
                 '',
                 'manual_event_action'], scope)),
-            'groupid': groupid,
+            'groupid': groupid
         }
 
         if description:


### PR DESCRIPTION
##### SUMMARY
Fixes script handling when description is not defined. Zabbix API requires description to be string. Currently when description is not defined in module, it sends `null` in JSON which is invalid.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_script.py

##### ADDITIONAL INFORMATION
Before change when description is not defined:
```
zabbix_api.ZabbixAPIException: ('Error -32602: Invalid params., Invalid parameter "/1/description": a character string is expected. while sending {"jsonrpc": "2.0", "method": "script.create", "params": {"name": "Test", "type": "0", "command": "true", "scope": "1", "groupid": "0", "description": null, "execute_on": "2"}, "auth": "xxx", "id": 3}', -32602)
```
After change when description is not defined:
```
localhost | CHANGED => {
    "changed": true,
    "msg": "Script Test created"
}
```