### PR TITLE
Move fping locations to Distro vars

### DIFF
--- a/changelogs/fragments/812-fping-binary-location.yml
+++ b/changelogs/fragments/812-fping-binary-location.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_server - move location of the fping(6) variables to distribution specific files (https://github.com/ansible-collections/community.zabbix/issues/812)

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -121,8 +121,6 @@ zabbix_server_unavailabledelay: 60
 zabbix_server_unreachabledelay: 15
 zabbix_server_alertscriptspath: /usr/lib/zabbix/alertscripts
 zabbix_server_externalscriptspath: /usr/lib/zabbix/externalscripts
-zabbix_server_fpinglocation: /usr/sbin/fping
-zabbix_server_fping6location: /usr/sbin/fping6
 zabbix_server_sshkeylocation:
 zabbix_server_logslowqueries: 0
 zabbix_server_tmpdir: /tmp

--- a/roles/zabbix_server/vars/Debian.yml
+++ b/roles/zabbix_server/vars/Debian.yml
@@ -31,3 +31,6 @@ zabbix_valid_server_versions:
     - 6.0
     - 5.0
     - 4.0
+
+zabbix_server_fpinglocation: /usr/bin/fping
+zabbix_server_fping6location: /usr/bin/fping6

--- a/roles/zabbix_server/vars/RedHat.yml
+++ b/roles/zabbix_server/vars/RedHat.yml
@@ -17,3 +17,6 @@ zabbix_valid_server_versions:
   "7":
     - 5.0
     - 4.0
+
+zabbix_server_fpinglocation: /usr/sbin/fping
+zabbix_server_fping6location: /usr/sbin/fping6


### PR DESCRIPTION
Since different distros put fping in different locations the variables should be specific to the distro. This fixes #812