### PR TITLE
zabbix_host: Fix update of host without interfaces

### DIFF
--- a/changelogs/fragments/792-update-host-without-iface-fix.yml
+++ b/changelogs/fragments/792-update-host-without-iface-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_host - fix updating of host without interfaces

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -703,7 +703,7 @@ class Host(ZabbixBase):
                     found = True
                     break
 
-        if not found:
+        if interfaces and not found:
             return True
 
         return False

--- a/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
+++ b/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
@@ -1594,6 +1594,24 @@
   - name: verify host was created without interfaces
     assert:
       that: zbx_host_create_interfaceless is changed
+  
+  - name: "test: create host without host interfaces (again)"
+    zabbix_host:
+      server_url: "{{ zabbix_api_server_url }}"
+      login_user: "{{ zabbix_api_login_user }}"
+      login_password: "{{ zabbix_api_login_pass }}"
+      host_name: ExampleHost
+      visible_name: ExampleName
+      description: My ExampleHost Description
+      host_groups:
+        - Linux servers
+      status: disabled
+      state: present
+    register: zbx_host_create_interfaceless
+
+  - name: expect to succeed and that things have not changed
+    assert:
+      that: zbx_host_create_interfaceless is not changed
 
   - name: "cleanup"
     zabbix_host:


### PR DESCRIPTION
##### SUMMARY
Fixes updating of host without interfaces. Fixes #791. Added test for this case (which fails before this commit).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host