### PR TITLE
zabbix_agent: Check if ansible_distribution_release is defined

### DIFF
--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -17,6 +17,7 @@
     zabbix_version: 6.0
     zabbix_agent_version: 6.0
   when:
+    - ansible_distribution_release is defined
     - ansible_distribution_release == "jammy"
     - ( zabbix_agent_version is version ('6.0','lt') or
         zabbix_version is version ('6.0','lt') )


### PR DESCRIPTION
##### SUMMARY
Add conditional check if `ansible_distribution_release` is defined, as it is (as specified in linked issue) not set on Windows.

Fixes #703

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent