### PR TITLE
fix: zabbix-agent2 deployment on Windows fails #778

### DIFF
--- a/changelogs/fragments/778-zbx-agent2-win.yml
+++ b/changelogs/fragments/778-zbx-agent2-win.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_agent - installation on Windows will no longer fail when zabbix_agent2 is used

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -216,11 +216,30 @@
     - zabbix_sender.exe
   when:
     - zabbix_win_install_dir_bin is defined
+    - not (zabbix_agent2 | bool)
+
+- name: "Windows | Copy binary files to expected location (zabbix-agent2)"
+  ansible.windows.win_copy:
+    src: "{{ zabbix_win_install_dir }}\\bin\\{{ item }}"
+    dest: "{{ zabbix_win_install_dir_bin }}\\{{ item }}"
+    remote_src: yes
+  loop:
+    - zabbix_agent2.exe
+  when:
+    - zabbix_win_install_dir_bin is defined
+    - zabbix_agent2 | bool
 
 - set_fact:
     zabbix_win_exe_path: "{{ zabbix_win_install_dir_bin }}\\zabbix_agentd.exe"
   when:
     - zabbix_win_install_dir_bin is defined
+    - not (zabbix_agent2 | bool)
+
+- set_fact:
+    zabbix_win_exe_path: "{{ zabbix_win_install_dir_bin }}\\zabbix_agent2.exe"
+  when:
+    - zabbix_win_install_dir_bin is defined
+    - zabbix_agent2 | bool
 
 - name: "Create directory for PSK file if not exist."
   win_file:


### PR DESCRIPTION
##### SUMMARY
Fixes: #778 
Cannot install zabbix agent2 on Windows machine.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Zabbix Agent2