### PR TITLE
Java Gateway Update

### DIFF
--- a/.github/workflows/javagateway.yml
+++ b/.github/workflows/javagateway.yml
@@ -3,29 +3,34 @@ name: "community.zabbix.zabbix_javagateway"
 on:
   push:
     paths:
-      - 'roles/zabbix_javagateway/**'
-      - 'molecule/zabbix_javagateway/**'
-      - 'molecule/requirements.txt'
-      - '.github/workflows/javagateway.yml'
+      - "roles/zabbix_javagateway/**"
+      - "molecule/zabbix_javagateway/**"
+      - "molecule/requirements.txt"
+      - ".github/workflows/javagateway.yml"
   pull_request:
     paths:
-      - 'roles/zabbix_javagateway/**'
-      - 'molecule/zabbix_javagateway/**'
-      - 'molecule/requirements.txt'
-      - '.github/workflows/javagateway.yml'
+      - "roles/zabbix_javagateway/**"
+      - "molecule/zabbix_javagateway/**"
+      - "molecule/requirements.txt"
+      - ".github/workflows/javagateway.yml"
 jobs:
   molecule:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
-        molecule_distro:
-          - container: centos
-            image: geerlingguy/docker-centos8-ansible:latest
-          - container: ubuntu
-            image: geerlingguy/docker-ubuntu2004-ansible
-          - container: debian
-            image: geerlingguy/docker-debian10-ansible
+        container:
+          - rockylinux8
+          - centos7
+          - ubuntu2204
+          - ubuntu2004
+          - ubuntu1804
+          - debian11
+          - debian10
+        version:
+          - v62
+          - v60
+          - v50
         collection_role:
           - zabbix_javagateway
     steps:
@@ -50,10 +55,10 @@ jobs:
       - name: Install the collection
         run: ansible-galaxy collection install $COLLECTION_FILE
 
-      - name: Run role tests
+      - name: Run server role tests
         run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.molecule_distro.container }}
-          MY_MOLECULE_IMAGE=${{ matrix.molecule_distro.image }}
-          MY_MOLECULE_GROUP=${{ matrix.molecule_distro.group }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.molecule_distro.command }}
+          MY_MOLECULE_CONTAINER=${{ matrix.container }}
+          MY_MOLECULE_IMAGE=${{ matrix.container }}
+          MY_MOLECULE_VERSION=${{ matrix.version }}
+          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
           molecule test -s ${{ matrix.collection_role }}

--- a/changelogs/fragments/796-Jave-Gateway-Rework.yml
+++ b/changelogs/fragments/796-Jave-Gateway-Rework.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+  - zabbix_javagateway - Removed support for all versions older than 5.0
+  - zabbix_javagateway -  Removed support for EOL operating systems
+  - zabbix_javagateway - Replaced zabbix_version variable with zabbix_javagateway_version

--- a/changelogs/fragments/javagateway.yml
+++ b/changelogs/fragments/javagateway.yml
@@ -1,7 +1,0 @@
-minor_changes:
-  - github workflow - Updated workflow files to checked against all supported combinations
-  - documentation - Updated role documentation to reflect changes
-breaking_changes:
-  - Zabbix < 5.0 - Removed support for all versions older than 5.0
-  - EOL Operating Systems - Removed support for EOL operating systems
-  - zabbix_server - Replaced zabbix_version variable with zabbix_javagateway_version

--- a/changelogs/fragments/javagateway.yml
+++ b/changelogs/fragments/javagateway.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - github workflow - Updated workflow files to checked against all supported combinations
+  - documentation - Updated role documentation to reflect changes
+breaking_changes:
+  - Zabbix < 5.0 - Removed support for all versions older than 5.0
+  - EOL Operating Systems - Removed support for EOL operating systems
+  - zabbix_server - Replaced zabbix_version variable with zabbix_javagateway_version

--- a/docs/ZABBIX_JAVAGATEWAY_ROLE.md
+++ b/docs/ZABBIX_JAVAGATEWAY_ROLE.md
@@ -35,24 +35,15 @@ Please send Pull Requests or suggestions when you want to use this role for othe
 
 See the following list of supported Operating systems with the Zabbix releases.
 
-| Zabbix              | 5.2 | 5.0 | 4.4 | 4.0 (LTS) | 3.0 (LTS) |
-|---------------------|-----|-----|-----|-----------|-----------|
-| Red Hat Fam 8       |  V  |  V  | V   |           |           |
-| Red Hat Fam 7       |  V  |  V  | V   | V         | V         |
-| Red Hat Fam 6       |  V  |  V  |     |           | V         |
-| Red Hat Fam 5       |  V  |  V  |     |           | V         |
-| Fedora              |     |     | V   | V         |           |
-| Ubuntu 20.04 focal  |  V  |  V  |     | V         |           |
-| Ubuntu 19.10 eoan   |     |     |     |           |           |
-| Ubuntu 18.04 bionic |  V  |  V  | V   | V         |           |
-| Ubuntu 16.04 xenial |  V  |  V  | V   | V         |           |
-| Ubuntu 14.04 trusty |  V  |  V  | V   | V         | V         |
-| Debian 10 buster    |  V  |  V  | V   |           |           |
-| Debian 9 stretch    |  V  |  V  | V   | V         |           |
-| Debian 8 jessie     |  V  |  V  | V   | V         | V         |
-| Debian 7 wheezy     |     |     |     | V         | V         |
-| macOS 10.15         |     |     | V   | V         |           |
-| macOS 10.14         |     |     | V   | V         |           |
+| Zabbix              | 6.2 | 6.0 (LTS) | 5.0 (LTS) | 
+|---------------------|-----|-----------|-----------|
+| Red Hat Fam 8       |  V  |  V        |  V        |
+| Red Hat Fam 7       |  V  |  V        |  V        |
+| Ubuntu 22.04 jammy  |  V  |  V        |  V        |
+| Ubuntu 20.04 focal  |  V  |  V        |  V        |
+| Ubuntu 18.04 bionic |  V  |  V        |  V        |
+| Debian 11 bullseye  |  V  |  V        |  V        |
+| Debian 10 buster    |  V  |  V        |  V        |
 
 # Role Variables
 
@@ -62,7 +53,7 @@ The following is an overview of all available configuration default for this rol
 
 ### Overall Zabbix
 
-* `zabbix_javagateway_version`: This is the version of zabbix. Default: 5.2. Can be overridden to 5.0, 4.4, 4.0, 3.4, 3.2, 3.0, 2.4, or 2.2. Previously the variable `zabbix_version` was used directly but it could cause [some inconvenience](https://github.com/dj-wasabi/ansible-zabbix-agent/pull/303). That variable is maintained by retrocompativility.
+* `zabbix_javagateway_version`: This is the version of zabbix. Default: The highest supported version for the operating system. Can be overridden to 6.2, 6.0, or 5.0.
 * `zabbix_repo`: Default: `zabbix`
   * `epel`: install agent from EPEL repo
   * `zabbix`: (default) install agent from Zabbix repo

--- a/molecule/zabbix_javagateway/molecule.yml
+++ b/molecule/zabbix_javagateway/molecule.yml
@@ -3,15 +3,17 @@ driver:
   name: docker
 
 platforms:
-  - name: zabbix-javagateway-${MY_MOLECULE_CONTAINER:-centos}
-    image: ${MY_MOLECULE_IMAGE:-"geerlingguy/docker-centos8-ansible"}
-    command: ${MY_MOLECULE_DOCKER_COMMAND:-""}
+  - name: zabbix-server-${MY_MOLECULE_CONTAINER:-centos}
+    image: geerlingguy/docker-${MY_MOLECULE_IMAGE:-"centos8"}-ansible:latest
     privileged: true
     pre_build_image: true
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
     networks:
       - name: zabbix
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    groups:
+      - ${MY_MOLECULE_VERSION:-v62}
 
 provisioner:
   name: ansible
@@ -20,6 +22,14 @@ provisioner:
   env:
     ANSIBLE_COLLECTIONS_PATHS: $HOME/.ansible/collections/ansible_collections/community/zabbix
     ANSIBLE_ROLES_PATH: $HOME/.ansible/collections/ansible_collections/community/zabbix/roles
+  inventory:
+    group_vars:
+      v62:
+        zabbix_server_version: 6.2
+      v60:
+        zabbix_server_version: 6.0
+      v50:
+        zabbix_server_version: 5.0
 
 verifier:
   name: testinfra

--- a/molecule/zabbix_javagateway/molecule.yml
+++ b/molecule/zabbix_javagateway/molecule.yml
@@ -25,11 +25,11 @@ provisioner:
   inventory:
     group_vars:
       v62:
-        zabbix_server_version: 6.2
+        zabbix_javagateway_version: 6.2
       v60:
-        zabbix_server_version: 6.0
+        zabbix_javagateway_version: 6.0
       v50:
-        zabbix_server_version: 5.0
+        zabbix_javagateway_version: 5.0
 
 verifier:
   name: testinfra

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -1,10 +1,8 @@
 ---
 # defaults file for zabbix_javagateway
 
-zabbix_javagateway_version: 6.2
-zabbix_version: "{{ zabbix_javagateway_version }}"
+zabbix_javagateway_version:
 zabbix_javagateway_package_state: present
-zabbix_selinux: false
 zabbix_repo: zabbix
 zabbix_repo_yum_schema: https
 zabbix_java_gateway_conf_mode: "0644"

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -1,11 +1,28 @@
 ---
-
-- name: "Include Zabbix gpg ids"
+- name: "Debian | Include Zabbix gpg ids"
   include_vars: zabbix.yml
 
-- name: "Set some variables"
+- name: "Debian | Set some variables"
   set_fact:
     zabbix_short_version: "{{ zabbix_javagateway_version | regex_replace('\\.', '') }}"
+
+- name: "Debian | Set some variables"
+  set_fact:
+    zabbix_javagateway_apt_repository:
+      - "http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/{{ ansible_distribution.lower() }}/"
+      - "{{ ansible_distribution_release }}"
+      - "main"
+  when:
+    - ansible_machine != "aarch64"
+
+- name: "Debian | Set some variables"
+  set_fact:
+    zabbix_javagateway_apt_repository:
+      - "http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/{{ ansible_distribution.lower() }}-arm64/"
+      - "{{ ansible_distribution_release }}"
+      - "main"
+  when:
+    - ansible_machine == "aarch64"
 
 - name: "Debian | Install gpg key"
   apt_key:
@@ -15,63 +32,12 @@
 
 - name: "Debian | Installing repository Debian"
   apt_repository:
-    repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/debian/ {{ ansible_distribution_release }} main"
+    repo: "{{ item }} {{ zabbix_javagateway_apt_repository | join(' ') }}"
     state: present
   become: true
-  when:
-    - ansible_distribution == "Debian"
-    - zabbix_repo == "zabbix"
-
-- name: "Debian | Installing repository Debian"
-  apt_repository:
-    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/debian/ {{ ansible_distribution_release }} main"
-    state: present
-  become: true
-  when:
-    - ansible_distribution == "Debian"
-    - ansible_machine == "aarch64"
-    - zabbix_repo == "zabbix"
-
-- name: "Debian | Installing repository Ubuntu"
-  apt_repository:
-    repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/ubuntu-arm64/ {{ ansible_distribution_release }} main"
-    state: present
-  become: true
-  when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_machine == "aarch64"
-    - zabbix_repo == "zabbix"
-
-
-- name: "Debian | Installing repository Ubuntu"
-  apt_repository:
-    repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/ubuntu/ {{ ansible_distribution_release }} main"
-    state: present
-  become: true
-  when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_machine != "aarch64"
-    - zabbix_repo == "zabbix"
-
-- name: "Debian | Installing repository Ubuntu"
-  apt_repository:
-    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/ubuntu-arm64/ {{ ansible_distribution_release }} main"
-    state: present
-  become: true
-  when:
-    - ansible_distribution == "Ubuntu"
-    - ansible_machine == "aarch64"
-    - zabbix_repo == "zabbix"
-
-
-- name: "Debian | Installing repository Ubuntu"
-  apt_repository:
-    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/ubuntu/ {{ ansible_distribution_release }} main"
-    state: present
-  become: true
-  when:
-    - ansible_distribution == "Ubuntu"
-    - zabbix_repo == "zabbix"
+  with_items:
+    - deb-src
+    - deb
 
 - name: "Debian | Installing zabbix-java-gateway"
   apt:
@@ -87,7 +53,7 @@
   until: zabbix_java_gateway_install is succeeded
   become: true
 
-- name: "Make sure Zabbix Java Gateway is not yet running"
+- name: "Debian | Make sure Zabbix Java Gateway is not yet running"
   systemd:
     name: zabbix-java-gateway
     state: stopped

--- a/roles/zabbix_javagateway/tasks/main.yml
+++ b/roles/zabbix_javagateway/tasks/main.yml
@@ -1,32 +1,43 @@
 ---
-# tasks file for zabbix_proxy
+# tasks file for zabbix_javagateway
+
+- name: Include OS-specific variables
+  include_vars: "{{ ansible_os_family }}.yml"
+
+- name: Determine Latest Supported Zabbix Version
+  set_fact:
+    zabbix_javagateway_version: "{{ zabbix_valid_javagateway_versions[ansible_distribution_major_version][0] | default(6.2) }}"
+  when: zabbix_server_version is not defined
+
+- name: Set More Variables
+  set_fact:
+    zabbix_valid_version: "{{ zabbix_javagateway_version|float in zabbix_valid_javagateway_versions[ansible_distribution_major_version] }}"
+
+- name: Stopping Install of Invalid Version
+  fail:
+    msg: Zabbix version {{ zabbix_javagateway_version }} is not supported on {{ ansible_distribution }} {{ ansible_distribution_major_version }}
+  when: not zabbix_valid_version
 
 - name: "Install the correct repository"
-  include: "RedHat.yml"
-  when:
-    - ansible_os_family == "RedHat"
+  include: "{{ ansible_os_family }}.yml"
 
-- name: "Install the correct repository"
-  include: "Debian.yml"
-  when:
-    - ansible_os_family == "Debian"
+- name: "Configure Service"
+  block:
+    - name: "Place systemd unit file"
+      copy:
+        src: systemd.service
+        dest: /etc/systemd/system/zabbix-java-gateway.service
+        mode: "0644"
+      register: systemd_state
 
-- name: "Place systemd unit file"
-  copy:
-    src: systemd.service
-    dest: /etc/systemd/system/zabbix-java-gateway.service
-    mode: '0644'
-  register: systemd_state
+    - name: "Reload systemd"
+      shell: systemctl daemon-reload
+      when:
+        - systemd_state.changed
+      tags:
+        - skip_ansible_lint
   when:
-    - zabbix_version is version('5.4', '<')
-
-- name: "Reload systemd"
-  shell: systemctl daemon-reload
-  when:
-    - zabbix_version is version('5.4', '<')
-    - systemd_state.changed
-  tags:
-    - skip_ansible_lint
+    - zabbix_javagateway_version is version('6.0', '<')
 
 - name: "Configure zabbix-proxy"
   template:

--- a/roles/zabbix_javagateway/templates/zabbix_java_gateway.conf.j2
+++ b/roles/zabbix_javagateway/templates/zabbix_java_gateway.conf.j2
@@ -4,7 +4,7 @@
 
 # This configuration file is "minimalized", which means all the original comments 
 # are removed. The full documentation for your Zabbix Java Gateway can be found here:
-# https://www.zabbix.com/documentation/{{ zabbix_version }}/en/manual/concepts/java
+# https://www.zabbix.com/documentation/{{ zabbix_javagateway_version }}/en/manual/concepts/java
 
 LISTEN_IP={{ zabbix_javagateway_listenip }}
 LISTEN_PORT={{ zabbix_javagateway_listenport }}

--- a/roles/zabbix_javagateway/vars/Debian.yml
+++ b/roles/zabbix_javagateway/vars/Debian.yml
@@ -1,6 +1,23 @@
----
-apache_user: www-data
-apache_group: www-data
-apache_log: apache2
-
-mysql_create_dir: ''
+zabbix_valid_javagateway_versions:
+  # Debian
+  "11":
+    - 6.2
+    - 6.0
+    - 5.0
+  "10":
+    - 6.2
+    - 6.0
+    - 5.0
+  # Ubuntu
+  "22":
+    - 6.2
+    - 6.0
+    - 5.0
+  "20":
+    - 6.2
+    - 6.0
+    - 5.0
+  "18":
+    - 6.2
+    - 6.0
+    - 5.0

--- a/roles/zabbix_javagateway/vars/RedHat.yml
+++ b/roles/zabbix_javagateway/vars/RedHat.yml
@@ -1,6 +1,13 @@
 ---
-apache_user: apache
-apache_group: apache
-apache_log: httpd
-
-mysql_create_dir: create/
+zabbix_valid_javagateway_versions:
+  "9":
+    - 6.2
+    - 6.0
+  "8":
+    - 6.2
+    - 6.0
+    - 5.0
+  "7":
+    - 6.2
+    - 6.0
+    - 5.0

--- a/roles/zabbix_javagateway/vars/zabbix.yml
+++ b/roles/zabbix_javagateway/vars/zabbix.yml
@@ -9,13 +9,13 @@ sign_keys:
       sign_key: E709712C
     focal:
       sign_key: E709712C
-    jammy:
-      sign_key: E709712C
     bionic:
       sign_key: E709712C
     xenial:
       sign_key: E709712C
     trusty:
+      sign_key: E709712C
+    jammy:
       sign_key: E709712C
   "60":
     bullseye:
@@ -26,57 +26,16 @@ sign_keys:
       sign_key: E709712C
     focal:
       sign_key: E709712C
+    bionic:
+      sign_key: E709712C
+    xenial:
+      sign_key: E709712C
+    trusty:
+      sign_key: E709712C
     jammy:
       sign_key: E709712C
-    bionic:
-      sign_key: E709712C
-    xenial:
-      sign_key: E709712C
-    trusty:
-      sign_key: E709712C
-  "54":
-    bullseye:
-      sign_key: E709712C
-    buster:
-      sign_key: E709712C
-    jessie:
-      sign_key: E709712C
-    stretch:
-      sign_key: E709712C
-    focal:
-      sign_key: E709712C
-    bionic:
-      sign_key: E709712C
-    xenial:
-      sign_key: E709712C
-    trusty:
-      sign_key: E709712C
-    tricia:
-      sign_key: E709712C
-  "52":
-    # bullseye: not available upstream
-    buster:
-      sign_key: E709712C
-    jessie:
-      sign_key: E709712C
-    stretch:
-      sign_key: E709712C
-    focal:
-      sign_key: E709712C
-    bionic:
-      sign_key: E709712C
-    xenial:
-      sign_key: E709712C
-    trusty:
-      sign_key: E709712C
-    tricia:
-      sign_key: E709712C
   "50":
-    bullseye:
-      sign_key: E709712C
     buster:
-      sign_key: E709712C
-    jessie:
       sign_key: E709712C
     stretch:
       sign_key: E709712C
@@ -90,152 +49,5 @@ sign_keys:
       sign_key: E709712C
     tricia:
       sign_key: E709712C
-  "44":
-    buster:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
-    stretch:
-      sign_key: A14FE591
-    focal:
-      sign_key: A14FE591
-    eoan:
-      sign_key: A14FE591
-    cosmic:
-      sign_key: A14FE591
-    bionic:
-      sign_key: A14FE591
-    sonya:
-      sign_key: A14FE591
-    serena:
-      sign_key: A14FE591
-    trusty:
-      sign_key: 79EA5ED4
-    xenial:
-      sign_key: E709712C
-  "42":
-    buster:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
-    stretch:
-      sign_key: A14FE591
-    eoan:
-      sign_key: A14FE591
-    cosmic:
-      sign_key: A14FE591
-    bionic:
-      sign_key: A14FE591
-    sonya:
-      sign_key: A14FE591
-    serena:
-      sign_key: A14FE591
-    trusty:
-      sign_key: 79EA5ED4
-    xenial:
-      sign_key: E709712C
-  "40":
     bullseye:
-      sign_key: A14FE591
-    buster:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
-    stretch:
-      sign_key: A14FE591
-    focal:
-      sign_key: A14FE591
-    bionic:
-      sign_key: A14FE591
-    sonya:
-      sign_key: A14FE591
-    serena:
-      sign_key: A14FE591
-    trusty:
-      sign_key: 79EA5ED4
-    xenial:
       sign_key: E709712C
-  "34":
-    jessie:
-      sign_key: 79EA5ED4
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: A14FE591
-    bionic:
-      sign_key: A14FE591
-    sonya:
-      sign_key: A14FE591
-    serena:
-      sign_key: A14FE591
-    trusty:
-      sign_key: 79EA5ED4
-    xenial:
-      sign_key: E709712C
-  "32":
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: 79EA5ED4
-    bionic:
-      sign_key: A14FE591
-    sonya:
-      sign_key: 79EA5ED4
-    serena:
-      sign_key: 79EA5ED4
-    trusty:
-      sign_key: 79EA5ED4
-    xenial:
-      sign_key: E709712C
-  "30":
-    buster:
-      sign_key: A14FE591
-    jessie:
-      sign_key: 79EA5ED4
-    stretch:
-      sign_key: A14FE591
-    wheezy:
-      sign_key: 79EA5ED4
-    bionic:
-      sign_key: A14FE591
-    trusty:
-      sign_key: 79EA5ED4
-    xenial:
-      sign_key: E709712C
-  "24":
-    jessie:
-      sign_key: 79EA5ED4
-    wheezy:
-      sign_key: 79EA5ED4
-    precise:
-      sign_key: 79EA5ED4
-    trusty:
-      sign_key: 79EA5ED4
-  "22":
-    squeeze:
-      sign_key: 79EA5ED4
-    wheezy:
-      sign_key: 79EA5ED4
-    precise:
-      sign_key: 79EA5ED4
-    trusty:
-      sign_key: 79EA5ED4
-    lucid:
-      sign_key: 79EA5ED4
-
-suse:
-  "openSUSE Leap":
-    "42":
-      name: server:monitoring
-      url: http://download.opensuse.org/repositories/server:/monitoring/openSUSE_Leap_{{ ansible_distribution_version }}/
-  "openSUSE":
-    "12":
-      name: server_monitoring
-      url: http://download.opensuse.org/repositories/server:/monitoring/openSUSE_{{ ansible_distribution_version }}
-  "SLES":
-    "11":
-      name: server_monitoring
-      url: http://download.opensuse.org/repositories/server:/monitoring/SLE_11_SP3/
-    "12":
-      name: server_monitoring
-      url: http://download.opensuse.org/repositories/server:/monitoring/SLE_12_SP3/


### PR DESCRIPTION
##### SUMMARY
Initial changes to java gateway role for 2.0.0

##### COMPONENT NAME
Java Gateway Role

##### ADDITIONAL INFORMATION
Major Changes include:

- Updating Molecule matrix to test all OS, with all versions, and all databases (#777 )
- Updated documentation
- Removed support for anything < 5.0 (#766)
- Cleaned up handling of variables between OSs
- Added Ubuntu 22.04 (#763)
- Added Support for Debian 11 (#764)
- Removed support for EOL operating systems
- Cleaned up some variables (#768 )
