### PR TITLE
Send opconditions for Zabbix 6

### DIFF
--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -1236,18 +1236,14 @@ class Operations(Zapi):
                 constructed_operation['opmessage'] = self._construct_opmessage(op)
                 constructed_operation['opmessage_usr'] = self._construct_opmessage_usr(op)
                 constructed_operation['opmessage_grp'] = self._construct_opmessage_grp(op)
-
-                if LooseVersion(self._zbx_api_version) < LooseVersion('6.0'):
-                    constructed_operation['opconditions'] = self._construct_opconditions(op)
+                constructed_operation['opconditions'] = self._construct_opconditions(op)
 
             # Send Command type
             if constructed_operation['operationtype'] == 1:
                 constructed_operation['opcommand'] = self._construct_opcommand(op)
                 constructed_operation['opcommand_hst'] = self._construct_opcommand_hst(op)
                 constructed_operation['opcommand_grp'] = self._construct_opcommand_grp(op)
-                if LooseVersion(self._zbx_api_version) < LooseVersion('6.0'):
-                    constructed_operation['opconditions'] = self._construct_opconditions(op)
-                elif event_source == 'trigger':
+                if event_source == 'trigger':
                     # opconditions valid only for 'trigger' action
                     constructed_operation['opconditions'] = self._construct_opconditions(op)
 


### PR DESCRIPTION
##### SUMMARY
I figured out the the operation_condition was not working in the new Zabbix:
```
  community.zabbix.zabbix_action:
    server_url: ""
    login_user: 
    login_password: ""
    name: "Alarm"
    event_source: 'trigger'
    state: present
    status: disabled
    esc_period: 15m
    eval_type: and
    operations:
      - type: send_message
        media_type: 'Email'
        operation_condition: not_acknowledged
        esc_step_from: 2
        esc_step_to: 0
        send_to_users:
          - 'someone@example.com'
```

Opconditions are still valid in the new zabbix: https://www.zabbix.com/documentation/current/en/manual/api/reference/action/object#action-operation-condition

I removed the zabbix >= 6.0 check and it is working again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_action

