### PR TITLE
Fixed typo of zabbix_server_database argument

### DIFF
--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -329,7 +329,7 @@ We need to have the following dependencies met:
 2. We need to set some variables, either as input for the playbook or set them into the `group_vars` or `host_vars` (Your preference choice). We need to set the following properties:
 
 ```yaml
-zabbix_server_database: pgsq;
+zabbix_server_database: pgsql;
 zabbix_server_database_long: postgresql
 zabbix_server_dbport: 5432
 zabbix_server_dbhost: pgsql-host


### PR DESCRIPTION
I had directly copy-pasted `zabbix_server_database` and `zabbix_server_database_long` for explicitation.

- Docs Pull Request

The typo produced failure below:
```
TASK [community.zabbix.zabbix_server : Debian | Installing zabbix-server-pgsq] *****************************************************************************************
FAILED - RETRYING: [somehost]: Debian | Installing zabbix-server-pgsq (3 retries left).
FAILED - RETRYING: [somehost]: Debian | Installing zabbix-server-pgsq (2 retries left).
FAILED - RETRYING: [somehost]: Debian | Installing zabbix-server-pgsq (1 retries left).
fatal: [somehost]: FAILED! => {"attempts": 3, "changed": false, "msg": "No package matching 'zabbix-server-pgsq' is available"}
```
