### PR TITLE
zabbix_action: Add another condition operator naming options

### DIFF
--- a/changelogs/fragments/749-action-operator-naming.yml
+++ b/changelogs/fragments/749-action-operator-naming.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - zabbix_action - added another condition operator naming options (contains, does not contain,...)

--- a/plugins/module_utils/helpers.py
+++ b/plugins/module_utils/helpers.py
@@ -74,10 +74,11 @@ def helper_cleanup_data(obj):
         return obj
 
 
-def helper_to_numeric_value(strs, value):
+def helper_to_numeric_value(elements, value):
     """Converts string values to integers
 
     Parameters:
+        elements: list of elements to enumerate
         value: string value
 
     Returns:
@@ -85,10 +86,13 @@ def helper_to_numeric_value(strs, value):
     """
     if value is None:
         return None
-    strs = [s.lower() if isinstance(s, str) else s for s in strs]
-    value = value.lower()
-    tmp_dict = dict(zip(strs, list(range(len(strs)))))
-    return tmp_dict[value]
+    for index, element in enumerate(elements):
+        if isinstance(element, str) and element.lower() == value.lower():
+            return index
+        if isinstance(element, list):
+            for deep_element in element:
+                if isinstance(deep_element, str) and deep_element.lower() == value.lower():
+                    return index
 
 
 def helper_convert_unicode_to_str(data):

--- a/plugins/modules/zabbix_action.py
+++ b/plugins/modules/zabbix_action.py
@@ -145,18 +145,18 @@ options:
                     - C(matches), C(does not match), C(Yes) and C(No) condition operators work only with >= Zabbix 4.0
                     - When I(type) is set to C(maintenance_status), the choices are C(Yes) and C(No) for Zabbix >= 6.0
                 choices:
-                    - '='
-                    - '<>'
-                    - 'like'
-                    - 'not like'
-                    - 'in'
-                    - '>='
-                    - '<='
-                    - 'not in'
-                    - 'matches'
-                    - 'does not match'
-                    - 'Yes'
-                    - 'No'
+                    - C(equals) or C(=)
+                    - C(does not equal) or C(<>)
+                    - C(contains) or C(like)
+                    - C(does not contain) or C(not like)
+                    - C(in)
+                    - C(is greater than or equals) or C(>=)
+                    - C(is less than or equals) or C(<=)
+                    - C(not in)
+                    - C(matches)
+                    - C(does not match)
+                    - C(Yes)
+                    - C(No)
             formulaid:
                 description:
                     - Arbitrary unique ID that is used to reference the condition from a custom expression.
@@ -1521,13 +1521,13 @@ class Filter(Zapi):
         """
         try:
             return zabbix_utils.helper_to_numeric_value([
-                "=",
-                "<>",
-                "like",
-                "not like",
+                ["equals", "="],
+                ["does not equal", "<>"],
+                ["contains", "like"],
+                ["does not contain", "not like"],
                 "in",
-                ">=",
-                "<=",
+                ["is greater than or equals", ">="],
+                ["is less than or equals", "<="],
                 "not in",
                 "matches",
                 "does not match",

--- a/tests/integration/targets/test_zabbix_action/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_action/tasks/main.yml
@@ -371,6 +371,24 @@
 
   - assert:
       that: zbxaction_conditions_operators.changed is sameas True
+  
+  - name: test - update action with multiple conditions with operator aliases
+    zabbix_action:
+      conditions:
+        - type: host_group
+          operator: does not equal
+          value: Linux servers
+        - type: event_tag_value
+          value: MyTag
+          operator: contains
+          value2: MyTagValue
+        - type: trigger_severity
+          operator: is less than or equals
+          value: Average
+    register: zbxaction_conditions_operator_aliases
+
+  - assert:
+      that: zbxaction_conditions_operator_aliases.changed is sameas True
 
   - name: test - update action with multiple conditions and evaltype
     zabbix_action:


### PR DESCRIPTION
##### SUMMARY
Adds condition operator naming used in newer Zabbix versions. Original options are kept as alternatives. Modification of `helper_to_numeric_value` function was needed to allow multiple string values to map into single integer. Hope this change is OK.

Resolves #746

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_action module
helper_to_numeric_value function