### PR TITLE
First attempt at User Role plugin

### DIFF
--- a/plugins/modules/zabbix_user_role.py
+++ b/plugins/modules/zabbix_user_role.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r'''
 module: zabbix_user_role
 short_description: Adds or removes zabbix roles
 author:
-    - Martin van Es
+    - Martin van Es (@mrvanes)
 description:
     - This module adds or removes zabbix roles
 requirements:
@@ -145,7 +145,7 @@ def main():
 
     argument_spec = zabbix_utils.zabbix_common_argument_spec()
     argument_spec.update(dict(
-        state=dict(type='str', required=False, default='present'),
+        state=dict(type='str', required=False, default='present', choices=['present', 'absent']),
         name=dict(type='str', required=True),
         type=dict(type='str', required=False, choices=["User", "Admin", "Super Admin"], default='User'),
         rules=dict(type='dict', required=False, default={}),

--- a/plugins/modules/zabbix_user_role.py
+++ b/plugins/modules/zabbix_user_role.py
@@ -153,8 +153,9 @@ def main():
     state = module.params['state']
     name = module.params['name']
     type = zabbix_utils.helper_to_numeric_value(
-        ['user', 'admin', 'auper admin'], module.params['type'].lower()
+        ['', 'user', 'admin', 'auper admin'], module.params['type'].lower()
     )
+    # raise Exception(f"type: {type}")
     rules = module.params['rules']
 
     user_role = UserRole(module)

--- a/plugins/modules/zabbix_user_role.py
+++ b/plugins/modules/zabbix_user_role.py
@@ -155,7 +155,6 @@ def main():
     type = zabbix_utils.helper_to_numeric_value(
         ['', 'user', 'admin', 'auper admin'], module.params['type'].lower()
     )
-    # raise Exception(f"type: {type}")
     rules = module.params['rules']
 
     user_role = UserRole(module)

--- a/plugins/modules/zabbix_user_role.py
+++ b/plugins/modules/zabbix_user_role.py
@@ -4,12 +4,11 @@
 # Copyright: (c) 2022, mrvanes
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-
 DOCUMENTATION = r'''
----
 module: zabbix_user_role
 short_description: Adds or removes zabbix roles
 author:
@@ -18,18 +17,34 @@ description:
     - This module adds or removes zabbix roles
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.4"
 options:
     state:
+        description:
+            - State of the user_role.
+            - On C(present), it will create if user_role does not exist or update the user_role if the associated data is different.
+            - On C(absent) will remove a user_role if it exists.
+        default: 'present'
+        choices: ['present', 'absent']
+        type: str
+        required: false
     name:
-        description: Name of the role to be processed
+        description:
+            - Name of the role to be processed
+        type: str
+        required: true
     type:
         description:
-            - User (default)
-            - Admin
-            - Super admin
+            - User type.
+        choices: ["User", "Admin", "Super Admin"]
+        default: "User"
+        type: str
+        required: false
     rules:
-        - description: Rules set as defined in https://www.zabbix.com/documentation/current/en/manual/api/reference/role/object#role-rules
+        description:
+            - Rules set as defined in https://www.zabbix.com/documentation/current/en/manual/api/reference/role/object#role-rules
+        default: {}
+        type: dict
+        required: false
 extends_documentation_fragment:
 - community.zabbix.zabbix
 '''
@@ -132,7 +147,7 @@ def main():
     argument_spec.update(dict(
         state=dict(type='str', required=False, default='present'),
         name=dict(type='str', required=True),
-        type=dict(type='str', required=False, default='User'),
+        type=dict(type='str', required=False, choices=["User", "Admin", "Super Admin"], default='User'),
         rules=dict(type='dict', required=False, default={}),
     ))
 

--- a/plugins/modules/zabbix_user_role.py
+++ b/plugins/modules/zabbix_user_role.py
@@ -1,0 +1,186 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, mrvanes
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: zabbix_role
+https://www.zabbix.com/documentation/current/en/manual/api/reference/role
+https://www.zabbix.com/documentation/current/en/manual/api/reference/role/create
+
+short_description: Adds or removes zabbix roles
+
+description: This module adds or removes zabbix roles
+
+options:
+    server_url: http://localhost/zabbix
+    login_user: username
+    login_password: password
+    state: exact
+    name: Operators
+      The name of the role
+    type: 1
+      https://www.zabbix.com/documentation/current/en/manual/api/reference/role/object#role
+    rules:
+      https://www.zabbix.com/documentation/current/en/manual/api/reference/role/object#role-rules
+
+author:
+    - Martin van Es
+'''
+
+EXAMPLES = r'''
+# Creat role Operators with ui elements monitoring.hosts
+# disabled and monitoring.maps enabled
+
+- name: Create Zabbix role
+  local_action:
+    module: zabbix_role
+    server_url: http://zabbix.scz-vm.net/
+    login_user: username
+    login_password: login_password
+    state: present
+    name: Operators
+    type: 1
+    rules:
+      ui.default_access: 0
+      ui:
+        - name: "monitoring.hosts"
+          status: 0
+        - name: "monitoring.maps"
+          status: 1
+'''
+
+RETURN = r'''
+# Return values
+msg:
+    description: The result of the action
+    type: str
+    returned: always
+    sample: 'No action'
+changed:
+    description: The consequence of the action
+    type: bool
+    returned: always
+    sample: False
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.zabbix.plugins.module_utils.version import LooseVersion
+
+from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
+import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
+
+
+class UserRole(ZabbixBase):
+    def __find_val(self, outval, inval):
+        if outval == str(inval):
+            return True
+        return False
+
+    def __find_list(self, outval, inval):
+        if set(outval) == set(inval):
+            return True
+        return False
+
+    def __find_dict(self, outval, inval):
+        for out in outval:
+            m = True
+            for k, v in inval.items():
+                if out[k] == str(v):
+                    continue
+                else:
+                    m = False
+            if m:
+                break
+        return m
+
+    def is_part_of(self, inp, out):
+        verdict = True
+        for rule, value in inp.items():
+            if not isinstance(value, list):
+                verdict = verdict and self.__find_val(out.get(rule, ''), value)
+            else:
+                if len(value):
+                    if not isinstance(value[0], dict):
+                        verdict = verdict and self.__find_list(out.get(rule, []), value)
+                    else:
+                        for v in value:
+                            verdict = verdict and self.__find_dict(out.get(rule, {}), v)
+                else:
+                    verdict = verdict and self.__find_list(rule, value)
+        return verdict
+
+    def get_user_role(self, name):
+        result = self._zapi.role.get({
+            "output": "extend",
+            "selectRules": "extend",
+            "filter": {"name": name}
+        })
+        return result
+
+
+def main():
+    msg = "No action"
+    changed = False
+
+    argument_spec = zabbix_utils.zabbix_common_argument_spec()
+    argument_spec.update(dict(
+        server_url=dict(type='str', required=True),
+        login_user=dict(type='str', required=True),
+        login_password=dict(type='str', required=True, no_log=True),
+        state=dict(type='str', required=False, default='present'),
+        name=dict(type='str', required=True),
+        type=dict(type='int', required=False, default=1),
+        rules=dict(type='dict', required=True),
+    ))
+
+    # the AnsibleModule object
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    state = module.params['state']
+    name = module.params['name']
+    type = module.params['type']
+    rules = module.params['rules']
+
+    user_role = UserRole(module)
+
+    result = user_role.get_user_role(name)
+    if result:
+        if len(result) == 1:
+            role = result[0]
+            if role['readonly'] != 1:
+                roleid = role['roleid']
+                if state == 'absent':
+                    result = user_role._zapi.role.delete([f"{roleid}"])
+                    changed = True
+                    msg = "Role deleted"
+                else:
+                    if not user_role.is_part_of(rules, role['rules']):
+                        result = user_role._zapi.role.update({"roleid": roleid, "rules": rules})
+                        changed = True
+                        msg = "Role updated"
+        else:
+            module.fail_json(msg='Too many role matches')
+    else:
+        user_role._zapi.role.create({
+            "name": name,
+            "type": type,
+            "rules": rules
+        })
+        changed = True
+        msg = "Role created"
+
+    module.exit_json(msg=msg, changed=changed)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/zabbix_user_role.py
+++ b/plugins/modules/zabbix_user_role.py
@@ -56,9 +56,6 @@ EXAMPLES = r'''
 - name: Create Zabbix role
   local_action:
     module: zabbix_role
-    server_url: http://zabbix.scz-vm.net/
-    login_user: username
-    login_password: login_password
     state: present
     name: Operators
     type: User

--- a/plugins/modules/zabbix_user_role.py
+++ b/plugins/modules/zabbix_user_role.py
@@ -143,6 +143,13 @@ def main():
         supports_check_mode=True
     )
 
+    zabbix_utils.require_creds_params(module)
+
+    for p in ['server_url', 'login_user', 'login_password', 'timeout', 'validate_certs']:
+        if p in module.params:
+            module.warn('Option "%s" is deprecated with the move to httpapi connection '
+                        'and will be removed in the next release' % p)
+
     state = module.params['state']
     name = module.params['name']
     type = zabbix_utils.helper_to_numeric_value(

--- a/plugins/modules/zabbix_user_role.py
+++ b/plugins/modules/zabbix_user_role.py
@@ -10,28 +10,28 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: zabbix_role
-https://www.zabbix.com/documentation/current/en/manual/api/reference/role
-https://www.zabbix.com/documentation/current/en/manual/api/reference/role/create
-
+module: zabbix_user_role
 short_description: Adds or removes zabbix roles
-
-description: This module adds or removes zabbix roles
-
-options:
-    server_url: http://localhost/zabbix
-    login_user: username
-    login_password: password
-    state: exact
-    name: Operators
-      The name of the role
-    type: 1
-      https://www.zabbix.com/documentation/current/en/manual/api/reference/role/object#role
-    rules:
-      https://www.zabbix.com/documentation/current/en/manual/api/reference/role/object#role-rules
-
 author:
     - Martin van Es
+description:
+    - This module adds or removes zabbix roles
+requirements:
+    - "python >= 2.6"
+    - "zabbix-api >= 0.5.4"
+options:
+    state:
+    name:
+        description: Name of the role to be processed
+    type:
+        description:
+            - User (default)
+            - Admin
+            - Super admin
+    rules:
+        - description: Rules set as defined in https://www.zabbix.com/documentation/current/en/manual/api/reference/role/object#role-rules
+extends_documentation_fragment:
+- community.zabbix.zabbix
 '''
 
 EXAMPLES = r'''
@@ -46,7 +46,7 @@ EXAMPLES = r'''
     login_password: login_password
     state: present
     name: Operators
-    type: 1
+    type: User
     rules:
       ui.default_access: 0
       ui:
@@ -133,8 +133,8 @@ def main():
     argument_spec.update(dict(
         state=dict(type='str', required=False, default='present'),
         name=dict(type='str', required=True),
-        type=dict(type='int', required=False, default=1),
-        rules=dict(type='dict', required=True),
+        type=dict(type='str', required=False, default='User'),
+        rules=dict(type='dict', required=False, default={}),
     ))
 
     # the AnsibleModule object
@@ -145,7 +145,9 @@ def main():
 
     state = module.params['state']
     name = module.params['name']
-    type = module.params['type']
+    type = zabbix_utils.helper_to_numeric_value(
+        ['user', 'admin', 'auper admin'], module.params['type'].lower()
+    )
     rules = module.params['rules']
 
     user_role = UserRole(module)

--- a/plugins/modules/zabbix_user_role.py
+++ b/plugins/modules/zabbix_user_role.py
@@ -131,9 +131,6 @@ def main():
 
     argument_spec = zabbix_utils.zabbix_common_argument_spec()
     argument_spec.update(dict(
-        server_url=dict(type='str', required=True),
-        login_user=dict(type='str', required=True),
-        login_password=dict(type='str', required=True, no_log=True),
         state=dict(type='str', required=False, default='present'),
         name=dict(type='str', required=True),
         type=dict(type='int', required=False, default=1),

--- a/plugins/modules/zabbix_user_role.py
+++ b/plugins/modules/zabbix_user_role.py
@@ -71,7 +71,6 @@ changed:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.zabbix.plugins.module_utils.version import LooseVersion
 
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
 import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils

--- a/tests/integration/targets/test_zabbix_user_role/meta/main.yml
+++ b/tests/integration/targets/test_zabbix_user_role/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_zabbix

--- a/tests/integration/targets/test_zabbix_user_role/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_user_role/tasks/main.yml
@@ -7,7 +7,7 @@
     login_password: "{{ zabbix_api_login_pass }}"
     state: present
     name: Operators
-    type: 1
+    type: User
     rules:
       ui.default_access: 0
       ui:
@@ -19,7 +19,7 @@
 
 - assert:
     that:
-      - create_zabbix_user_result.changed is sameas true
+      - create_zabbix_user_role_result.changed is sameas true
 
 # Check user role idempotency
 - name: test - Update a Zabbix role with same rules
@@ -29,7 +29,7 @@
     login_password: "{{ zabbix_api_login_pass }}"
     state: present
     name: Operators
-    type: 1
+    type: User
     rules:
       ui.default_access: 0
       ui:
@@ -41,7 +41,7 @@
 
 - assert:
     that:
-      - create_zabbix_user_result.changed is sameas false
+      - create_zabbix_user_role_result.changed is sameas false
 
 # Check user role change
 - name: test - Update a Zabbix role with new rules
@@ -51,7 +51,7 @@
     login_password: "{{ zabbix_api_login_pass }}"
     state: present
     name: Operators
-    type: 1
+    type: User
     rules:
       ui.default_access: 0
       ui:
@@ -63,7 +63,7 @@
 
 - assert:
     that:
-      - create_zabbix_user_result.changed is sameas true
+      - create_zabbix_user_role_result.changed is sameas true
 
 # Check user role remove
 - name: test - Remote Zabbix role
@@ -77,5 +77,5 @@
 
 - assert:
     that:
-      - create_zabbix_user_result.changed is sameas true
+      - create_zabbix_user_role_result.changed is sameas true
 

--- a/tests/integration/targets/test_zabbix_user_role/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_user_role/tasks/main.yml
@@ -23,9 +23,6 @@
     # Check user role idempotency
     - name: test - Update a Zabbix role with same rules
       zabbix_user_role:
-        server_url: "{{ zabbix_api_server_url }}"
-        login_user: "{{ zabbix_api_login_user }}"
-        login_password: "{{ zabbix_api_login_pass }}"
         state: present
         name: Operators
         type: User
@@ -45,9 +42,6 @@
     # Check user role change
     - name: test - Update a Zabbix role with new rules
       zabbix_user_role:
-        server_url: "{{ zabbix_api_server_url }}"
-        login_user: "{{ zabbix_api_login_user }}"
-        login_password: "{{ zabbix_api_login_pass }}"
         state: present
         name: Operators
         type: User
@@ -67,9 +61,6 @@
     # Check user role remove
     - name: test - Remote Zabbix role
       zabbix_user_role:
-        server_url: "{{ zabbix_api_server_url }}"
-        login_user: "{{ zabbix_api_login_user }}"
-        login_password: "{{ zabbix_api_login_pass }}"
         state: absent
         name: Operators
       register: create_zabbix_user_role_result

--- a/tests/integration/targets/test_zabbix_user_role/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_user_role/tasks/main.yml
@@ -4,9 +4,6 @@
   block:
     - name: test - Create a new Zabbix role
       zabbix_user_role:
-        server_url: "{{ zabbix_api_server_url }}"
-        login_user: "{{ zabbix_api_login_user }}"
-        login_password: "{{ zabbix_api_login_pass }}"
         state: present
         name: Operators
         type: User

--- a/tests/integration/targets/test_zabbix_user_role/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_user_role/tasks/main.yml
@@ -1,0 +1,81 @@
+---
+# New user role create test from here
+- name: test - Create a new Zabbix role
+  zabbix_user_role:
+    server_url: "{{ zabbix_api_server_url }}"
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    state: present
+    name: Operators
+    type: 1
+    rules:
+      ui.default_access: 0
+      ui:
+        - name: "monitoring.hosts"
+          status: 0
+        - name: "monitoring.maps"
+          status: 1
+  register: create_zabbix_user_role_result
+
+- assert:
+    that:
+      - create_zabbix_user_result.changed is sameas true
+
+# Check user role idempotency
+- name: test - Update a Zabbix role with same rules
+  zabbix_user_role:
+    server_url: "{{ zabbix_api_server_url }}"
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    state: present
+    name: Operators
+    type: 1
+    rules:
+      ui.default_access: 0
+      ui:
+        - name: "monitoring.hosts"
+          status: 0
+        - name: "monitoring.maps"
+          status: 1
+  register: create_zabbix_user_role_result
+
+- assert:
+    that:
+      - create_zabbix_user_result.changed is sameas false
+
+# Check user role change
+- name: test - Update a Zabbix role with new rules
+  zabbix_user_role:
+    server_url: "{{ zabbix_api_server_url }}"
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    state: present
+    name: Operators
+    type: 1
+    rules:
+      ui.default_access: 0
+      ui:
+        - name: "monitoring.hosts"
+          status: 1
+        - name: "monitoring.maps"
+          status: 0
+  register: create_zabbix_user_role_result
+
+- assert:
+    that:
+      - create_zabbix_user_result.changed is sameas true
+
+# Check user role remove
+- name: test - Remote Zabbix role
+  zabbix_user_role:
+    server_url: "{{ zabbix_api_server_url }}"
+    login_user: "{{ zabbix_api_login_user }}"
+    login_password: "{{ zabbix_api_login_pass }}"
+    state: absent
+    name: Operators
+  register: create_zabbix_user_role_result
+
+- assert:
+    that:
+      - create_zabbix_user_result.changed is sameas true
+

--- a/tests/integration/targets/test_zabbix_user_role/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_user_role/tasks/main.yml
@@ -1,81 +1,82 @@
 ---
-# New user role create test from here
-- name: test - Create a new Zabbix role
-  zabbix_user_role:
-    server_url: "{{ zabbix_api_server_url }}"
-    login_user: "{{ zabbix_api_login_user }}"
-    login_password: "{{ zabbix_api_login_pass }}"
-    state: present
-    name: Operators
-    type: User
-    rules:
-      ui.default_access: 0
-      ui:
-        - name: "monitoring.hosts"
-          status: 0
-        - name: "monitoring.maps"
-          status: 1
-  register: create_zabbix_user_role_result
+# New user role create test from here, only 6.0 and higher
+- when: zabbix_version is version('6.0', '>=')
+  block:
+    - name: test - Create a new Zabbix role
+      zabbix_user_role:
+        server_url: "{{ zabbix_api_server_url }}"
+        login_user: "{{ zabbix_api_login_user }}"
+        login_password: "{{ zabbix_api_login_pass }}"
+        state: present
+        name: Operators
+        type: User
+        rules:
+          ui.default_access: 0
+          ui:
+            - name: "monitoring.hosts"
+              status: 0
+            - name: "monitoring.maps"
+              status: 1
+      register: create_zabbix_user_role_result
 
-- assert:
-    that:
-      - create_zabbix_user_role_result.changed is sameas true
+    - assert:
+        that:
+          - create_zabbix_user_role_result.changed is sameas true
 
-# Check user role idempotency
-- name: test - Update a Zabbix role with same rules
-  zabbix_user_role:
-    server_url: "{{ zabbix_api_server_url }}"
-    login_user: "{{ zabbix_api_login_user }}"
-    login_password: "{{ zabbix_api_login_pass }}"
-    state: present
-    name: Operators
-    type: User
-    rules:
-      ui.default_access: 0
-      ui:
-        - name: "monitoring.hosts"
-          status: 0
-        - name: "monitoring.maps"
-          status: 1
-  register: create_zabbix_user_role_result
+    # Check user role idempotency
+    - name: test - Update a Zabbix role with same rules
+      zabbix_user_role:
+        server_url: "{{ zabbix_api_server_url }}"
+        login_user: "{{ zabbix_api_login_user }}"
+        login_password: "{{ zabbix_api_login_pass }}"
+        state: present
+        name: Operators
+        type: User
+        rules:
+          ui.default_access: 0
+          ui:
+            - name: "monitoring.hosts"
+              status: 0
+            - name: "monitoring.maps"
+              status: 1
+      register: create_zabbix_user_role_result
 
-- assert:
-    that:
-      - create_zabbix_user_role_result.changed is sameas false
+    - assert:
+        that:
+          - create_zabbix_user_role_result.changed is sameas false
 
-# Check user role change
-- name: test - Update a Zabbix role with new rules
-  zabbix_user_role:
-    server_url: "{{ zabbix_api_server_url }}"
-    login_user: "{{ zabbix_api_login_user }}"
-    login_password: "{{ zabbix_api_login_pass }}"
-    state: present
-    name: Operators
-    type: User
-    rules:
-      ui.default_access: 0
-      ui:
-        - name: "monitoring.hosts"
-          status: 1
-        - name: "monitoring.maps"
-          status: 0
-  register: create_zabbix_user_role_result
+    # Check user role change
+    - name: test - Update a Zabbix role with new rules
+      zabbix_user_role:
+        server_url: "{{ zabbix_api_server_url }}"
+        login_user: "{{ zabbix_api_login_user }}"
+        login_password: "{{ zabbix_api_login_pass }}"
+        state: present
+        name: Operators
+        type: User
+        rules:
+          ui.default_access: 0
+          ui:
+            - name: "monitoring.hosts"
+              status: 1
+            - name: "monitoring.maps"
+              status: 0
+      register: create_zabbix_user_role_result
 
-- assert:
-    that:
-      - create_zabbix_user_role_result.changed is sameas true
+    - assert:
+        that:
+          - create_zabbix_user_role_result.changed is sameas true
 
-# Check user role remove
-- name: test - Remote Zabbix role
-  zabbix_user_role:
-    server_url: "{{ zabbix_api_server_url }}"
-    login_user: "{{ zabbix_api_login_user }}"
-    login_password: "{{ zabbix_api_login_pass }}"
-    state: absent
-    name: Operators
-  register: create_zabbix_user_role_result
+    # Check user role remove
+    - name: test - Remote Zabbix role
+      zabbix_user_role:
+        server_url: "{{ zabbix_api_server_url }}"
+        login_user: "{{ zabbix_api_login_user }}"
+        login_password: "{{ zabbix_api_login_pass }}"
+        state: absent
+        name: Operators
+      register: create_zabbix_user_role_result
 
-- assert:
-    that:
-      - create_zabbix_user_role_result.changed is sameas true
-
+    - assert:
+        that:
+          - create_zabbix_user_role_result.changed is sameas true


### PR DESCRIPTION
##### SUMMARY
Adds User Role plugin

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
zabbix_user_role

##### ADDITIONAL INFORMATION
First attempt at creating user_role plugin, based on the logic of user_info.
I added my own is_part_of configuration comparison method (and helpers) so that idempotency is true, even if Zabbix returns more rules than what was configured in the role, but what was configured is at least the same as what was returned.