### PR TITLE
Module defaults group

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -68,7 +68,7 @@ jobs:
       # As we need to connect to an existing docker container we can't use `--docker` here as the VMs would be on different
       # (non-routing) networks, so we run them locally and ensure any required dependencies are installed via `--requirements`
       - name: Run integration test
-        run: ansible-test integration -v --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python }} --requirements --coverage
+        run: ansible-test integration -v --color --continue-on-error --diff --python ${{ matrix.python }} --requirements --coverage
         working-directory: ./ansible_collections/community/zabbix
 
         # ansible-test support producing code coverage date

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Modules are tested via `ansible-test` command. Configurations for integration an
 Running test suites locally requires a few dependencies to be installed. Same as for the roles, it is recommended to use [Python virtual environment](#virtualenv):
 
 ```bash
-pip install docker-compose zabbix-api
+pip install docker-compose
 ```
 
 Integration test suite for modules can be run with the commands below:
@@ -129,7 +129,7 @@ Integration test suite for modules can be run with the commands below:
 ```bash
 export zabbix_version=X.Y
 docker-compose up -d
-ansible-test integration -v --color --retry-on-error --continue-on-error --diff
+ansible-test integration -v --color --continue-on-error --diff [test_zabbix_xyz]
 docker-compose down
 ```
 *Notes*:

--- a/changelogs/fragments/326-module_defaults-group.yml
+++ b/changelogs/fragments/326-module_defaults-group.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - collection now supports creating ``module_defaults`` for ``group/community.zabbix.zabbix`` (see https://github.com/ansible-collections/community.zabbix/issues/326)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,34 @@
 ---
 requires_ansible: '>=2.9.10'
+action_groups:
+  zabbix:
+    - zabbix_action
+    - zabbix_authentication
+    - zabbix_autoregister
+    - zabbix_discovery_rule
+    - zabbix_globalmacro
+    - zabbix_group_facts
+    - zabbix_group_info
+    - zabbix_group
+    - zabbix_host_events_info
+    - zabbix_host_facts
+    - zabbix_host_info
+    - zabbix_hostmacro
+    - zabbix_host
+    - zabbix_housekeeping
+    - zabbix_maintenance
+    - zabbix_map
+    - zabbix_mediatype
+    - zabbix_proxy_info
+    - zabbix_proxy
+    - zabbix_screen
+    - zabbix_script
+    - zabbix_service
+    - zabbix_template_info
+    - zabbix_template
+    - zabbix_user_directory
+    - zabbix_usergroup
+    - zabbix_user_info
+    - zabbix_user
+    - zabbix_user_role
+    - zabbix_valuemap

--- a/tests/integration/targets/test_zabbix_module_defaults_group/meta/main.yml
+++ b/tests/integration/targets/test_zabbix_module_defaults_group/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_zabbix

--- a/tests/integration/targets/test_zabbix_module_defaults_group/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_module_defaults_group/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Test module_defaults applied to a group during creation
+  module_defaults:
+    group/community.zabbix.zabbix:
+      host_groups:
+        - Example Group
+      state: present
+  block:
+    - name: Create host group
+      zabbix_group:
+      register: _grp
+
+    - name: Create host
+      zabbix_host:
+        host_name: Example Host
+        interfaces:
+          - type: agent
+            main: 1
+            dns: example-host01.local
+      register: _host
+
+    - name: Assert that resources were correctly created
+      assert:
+        that:
+          - _grp is changed
+          - _host is changed
+
+- name: Test module_defaults applied to a group during deletion
+  module_defaults:
+    group/community.zabbix.zabbix:
+      host_groups:
+        - Example Group
+      state: absent
+  block:
+    - name: Delete host
+      zabbix_host:
+        host_name: Example Host
+      register: _host
+
+    - name: Delete host group
+      zabbix_group:
+      register: _grp
+
+    - name: Assert that resources were correctly deleted
+      assert:
+        that:
+          - _grp is changed
+          - _host is changed


### PR DESCRIPTION
##### SUMMARY
Fixes #326 

I've also removed `--retry-on-error` as it makes our testing suite worse rather than better. Usually tests fail on some specific error (e.g. error creating SMTP interface for the host), then `--retry-on-error` kicks in and fails in a different and unrelated place (e.g. Host already exists), which further confuses user and also makes scrolling through tests longer as the second round of tests has much higher verbosity.

Included tests are only very simple to illustrate the point. I believe our users will be much more creative with the module_defaults for the whole collection.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
meta/runtime.yml
tests/integration/targets/test_zabbix_module_defaults_group/
.github/workflows/plugins-integration.yml
