### PR TITLE
zabbix_template module: correct last merge

### DIFF
--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -206,11 +206,7 @@ EXAMPLES = r'''
     state: present
 
 - name: Add tags to the existing Zabbix template
-  local_action:
-    module: community.zabbix.zabbix_template
-    server_url: http://127.0.0.1
-    login_user: username
-    login_password: password
+  community.zabbix.zabbix_template:
     template_name: Template
     tags:
       - tag: class

--- a/tests/integration/targets/test_zabbix_template/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template/tasks/main.yml
@@ -174,9 +174,6 @@
 
 - name: Add tags to Zabbix template.
   zabbix_template:
-    server_url: "{{ zabbix_api_server_url }}"
-    login_user: "{{ zabbix_api_login_user }}"
-    login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleHost
     template_groups:
       - 'Templates'
@@ -204,9 +201,6 @@
 
 - name: Add tags to Zabbix template (idempotency check).
   zabbix_template:
-    server_url: "{{ zabbix_api_server_url }}"
-    login_user: "{{ zabbix_api_login_user }}"
-    login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleHost
     template_groups:
       - 'Templates'
@@ -234,9 +228,6 @@
 
 - name: Remove tags from Zabbix template.
   zabbix_template:
-    server_url: "{{ zabbix_api_server_url }}"
-    login_user: "{{ zabbix_api_login_user }}"
-    login_password: "{{ zabbix_api_login_pass }}"
     template_name: ExampleHost
     template_groups:
       - 'Templates'


### PR DESCRIPTION
…i instead of zabbix-api.

##### SUMMARY
The latest PR https://github.com/ansible-collections/community.zabbix/pull/800  to bring new feature to zabbix_template module did not consider that we moved to httpapi as default connection

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_template module