### PR TITLE
Zabbix API doesn't accept IPv6 addresses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,6 @@ Bugfixes
 - zabbix_host - fixed idempotency of the module when hostmacros or snmp interfaces are used
 - zabbix_script - fix compatibility with Zabbix <5.4.
 - zabbix_script - should no longer fail when description is not set
-- zabbix_agent - fix Windows script attempting to register host with IPv6 address
 
 v1.7.0
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Bugfixes
 - zabbix_host - fixed idempotency of the module when hostmacros or snmp interfaces are used
 - zabbix_script - fix compatibility with Zabbix <5.4.
 - zabbix_script - should no longer fail when description is not set
+- zabbix_agent - fix Windows script attempting to register host with IPv6 address
 
 v1.7.0
 ======

--- a/changelogs/fragments/795-zbx-agent-win-ipv6.yml
+++ b/changelogs/fragments/795-zbx-agent-win-ipv6.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_agent - Filter IPv6 addresses from list of IP as Zabbix host creation expects IPv4

--- a/roles/zabbix_agent/tasks/Windows_conf.yml
+++ b/roles/zabbix_agent/tasks/Windows_conf.yml
@@ -2,7 +2,7 @@
 
 - name: "Set default ip address for zabbix_agent_ip"
   set_fact:
-    zabbix_agent_ip: "{{ hostvars[inventory_hostname]['ansible_ip_addresses'][0] }}"
+    zabbix_agent_ip: "{{ hostvars[inventory_hostname]['ansible_ip_addresses'] | ansible.utils.ipv4 | first }}"
   when:
     - zabbix_agent_ip is not defined
     - "'ansible_ip_addresses' in hostvars[inventory_hostname]"


### PR DESCRIPTION
##### SUMMARY
Creating a new host with an IPv6 address returns an error on Zabbix (invalid IP). Limiting the output to the first IPv4 address.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.zabbix.zabbix_agent

##### ADDITIONAL INFORMATION
Order of IP addresses is not guaranteed on Windows:
```
    "hostvars[inventory_hostname]['ansible_ip_addresses']": [
        "fe80::xxxx:xxxx:xxxx:xxxx%x",
        "10.0.0.1"
    ]
```
Resulting in
`"msg": "Failed to create host myhost: ('Error -32602: Invalid params., Invalid IP address \"fe80::xxxx:xxxx:xxxx:xxxx%x\"`