### PR TITLE
zabbix_template_info: Add yaml and none formats

### DIFF
--- a/changelogs/fragments/731-template-info-formats.yml
+++ b/changelogs/fragments/731-template-info-formats.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - zabbix_template_info - add yaml and none formats
+  - zabbix_template_info - add template_id return value

--- a/plugins/modules/zabbix_template_info.py
+++ b/plugins/modules/zabbix_template_info.py
@@ -231,7 +231,7 @@ class TemplateInfo(ZabbixBase):
 
     def load_yaml_template(self, template_yaml, omit_date=False):
         if omit_date:
-            yaml_lines = template_yaml.splitlines(keepends=True)
+            yaml_lines = template_yaml.splitlines(True)
             for index, line in enumerate(yaml_lines):
                 if 'date:' in line:
                     del yaml_lines[index]

--- a/plugins/modules/zabbix_template_info.py
+++ b/plugins/modules/zabbix_template_info.py
@@ -285,11 +285,23 @@ def main():
         module.fail_json(msg='Template not found: %s' % template_name)
 
     if format == 'json':
-        module.exit_json(changed=False, template_id=template_id[0], template_json=template_info.dump_template(template_id, template_type='json', omit_date=omit_date))
+        module.exit_json(
+            changed=False,
+            template_id=template_id[0],
+            template_json=template_info.dump_template(template_id, template_type='json', omit_date=omit_date)
+        )
     elif format == 'xml':
-        module.exit_json(changed=False, template_id=template_id[0], template_xml=template_info.dump_template(template_id, template_type='xml', omit_date=omit_date))
+        module.exit_json(
+            changed=False,
+            template_id=template_id[0],
+            template_xml=template_info.dump_template(template_id, template_type='xml', omit_date=omit_date)
+        )
     elif format == 'yaml':
-        module.exit_json(changed=False, template_id=template_id[0], template_yaml=template_info.dump_template(template_id, template_type='yaml', omit_date=omit_date))
+        module.exit_json(
+            changed=False,
+            template_id=template_id[0],
+            template_yaml=template_info.dump_template(template_id, template_type='yaml', omit_date=omit_date)
+        )
     elif format == 'none':
         module.exit_json(changed=False, template_id=template_id[0])
 

--- a/tests/integration/targets/test_zabbix_template_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template_info/tasks/main.yml
@@ -84,3 +84,54 @@
       - fetch_template_xml_format_omit_date_result.template_xml | regex_search('<date>.*</date>') is none
       - fetch_template_xml_format_omit_date_result.template_xml | regex_search('</date><groups><group><name>Templates</name></group></groups><templates>') is defined
       - fetch_template_xml_format_omit_date_result.template_xml | regex_search('<templates><template><template>ExampleTemplateForTempleteInfoModule</template><name>ExampleTemplateForTempleteInfoModule</name><groups><group><name>Templates</name></group></groups></template></templates>') is defined
+
+- name: "test - Fetch template info as a YAML format from Zabbix Server"
+  zabbix_template_info:
+    server_url: "{{ zabbix_api_server_url }} "
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    template_name: ExampleTemplateForTempleteInfoModule
+    format: yaml
+  register: fetch_template_yaml_format_result
+  when: zabbix_version is version('5.2', '>=')
+
+- assert:
+    that:
+      - (fetch_template_yaml_format_result.template_yaml | from_yaml)[template_export_key]['date'] is defined
+      - (fetch_template_yaml_format_result.template_yaml | from_yaml)[template_export_key]['groups'][0]['name'] == 'Templates'
+      - (fetch_template_yaml_format_result.template_yaml | from_yaml)[template_export_key]['templates'][0]['template'] == 'ExampleTemplateForTempleteInfoModule'
+  when: zabbix_version is version('5.2', '>=')
+
+- name: "test - Fetch template info as a YAML format with omit_date parameter from Zabbix Server"
+  zabbix_template_info:
+    server_url: "{{ zabbix_api_server_url }} "
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    template_name: ExampleTemplateForTempleteInfoModule
+    format: yaml
+    omit_date: true
+  register: fetch_template_yaml_format_omit_date_result
+  when: zabbix_version is version('5.2', '>=')
+
+- assert:
+    that:
+      - (fetch_template_yaml_format_omit_date_result.template_yaml | from_yaml)[template_export_key]['date'] is not defined
+      - (fetch_template_yaml_format_omit_date_result.template_yaml | from_yaml)[template_export_key]['groups'][0]['name'] == 'Templates'
+      - (fetch_template_yaml_format_omit_date_result.template_yaml | from_yaml)[template_export_key]['templates'][0]['template'] == 'ExampleTemplateForTempleteInfoModule'
+  when: zabbix_version is version('5.2', '>=')
+
+- name: "test - Fetch template info with none format from Zabbix Server"
+  zabbix_template_info:
+    server_url: "{{ zabbix_api_server_url }} "
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    template_name: ExampleTemplateForTempleteInfoModule
+    format: none
+  register: fetch_template_none_format_result
+
+- assert:
+    that:
+      - fetch_template_none_format_result.template_id is defined
+      - fetch_template_none_format_result.template_json is not defined
+      - fetch_template_none_format_result.template_xml is not defined
+      - fetch_template_none_format_result.template_yaml is not defined

--- a/tests/integration/targets/test_zabbix_template_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template_info/tasks/main.yml
@@ -97,9 +97,9 @@
 
 - assert:
     that:
-      - (fetch_template_yaml_format_result.template_yaml | from_yaml)[template_export_key]['date'] is defined
-      - (fetch_template_yaml_format_result.template_yaml | from_yaml)[template_export_key]['groups'][0]['name'] == 'Templates'
-      - (fetch_template_yaml_format_result.template_yaml | from_yaml)[template_export_key]['templates'][0]['template'] == 'ExampleTemplateForTempleteInfoModule'
+      - fetch_template_yaml_format_result.template_yaml | regex_search('date: .+') is defined
+      - fetch_template_yaml_format_result.template_yaml | regex_search('name: Templates') is defined
+      - fetch_template_yaml_format_result.template_yaml | regex_search('template: ExampleTemplateForTempleteInfoModule') is defined
   when: zabbix_version is version('5.2', '>=')
 
 - name: "test - Fetch template info as a YAML format with omit_date parameter from Zabbix Server"
@@ -115,9 +115,9 @@
 
 - assert:
     that:
-      - (fetch_template_yaml_format_omit_date_result.template_yaml | from_yaml)[template_export_key]['date'] is not defined
-      - (fetch_template_yaml_format_omit_date_result.template_yaml | from_yaml)[template_export_key]['groups'][0]['name'] == 'Templates'
-      - (fetch_template_yaml_format_omit_date_result.template_yaml | from_yaml)[template_export_key]['templates'][0]['template'] == 'ExampleTemplateForTempleteInfoModule'
+      - fetch_template_yaml_format_result.template_yaml | regex_search('date: .+') is not defined
+      - fetch_template_yaml_format_result.template_yaml | regex_search('name: Templates') is defined
+      - fetch_template_yaml_format_result.template_yaml | regex_search('template: ExampleTemplateForTempleteInfoModule') is defined
   when: zabbix_version is version('5.2', '>=')
 
 - name: "test - Fetch template info with none format from Zabbix Server"


### PR DESCRIPTION
##### SUMMARY
Adds 3 features into zabbix_template_info module:
1. `format: yaml` - export of template in YAML format (supported in Zabbix >= 5.2)
2. `format: none` - do not retrieve template export at all
3. `template_id` - return value of ID of the template (which we retrieve anyway in the code but was not returned from module)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_template_info

##### ADDITIONAL INFORMATION FOR `format: yaml`:
I chose to implement `omit_date` without parsing and dumping YAML as it changed the resulting format a lot. I think it is better to keep it in line with native Zabbix output.

##### ADDITIONAL INFORMATION FOR `format: none`:
It is useful when you need only to test template presence/absence. In that case we can skip one possibly huge API request/response. We can then force task to not fail and check result to determine if template exists:
```
- name: retrieve information about template
  community.zabbix.zabbix_template_info:
    ...login parameters...
    template_name: Some template
    format: none
  failed_when: false
  register: template_result

- name: do something when template exists
    ...some module data...
  when: template_result.template_id is defined
```

##### ADDITIONAL INFORMATION FOR `template_id`:
Needed for template existence check as seen in previous example when template export is not returned and task is set to not fail. For consistency I added it to all results as we have the value anyway and it is not returned in the template export itself.