### PR TITLE
zabbix_proxy role: fix host delegation for API task.

### DIFF
--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -127,7 +127,7 @@
     tls_connect: "{{ zabbix_proxy_tls_config[zabbix_proxy_tlsconnect if zabbix_proxy_tlsconnect else 'no_encryption'] }}"
   when:
     - zabbix_api_create_proxy | bool
-  delegate_to: localhost
+  delegate_to: "{{ zabbix_api_server_host }}"
   become: false
   tags:
     - api


### PR DESCRIPTION
##### SUMMARY
To fix my miss in previous PR - when zabbix_proxy role "talks" to Zabbix API, the action needs to be delegated to Zabbix server not to localhost (which is ok only for tests).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_proxy role