### PR TITLE
zabbix_agent: Add zabbix_agent(2)_include_pattern variable

### DIFF
--- a/changelogs/fragments/770-agent-include-pattern.yml
+++ b/changelogs/fragments/770-agent-include-pattern.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - zabbix_agent - add possiblity to set include file pattern using ``zabbix_agent(2)_include_pattern`` variable.

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -211,6 +211,7 @@ Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
 * `zabbix_agent(2)_zabbix_alias`: sets an alias for parameter. it can be useful to substitute long and complex parameter name with a smaller and simpler one. Can be both a string as an list.
 * `zabbix_agent(2)_timeout`: spend no more than timeout seconds on processing
 * `zabbix_agent(2)_include`: you may include individual files or all files in a directory in the configuration file.
+* `zabbix_agent(2)_include_pattern`: Optional file pattern used for included files.
 * `zabbix_agent(2)_include_mode`: The mode for the directory mentioned above.
 * `zabbix_agent(2)_unsafeuserparameters`: allow all characters to be passed in arguments to user-defined parameters.
 * `zabbix_agent_loadmodulepath`: Full path to location of agent modules.

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -141,6 +141,7 @@ zabbix_agent_allowroot: 0
 zabbix_agent_zabbix_alias:
 zabbix_agent_timeout: 3
 zabbix_agent_include: /etc/zabbix/zabbix_agentd.d
+zabbix_agent_include_pattern:
 zabbix_agent_include_mode: "0750"
 zabbix_agent_unsafeuserparameters: 0
 zabbix_agent_userparameters: []
@@ -186,6 +187,7 @@ zabbix_agent2_logfile: /var/log/zabbix/zabbix_agent2.log
 zabbix_agent2_logtype: file
 zabbix_agent2_statusport: 9999
 zabbix_agent2_include: /etc/zabbix/zabbix_agent2.d
+zabbix_agent2_include_pattern:
 zabbix_agent2_logfilesize: 100
 zabbix_agent2_debuglevel: 3
 zabbix_agent2_sourceip:

--- a/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -82,7 +82,7 @@ Timeout={{ zabbix_agent2_timeout }}
 {% if zabbix_agent_os_family == "Windows" %}
 Include={{ zabbix_agent_win_include }}
 {% else %}
-Include={{ zabbix_agent2_include }}
+Include={{ zabbix_agent2_include }}/{{ zabbix_agent2_include_pattern }}
 {% endif %}
 UnsafeUserParameters={{ zabbix_agent2_unsafeuserparameters }}
 {% if zabbix_agent_os_family != "Windows" %}

--- a/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
+++ b/roles/zabbix_agent/templates/zabbix_agentd.conf.j2
@@ -76,7 +76,7 @@ User={{ zabbix_agent_runas_user }}
 {% if zabbix_agent_os_family == "Windows" %}
 Include={{ zabbix_agent_win_include }}
 {% else %}
-Include={{ zabbix_agent_include }}
+Include={{ zabbix_agent_include }}/{{ zabbix_agent_include_pattern }}
 {% endif %}
 UnsafeUserParameters={{ zabbix_agent_unsafeuserparameters }}
 {% if zabbix_version is version_compare('2.2', '>=') %}


### PR DESCRIPTION
##### SUMMARY
Adds possibility to set `zabbix_agent(2)_include_pattern` for zabbix_agent role. Allows to use custom file pattern in Include configuration option.

~~Adds possibility to set `zabbix_agent(2)_include_dir` for zabbix_agent role. Allows to use file pattern in the `zabbix_agent(2)_include`. It defaults to the latter to not break existing role's configs.~~

Resolves #748

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_agent

##### EXAMPLE
```yaml
zabbix_agent_include_pattern: "*.conf"
```