### PR TITLE
zabbix_host: mark tls_psk param as sensitive/no_log

### DIFF
--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -978,7 +978,7 @@ def main():
         tls_connect=dict(type='int', required=False),
         tls_accept=dict(type='int', required=False),
         tls_psk_identity=dict(type='str', required=False),
-        tls_psk=dict(type='str', required=False),
+        tls_psk=dict(type='str', required=False, no_log=True),
         ca_cert=dict(type='str', required=False, aliases=['tls_issuer']),
         tls_subject=dict(type='str', required=False),
         inventory_zabbix=dict(type='dict', required=False),

--- a/plugins/modules/zabbix_proxy.py
+++ b/plugins/modules/zabbix_proxy.py
@@ -341,7 +341,7 @@ def main():
         ca_cert=dict(type='str', required=False, default=None, aliases=['tls_issuer']),
         tls_subject=dict(type='str', required=False, default=None),
         tls_psk_identity=dict(type='str', required=False, default=None),
-        tls_psk=dict(type='str', required=False, default=None),
+        tls_psk=dict(type='str', required=False, default=None, no_log=True),
         interface=dict(
             type='dict',
             required=False,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When setting a `tls_psk` with the `zabbix_host` module, the PSK is exposed in verbose log output (e.g. job details in awx/AAP), even though this secret should be hidden.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_host

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
