### PR TITLE
zabbix_mediatype: Add support for time units in attempt_interval

### DIFF
--- a/changelogs/fragments/744-mediatype-attemptinterval-timeunits.yml
+++ b/changelogs/fragments/744-mediatype-attemptinterval-timeunits.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - zabbix_mediatype - added support for time units in ``attempt_interval`` parameter

--- a/plugins/modules/zabbix_mediatype.py
+++ b/plugins/modules/zabbix_mediatype.py
@@ -77,12 +77,12 @@ options:
             - Works only with Zabbix versions 3.4 or newer.
         default: 3
     attempt_interval:
-        type: 'int'
+        type: 'str'
         description:
             - The interval between retry attempts.
-            - Possible range is 0-60.
+            - Possible range is 0-60s in Zabbix < 5.0 or 0-1h in Zabbix >= 5.0.
             - Works only with Zabbix versions 3.4 or newer.
-        default: 10
+        default: 10s
     script_name:
         type: 'str'
         description:
@@ -641,7 +641,7 @@ def main():
         status=dict(type='str', default='enabled', choices=['enabled', 'disabled'], required=False),
         max_sessions=dict(type='int', default=1, required=False),
         max_attempts=dict(type='int', default=3, required=False),
-        attempt_interval=dict(type='int', default=10, required=False),
+        attempt_interval=dict(type='str', default='10s', required=False),
         # Script
         script_name=dict(type='str', required=False),
         script_params=dict(type='list', required=False),

--- a/tests/integration/targets/test_zabbix_mediatype/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_mediatype/tasks/main.yml
@@ -123,7 +123,7 @@
       zabbix_mediatype:
         max_sessions: 99
         max_attempts: 10
-        attempt_interval: 30
+        attempt_interval: 30s
       register: zbxmediatype_concur
 
     - assert:
@@ -133,7 +133,7 @@
       zabbix_mediatype:
         max_sessions: 99
         max_attempts: 10
-        attempt_interval: 30
+        attempt_interval: 30s
       register: zbxmediatype_concur
 
     - assert:
@@ -142,8 +142,8 @@
     - name: test - update email mediatype concurrent settings above range (fail)
       zabbix_mediatype:
         max_sessions: 102
-        max_attempts: 11
-        attempt_interval: 61
+        max_attempts: 101
+        attempt_interval: 61m
       register: zbxmediatype_concur_fail
       ignore_errors: true
 


### PR DESCRIPTION
##### SUMMARY
Adds support for time unit suffixes for `attempt_interval` parameter in zabbix_mediatype module. Now it accepts both, only number for seconds or unit suffixed number. Time suffixes in this parameter are supported since the parameter appeared in API, so there is no need to make if/else based on version.

Resolves #721

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_mediatype