### PR TITLE
Support for template groups (for Zabbix >= 6.2)

### DIFF
--- a/tests/integration/targets/test_zabbix_template/defaults/main.yml
+++ b/tests/integration/targets/test_zabbix_template/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+template_groups_key: "{{ 'template_groups' if zabbix_version is version('6.2', '>=') else 'groups' }}"

--- a/tests/integration/targets/test_zabbix_template/files/template1-changed_50_lower.json
+++ b/tests/integration/targets/test_zabbix_template/files/template1-changed_50_lower.json
@@ -8,10 +8,10 @@
         "description": "",
         "groups": [
           {
-            "name": "Linux servers"
+            "name": "Templates"
           },
           {
-            "name": "Templates"
+            "name": "Templates/Applications"
           }
         ],
         "macros": [
@@ -41,10 +41,10 @@
     "version": "3.0",
     "groups": [
       {
-        "name": "Linux servers"
+        "name": "Templates"
       },
       {
-        "name": "Templates"
+        "name": "Templates/Applications"
       }
     ]
   }

--- a/tests/integration/targets/test_zabbix_template/files/template1_50_lower.json
+++ b/tests/integration/targets/test_zabbix_template/files/template1_50_lower.json
@@ -8,10 +8,10 @@
         "description": "",
         "groups": [
           {
-            "name": "Linux servers"
+            "name": "Templates"
           },
           {
-            "name": "Templates"
+            "name": "Templates/Applications"
           }
         ],
         "macros": [
@@ -37,10 +37,10 @@
     "version": "3.0",
     "groups": [
       {
-        "name": "Linux servers"
+        "name": "Templates"
       },
       {
-        "name": "Templates"
+        "name": "Templates/Applications"
       }
     ]
   }

--- a/tests/integration/targets/test_zabbix_template/files/template2_50_lower.xml
+++ b/tests/integration/targets/test_zabbix_template/files/template2_50_lower.xml
@@ -8,10 +8,10 @@
       <description></description>
       <groups>
         <group>
-          <name>Linux servers</name>
+          <name>Templates</name>
         </group>
         <group>
-          <name>Templates</name>
+          <name>Templates/Applications</name>
         </group>
       </groups>
       <macros>
@@ -44,10 +44,10 @@
   <version>3.0</version>
   <groups>
     <group>
-      <name>Linux servers</name>
+      <name>Templates</name>
     </group>
     <group>
-      <name>Templates</name>
+      <name>Templates/Applications</name>
     </group>
   </groups>
 </zabbix_export>

--- a/tests/integration/targets/test_zabbix_template/files/template3-changed_54_higher.json
+++ b/tests/integration/targets/test_zabbix_template/files/template3-changed_54_higher.json
@@ -3,22 +3,22 @@
       "date": "2022-01-23T15:13:26Z",
       "groups": [
           {
-              "name": "Linux servers",
-              "uuid": "dc579cd7a1a34222933f24f52a68bcd8"
-          },
-          {
               "name": "Templates",
               "uuid": "7df96b18c230490a9a0a9e2307226338"
+          },
+          {
+              "name": "Templates/Applications",
+              "uuid": "a571c0d144b14fd4a87a9d9b2aa9fcd6"
           }
       ],
       "templates": [
           {
               "groups": [
                   {
-                      "name": "Linux servers"
+                      "name": "Templates"
                   },
                   {
-                      "name": "Templates"
+                      "name": "Templates/Applications"
                   }
               ],
               "macros": [

--- a/tests/integration/targets/test_zabbix_template/files/template3_54_higher.json
+++ b/tests/integration/targets/test_zabbix_template/files/template3_54_higher.json
@@ -3,22 +3,22 @@
       "date": "2022-01-23T15:13:26Z",
       "groups": [
           {
-              "name": "Linux servers",
-              "uuid": "dc579cd7a1a34222933f24f52a68bcd8"
-          },
-          {
               "name": "Templates",
               "uuid": "7df96b18c230490a9a0a9e2307226338"
+          },
+          {
+              "name": "Templates/Applications",
+              "uuid": "a571c0d144b14fd4a87a9d9b2aa9fcd6"
           }
       ],
       "templates": [
           {
               "groups": [
                   {
-                      "name": "Linux servers"
+                      "name": "Templates"
                   },
                   {
-                      "name": "Templates"
+                      "name": "Templates/Applications"
                   }
               ],
               "macros": [

--- a/tests/integration/targets/test_zabbix_template/files/template3_54_higher.xml
+++ b/tests/integration/targets/test_zabbix_template/files/template3_54_higher.xml
@@ -4,12 +4,12 @@
     <date>2022-01-23T15:24:01Z</date>
     <groups>
         <group>
-            <uuid>dc579cd7a1a34222933f24f52a68bcd8</uuid>
-            <name>Linux servers</name>
-        </group>
-        <group>
             <uuid>7df96b18c230490a9a0a9e2307226338</uuid>
             <name>Templates</name>
+        </group>
+        <group>
+            <uuid>a571c0d144b14fd4a87a9d9b2aa9fcd6</uuid>
+            <name>Templates/Applications</name>
         </group>
     </groups>
     <templates>
@@ -27,10 +27,10 @@
             </templates>
             <groups>
                 <group>
-                    <name>Linux servers</name>
+                    <name>Templates</name>
                 </group>
                 <group>
-                    <name>Templates</name>
+                    <name>Templates/Applications</name>
                 </group>
             </groups>
             <macros>

--- a/tests/integration/targets/test_zabbix_template/tasks/import_54_higher.yml
+++ b/tests/integration/targets/test_zabbix_template/tasks/import_54_higher.yml
@@ -77,8 +77,8 @@
 - block:
     - assert:
         that:
-          - gather_template_result.template_json[template_export_key].groups.0.name == 'Linux servers'
-          - gather_template_result.template_json[template_export_key].groups.1.name == 'Templates'
+          - gather_template_result.template_json[template_export_key][template_groups_key].0.name == 'Templates'
+          - gather_template_result.template_json[template_export_key][template_groups_key].1.name == 'Templates/Applications'
           - gather_template_result.template_json[template_export_key].templates.0.templates.0.name == 'FTP Service'
           - gather_template_result.template_json[template_export_key].templates.0.templates.1.name == 'Zabbix proxy health'
           - gather_template_result.template_json[template_export_key].templates.0.macros.0.macro == '{$EXAMPLE_MACRO1}'

--- a/tests/integration/targets/test_zabbix_template/tasks/import_54_lower.yml
+++ b/tests/integration/targets/test_zabbix_template/tasks/import_54_lower.yml
@@ -22,8 +22,8 @@
 - block:
     - assert:
         that:
-          - gather_template_result.template_json[template_export_key].groups.0.name == 'Linux servers'
-          - gather_template_result.template_json[template_export_key].groups.1.name == 'Templates'
+          - gather_template_result.template_json[template_export_key].groups.0.name == 'Templates'
+          - gather_template_result.template_json[template_export_key].groups.1.name == 'Templates/Applications'
           - gather_template_result.template_json[template_export_key].templates.0.templates.0.name == 'Template App FTP Service'
           - gather_template_result.template_json[template_export_key].templates.0.templates.1.name == 'Template App Zabbix Proxy'
           - gather_template_result.template_json[template_export_key].templates.0.macros.0.macro == '{$EXAMPLE_MACRO1}'

--- a/tests/integration/targets/test_zabbix_template/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template/tasks/main.yml
@@ -7,8 +7,8 @@
     login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleHost
     template_groups:
-      - 'Linux servers'
       - 'Templates'
+      - 'Templates/Applications'
     state: present
   register: create_zabbix_template_result
   check_mode: true
@@ -24,8 +24,8 @@
     login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleHost
     template_groups:
-      - 'Linux servers'
       - 'Templates'
+      - 'Templates/Applications'
     state: present
   register: create_zabbix_template_result
 
@@ -40,8 +40,8 @@
     login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleHost
     template_groups:
-      - 'Linux servers'
       - 'Templates'
+      - 'Templates/Applications'
     state: present
   register: create_zabbix_template_result
 
@@ -56,8 +56,8 @@
     login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleHostWithLinked
     template_groups:
-      - 'Linux servers'
       - 'Templates'
+      - 'Templates/Applications'
     link_templates:
       - "{{ 'Zabbix proxy health' if zabbix_version | float >= 5.4 else 'Template App Zabbix Proxy' }}"
       - "{{ 'FTP Service' if zabbix_version | float >= 5.4 else 'Template App FTP Service' }}"
@@ -86,8 +86,8 @@
 
 - assert:
     that:
-      - gather_template_result.template_json[template_export_key].groups.0.name == 'Linux servers'
-      - gather_template_result.template_json[template_export_key].groups.1.name == 'Templates'
+      - gather_template_result.template_json[template_export_key][template_groups_key].0.name == 'Templates'
+      - gather_template_result.template_json[template_export_key][template_groups_key].1.name == 'Templates/Applications'
 
 - name: Add link_templates to Zabbix template.
   zabbix_template:
@@ -96,8 +96,8 @@
     login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleHost
     template_groups:
-      - 'Linux servers'
       - 'Templates'
+      - 'Templates/Applications'
     link_templates:
       - "{{ 'Zabbix proxy health' if zabbix_version | float >= 5.4 else 'Template App Zabbix Proxy' }}"
       - "{{ 'FTP Service' if zabbix_version | float >= 5.4 else 'Template App FTP Service' }}"
@@ -115,8 +115,8 @@
     login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleHost
     template_groups:
-      - 'Linux servers'
       - 'Templates'
+      - 'Templates/Applications'
     link_templates:
       - "{{ 'Zabbix proxy health' if zabbix_version | float >= 5.4 else 'Template App Zabbix Proxy' }}"
       - "{{ 'FTP Service' if zabbix_version | float >= 5.4 else 'Template App FTP Service' }}"
@@ -140,8 +140,8 @@
   block:
     - assert:
         that:
-          - gather_template_result.template_json[template_export_key].groups.0.name == 'Linux servers'
-          - gather_template_result.template_json[template_export_key].groups.1.name == 'Templates'
+          - gather_template_result.template_json[template_export_key].groups.0.name == 'Templates'
+          - gather_template_result.template_json[template_export_key].groups.1.name == 'Templates/Applications'
           - gather_template_result.template_json[template_export_key].templates.0.templates.0.name == 'Template App FTP Service'
           - gather_template_result.template_json[template_export_key].templates.0.templates.1.name == 'Template App Zabbix Proxy'
 
@@ -149,8 +149,8 @@
   block:
     - assert:
         that:
-          - gather_template_result.template_json[template_export_key].groups.0.name == 'Linux servers'
-          - gather_template_result.template_json[template_export_key].groups.1.name == 'Templates'
+          - gather_template_result.template_json[template_export_key][template_groups_key].0.name == 'Templates'
+          - gather_template_result.template_json[template_export_key][template_groups_key].1.name == 'Templates/Applications'
           - gather_template_result.template_json[template_export_key].templates.0.templates.0.name == 'FTP Service'
           - gather_template_result.template_json[template_export_key].templates.0.templates.1.name == 'Zabbix proxy health'
 
@@ -161,8 +161,8 @@
     login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleHost
     template_groups:
-      - 'Linux servers'
       - 'Templates'
+      - 'Templates/Applications'
     link_templates:
       - "{{ 'Zabbix proxy health' if zabbix_version | float >= 5.4 else 'Template App Zabbix Proxy' }}"
       - "{{ 'FTP Service' if zabbix_version | float >= 5.4 else 'Template App FTP Service' }}"
@@ -185,8 +185,8 @@
     login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleHost
     template_groups:
-      - 'Linux servers'
       - 'Templates'
+      - 'Templates/Applications'
     link_templates:
       - "{{ 'Zabbix proxy health' if zabbix_version | float >= 5.4 else 'Template App Zabbix Proxy' }}"
       - "{{ 'FTP Service' if zabbix_version | float >= 5.4 else 'Template App FTP Service' }}"

--- a/tests/integration/targets/test_zabbix_template_info/defaults/main.yml
+++ b/tests/integration/targets/test_zabbix_template_info/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+template_groups_key: "{{ 'template_groups' if zabbix_version is version('6.2', '>=') else 'groups' }}"

--- a/tests/integration/targets/test_zabbix_template_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template_info/tasks/main.yml
@@ -33,7 +33,7 @@
 - assert:
     that:
       - fetch_template_json_format_result.template_json[template_export_key].date is defined
-      - fetch_template_json_format_result.template_json[template_export_key].groups.0.name == "Templates"
+      - fetch_template_json_format_result.template_json[template_export_key][template_groups_key].0.name == "Templates"
       - fetch_template_json_format_result.template_json[template_export_key].templates.0.name == "ExampleTemplateForTempleteInfoModule"
       - fetch_template_json_format_result.template_json[template_export_key].templates.0.template == "ExampleTemplateForTempleteInfoModule"
 
@@ -50,7 +50,7 @@
 - assert:
     that:
       - fetch_template_json_format_omit_date_result.template_json[template_export_key].date is not defined
-      - fetch_template_json_format_omit_date_result.template_json[template_export_key].groups.0.name == "Templates"
+      - fetch_template_json_format_omit_date_result.template_json[template_export_key][template_groups_key].0.name == "Templates"
       - fetch_template_json_format_omit_date_result.template_json[template_export_key].templates.0.name == "ExampleTemplateForTempleteInfoModule"
       - fetch_template_json_format_omit_date_result.template_json[template_export_key].templates.0.template == "ExampleTemplateForTempleteInfoModule"
 


### PR DESCRIPTION
##### SUMMARY
Adds support for template groups which are new in Zabbix 6.2.

Resolves #736

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- zabbix_template
- zabbix_template_info

##### ADDITIONAL INFORMATION
- Based on Zabbix version determines if use `hostgroup.get` (<6.2) or `templategroup.get` (>=6.2) API calls.
- Based on Zabbix version determines if use `groups` (<6.2) or `template_groups` (>=6.2) key in exports.
- Removed `check_host_group_exist` function. I check if template group exists directly in `get_group_ids_by_group_names` function. Uses one less request to API (and one less Zabbix version check).
- Using _Templates/Applications_ instead of _Linux servers_ in tests as it exists by default as template group.
- Change of `groups` rule into `host_groups` and `template_groups` in `configuration.import` is not [documented](https://www.zabbix.com/documentation/6.2/en/manual/api/reference/configuration/import#parameters) yet. I found correct rule names [in the source code](https://github.com/zabbix/zabbix/blob/release/6.2/ui/include/classes/api/services/CConfiguration.php#L107-L114). I will create upstream ZBX issue on this.