### PR TITLE
Set mediatypeid on recovery and acknowledge actions

### DIFF
--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -1329,8 +1329,6 @@ class RecoveryOperations(Operations):
                 constructed_operation['opmessage'] = self._construct_opmessage(op)
                 constructed_operation['opmessage_usr'] = self._construct_opmessage_usr(op)
                 constructed_operation['opmessage_grp'] = self._construct_opmessage_grp(op)
-                if LooseVersion(self._zbx_api_version) >= LooseVersion('6.0'):
-                    constructed_operation['opmessage'].pop('mediatypeid')
 
             if constructed_operation['operationtype'] == 11:
                 constructed_operation['opmessage'] = self._construct_opmessage(op)
@@ -1401,8 +1399,6 @@ class AcknowledgeOperations(Operations):
                 constructed_operation['opmessage'] = self._construct_opmessage(op)
                 constructed_operation['opmessage_usr'] = self._construct_opmessage_usr(op)
                 constructed_operation['opmessage_grp'] = self._construct_opmessage_grp(op)
-                if LooseVersion(self._zbx_api_version) >= LooseVersion('6.0'):
-                    constructed_operation['opmessage'].pop('mediatypeid')
 
             if constructed_operation['operationtype'] == 12:
                 constructed_operation['opmessage'] = self._construct_opmessage(op)


### PR DESCRIPTION
##### SUMMARY
Fixes #728 

I can't find out why the `.pop('mediatypeid')` is added, according to https://www.zabbix.com/documentation/current/en/manual/api/reference/action/object#action-operation-message a mediatypeid can always be set at any action.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
zabbix_action

##### ADDITIONAL INFORMATION
Set a media type on a recovery or acknowledge operation and check if it's set in the GUI:

    - name: MS teams alarm
      community.zabbix.zabbix_action:
        server_url: ""
        login_user: 
        login_password: ""
        name: "MS teams alarm"
        event_source: 'trigger'
        state: present
        status: enabled
        esc_period: 15m
        eval_type: and
        conditions:
          - type: 'trigger_severity'
            operator: '>='
            value: 'high'
        operations:
          - type: send_message
            media_type: 'MS Teams'
            send_to_users:
              - 'something@example.com'
        recovery_operations:
          - type: send_message
            media_type: 'MS Teams'
            send_to_users:
              - 'something@example.com'