### PR TITLE
fix windows variable check, add install dirs params

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -291,6 +291,8 @@ Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
 * `zabbix_version_long`: The long (major.minor.patch) version of the Zabbix Agent. This will be used to generate the `zabbix(2)_win_package` and `zabbix(2)_win_download_link` variables. This takes precedence over `zabbix_agent_version`.
 * `zabbix(2)_win_download_link`: The download url to the `win.zip` file.
 * `zabbix_win_install_dir`: The directory where Zabbix needs to be installed.
+* `zabbix_win_install_dir_conf`: The directory where Zabbix configuration file needs to be installed.
+* `zabbix_win_install_dir_bin`: The directory where Zabbix binary file needs to be installed.
 * `zabbix_agent(2)_win_logfile`: The full path to the logfile for the Zabbix Agent.
 * `zabbix_agent_win_include`: The directory in which the Zabbix Agent specific configuration files are stored.
 * `zabbix_agent_win_svc_recovery`: Enable Zabbix Agent service auto-recovery settings.

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -233,6 +233,8 @@ zabbix_win_download_url: https://cdn.zabbix.com/zabbix/binaries/stable
 zabbix_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long | regex_search('^\\d+\\.\\d+') }}/{{ zabbix_version_long }}/{{ zabbix_win_package }}"
 zabbix2_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long | regex_search('^\\d+\\.\\d+') }}/{{ zabbix_version_long }}/{{ zabbix2_win_package }}"
 zabbix_win_install_dir: 'C:\Zabbix'
+zabbix_win_install_dir_conf: '{{ zabbix_win_install_dir }}\\conf'
+zabbix_win_install_dir_bin: '{{ zabbix_win_install_dir }}\\bin'
 zabbix_agent_win_logfile: "{{ zabbix_win_install_dir }}\\zabbix_agentd.log"
 zabbix_agent_win_include: "{{ zabbix_win_install_dir }}\\zabbix_agent.d\\"
 zabbix_agent2_win_logfile: "{{ zabbix_win_install_dir }}\\zabbix_agent2.log"

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -118,13 +118,13 @@
     - zabbix_agent_2_service_exist | default(false)
 
 - name: "Windows | Uninstall Zabbix v1"
-  ansible.windows.win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\conf\{{ zabbix_win_config_name }}" --uninstall'
+  ansible.windows.win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir_conf }}\{{ zabbix_win_config_name }}" --uninstall'
   when:
     - zabbix_agent_version_change | default(false) or zabbix_agent2
     - zabbix_agent_1_service_exist | default(false)
 
 - name: "Windows | Uninstall Zabbix v2"
-  ansible.windows.win_command: '"{{ zabbix2_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\conf\{{ zabbix2_win_config_name }}" --uninstall'
+  ansible.windows.win_command: '"{{ zabbix2_win_exe_path }}" --config "{{ zabbix_win_install_dir_conf }}\{{ zabbix2_win_config_name }}" --uninstall'
   when:
     - zabbix_agent_version_change | default(false) or not zabbix_agent2
     - zabbix_agent_2_service_exist | default(false)
@@ -206,6 +206,22 @@
   when:
     - zabbix_agent_win_download_zip.changed
 
+- name: "Windows | Copy binary files to expected location"
+  ansible.windows.win_copy:
+    src: "{{ zabbix_win_install_dir }}\\bin\\{{ item }}"
+    dest: "{{ zabbix_win_install_dir_bin }}\\{{ item }}"
+    remote_src: yes
+  loop:
+    - zabbix_agentd.exe
+    - zabbix_sender.exe
+  when:
+    - zabbix_win_install_dir_bin is defined
+
+- set_fact:
+    zabbix_win_exe_path: "{{ zabbix_win_install_dir_bin }}\\zabbix_agentd.exe"
+  when:
+    - zabbix_win_install_dir_bin is defined
+
 - name: "Create directory for PSK file if not exist."
   win_file:
     path: "{{ zabbix_agent_tlspskfile | win_dirname }}"
@@ -254,7 +270,7 @@
   register: zabbix_windows_service
 
 - name: "Windows | Register Service"
-  ansible.windows.win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir }}\conf\{{ zabbix_win_config_name }}" --install'
+  ansible.windows.win_command: '"{{ zabbix_win_exe_path }}" --config "{{ zabbix_win_install_dir_conf }}\{{ zabbix_win_config_name }}" --install'
   when: not zabbix_windows_service.exists
 
 - name: "Windows | Set service startup mode to auto, ensure it is started and set auto-recovery"

--- a/roles/zabbix_agent/tasks/Windows_conf.yml
+++ b/roles/zabbix_agent/tasks/Windows_conf.yml
@@ -10,7 +10,7 @@
 - name: "Windows | Configure zabbix-agent"
   ansible.windows.win_template:
     src: "{{ zabbix_win_config_name }}.j2"
-    dest: "{{ zabbix_win_install_dir }}\\conf\\{{ zabbix_win_config_name }}"
+    dest: "{{ zabbix_win_install_dir_conf }}\\{{ zabbix_win_config_name }}"
   notify: restart win zabbix agent
 
 - name: "Windows | Set service startup mode to auto, ensure it is started and set auto-recovery"

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -17,7 +17,7 @@
     zabbix_version: 6.0
     zabbix_agent_version: 6.0
   when:
-    - ansible_distribution_release == "jammy"
+    - ansible_distribution_release is defined and ansible_distribution_release == "jammy"
     - ( zabbix_agent_version is version ('6.0','lt') or
         zabbix_version is version ('6.0','lt') )
 


### PR DESCRIPTION
##### SUMMARY
* fix: when installing on Windows, variable `ansible_distribution_release` does not exists.
* feature: option to change conf and bin folder when needed. Default behavior is use the default folders.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
zabbix-agent
