### PR TITLE
Added geerlingguy.php role to zabbix_web examples

### DIFF
--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -232,6 +232,7 @@ When there is one host running both Zabbix Server and the Zabbix Web (Running My
   become: yes
   roles:
     - role: geerlingguy.apache
+    - role: geerlingguy.php
     - role: community.zabbix.zabbix_server
       zabbix_server_database: mysql
       zabbix_server_database_long: mysql
@@ -260,6 +261,7 @@ This is a two host setup. On one host (Named: "zabbix-server") the Zabbix Server
   become: yes
   roles:
     - role: geerlingguy.apache
+    - role: geerlingguy.php
     - role: community.zabbix.zabbix_web
       zabbix_api_server_url: zabbix.mydomain.com
       zabbix_server_hostname: zabbix-server


### PR DESCRIPTION
- Docs Pull Request

Unless PHP was already installed, playbook would fail as such in single host mode (I assume same is true for multi host as well):

```
TASK [community.zabbix.zabbix_web : Debian | Install PHP] **********************************************************************************************************************************
fatal: [somehost]: FAILED! => {"changed": false, "checksum": "6143f26cadc359043b8e0eb8a4e3efef512476c2", "msg": "Destination directory /etc/php/7.4/fpm/pool.d does not exist"}
```