### PR TITLE
Allow system.hw.chassis to populate on Linux

### DIFF
--- a/changelogs/fragments/784-allow-system.hw.chassis-to-populate-on-linux.yml
+++ b/changelogs/fragments/784-allow-system.hw.chassis-to-populate-on-linux.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - zabbix_agent - give Zabbix Agent access to the Linux DMI table allowing system.hw.chassis info to populate.

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -172,6 +172,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_agent_apt_priority`: Add a weight (`Pin-Priority`) for the APT repository.
 * `zabbix_agent_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 * `zabbix_agent_dont_detect_ip`: Default `false`. When set to `true`, it won't detect available ip addresses on the host and no need for the Python module `netaddr` to be installed.
+* `zabbix_agent_chassis`: Default: `false`. When set to `true`, it will give Zabbix Agent access to the Linux DMI table allowing system.hw.chassis info to populate.
 
 ### Zabbix Agent vs Zabbix Agent 2 configuration
 

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -159,6 +159,7 @@ zabbix_agent_heartbeatfrequency: 60
 zabbix_macros: [] # Will be deprecated in 2.0.0
 zabbix_agent_macros: "{{ zabbix_macros }}"
 zabbix_agent_tags: []
+zabbix_agent_chassis: false
 
 # TLS settings
 zabbix_agent_tlsconnect:

--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -219,3 +219,10 @@
   tags:
     - init
     - service
+
+- name: "Give zabbix-agent access to system.hw.chassis info"
+  file:
+    path: /sys/firmware/dmi/tables/DMI
+    owner: root
+    group: zabbix
+  when: zabbix_agent_chassis | bool


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
allow system.hw.chassis to be populated by giving zabbix group access to DMI table.

fixes #784 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_agent_chassis

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This task changes permissions of `/sys/firmware/dmi/tables/DMI` to `root:zabbix` and is opt-in
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
