### PR TITLE
Rhel 9 support

### DIFF
--- a/changelogs/fragments/845-rhel-9-support.yml
+++ b/changelogs/fragments/845-rhel-9-support.yml
@@ -1,0 +1,3 @@
+---
+major_changes:
+  - zabbix suport for rhel 9

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -97,6 +97,7 @@ See the following list of supported Operating systems with the Zabbix releases:
 
 | Zabbix              | 6.2 | 6.0 | 5.4 | 5.2 | 5.0 (LTS)| 4.4 | 4.0 (LTS) | 3.0 (LTS) |
 |---------------------|-----|-----|-----|-----|----------|-----|-----------|-----------|
+| Red Hat Fam 9       |  V  |  V  |     |     |          |     |           |           |
 | Red Hat Fam 8       |  V  |  V  |  V  |  V  |  V       | V   |           |           |
 | Red Hat Fam 7       |  V  |  V  |  V  |  V  |  V       | V   | V         | V         |
 | Red Hat Fam 6       |  V  |  V  |  V  |  V  |  V       |     |           | V         |

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -79,6 +79,7 @@ See the following list of supported Operating systems with the Zabbix releases.
 
 | Zabbix              | 6.2 | 6.0 | 5.4 | 5.2 | 5.0  (LTS)| 4.4 | 4.0 (LTS) | 3.0 (LTS) |
 |---------------------|-----|-----|-----|-----|-----------|-----|-----------|-----------|
+| Red Hat Fam 9       |  V  |  V  |     |     |           |     |           |           |
 | Red Hat Fam 8       |  V  |  V  |  V  |  V  |  V        | V   |           |           |
 | Red Hat Fam 7       |  V  |  V  |  V  |  V  |  V        | V   | V         | V         |
 | Red Hat Fam 6       |     |     |     |  V  |  V        |     |           | V         |

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -77,6 +77,7 @@ See the following list of supported Operating systems with the Zabbix releases:
 
 | Zabbix              | 6.2 | 6.0 | 5.4 | 5.2 | 5.0 (LTS) | 4.4 | 4.0 (LTS) | 3.0 (LTS) |
 |---------------------|-----|-----|-----|-----|-----------|-----|-----------|-----------|
+| Red Hat Fam 9       |  V  |  V  |     |     |           |     |           |           |
 | Red Hat Fam 8       |  V  |  V  |  V  |  V  |  V        | V   |           |           |
 | Red Hat Fam 7       |     |     |     |     |  V        | V   | V         | V         |
 | Red Hat Fam 6       |     |     |     |  V  |  V        |     |           | V         |

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -56,6 +56,7 @@ See the following list of supported Operating Systems with the Zabbix releases.
 
 | Zabbix              | 6.2 | 6.0 | 5.4 | 5.2 | 5.0  (LTS) | 4.4 | 4.0 (LTS) | 3.0 (LTS) |
 |---------------------|-----|-----|-----|-----|------------|-----|-----------|-----------|
+| Red Hat Fam 9       |  V  |  V  |     |     |            |     |           |           |
 | Red Hat Fam 8       |  V  |  V  |  V  |  V  |  V         | V   |           |           |
 | Red Hat Fam 7       |     |  V  |  V  |  V  |  V         | V   | V         | V         |
 | Red Hat Fam 6       |     |     |     |  V  |  V         |     |           | V         |

--- a/roles/zabbix_agent/tasks/RedHat.yml
+++ b/roles/zabbix_agent/tasks/RedHat.yml
@@ -61,7 +61,7 @@
     gpgcheck: "{{ item.gpgcheck }}"
     gpgkey: "{{ item.gpgkey }}"
     mode: "{{ item.mode | default('0644') }}"
-    priority: "{{ item.priority | default('99') }}"
+    priority: "{{ item.priority | default('98') }}"
     state: "{{ item.state | default('present') }}"
     proxy: "{{ zabbix_http_proxy | default(omit) }}"
   with_items: "{{ zabbix_repo_yum }}"

--- a/roles/zabbix_javagateway/tasks/RedHat.yml
+++ b/roles/zabbix_javagateway/tasks/RedHat.yml
@@ -9,7 +9,7 @@
     gpgcheck: "{{ item.gpgcheck }}"
     gpgkey: "{{ item.gpgkey }}"
     mode: "{{ item.mode | default('0644') }}"
-    priority: "{{ item.priority | default('99') }}"
+    priority: "{{ item.priority | default('98') }}"
     state: "{{ item.state | default('present') }}"
     proxy: "{{ zabbix_http_proxy | default(omit) }}"
   with_items: "{{ zabbix_repo_yum }}"

--- a/roles/zabbix_proxy/tasks/RedHat.yml
+++ b/roles/zabbix_proxy/tasks/RedHat.yml
@@ -117,7 +117,7 @@
     gpgcheck: "{{ item.gpgcheck }}"
     gpgkey: "{{ item.gpgkey }}"
     mode: "{{ item.mode | default('0644') }}"
-    priority: "{{ item.priority | default('99') }}"
+    priority: "{{ item.priority | default('98') }}"
     state: "{{ item.state | default('present') }}"
     proxy: "{{ zabbix_http_proxy | default(omit) }}"
   with_items: "{{ zabbix_repo_yum }}"
@@ -204,7 +204,7 @@
     - zabbix-proxy
     - init
 
-- name: "RedHat | Install Ansible module dependencies on RHEL8"
+- name: "RedHat | Install Ansible module dependencies on RHEL9 or RHEL8"
   yum:
     name: python3-psycopg2
     state: present
@@ -217,7 +217,7 @@
   when:
     - zabbix_database_creation
     - zabbix_proxy_database == 'pgsql'
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version|int >= 8
   tags:
     - zabbix-server
 
@@ -241,7 +241,7 @@
     - zabbix-proxy
     - init
 
-- name: "RedHat | Install Mysql Client packages RHEL8"
+- name: "RedHat | Install Mysql Client packages RHEL9 or RHEL8"
   yum:
     name:
       - mysql
@@ -255,7 +255,7 @@
   become: true
   when:
     - zabbix_proxy_database == 'mysql'
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version|int >= 8
   tags:
     - zabbix-proxy
     - init

--- a/roles/zabbix_proxy/tasks/selinux.yml
+++ b/roles/zabbix_proxy/tasks/selinux.yml
@@ -34,7 +34,7 @@
   become: true
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version|int >= 8
   tags:
     - zabbix-proxy
 

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -25,7 +25,7 @@ zabbix_repo_yum:
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version | regex_search('^[0-9]+.[0-9]+') }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     mode: "0644"
-    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABfBIX
     state: present
   - name: zabbix-non-supported
     description: Zabbix Official Repository non-supported - $basearch

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -25,7 +25,7 @@ zabbix_repo_yum:
     baseurl: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_version | regex_search('^[0-9]+.[0-9]+') }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
     gpgcheck: "{{ zabbix_repo_yum_gpgcheck }}"
     mode: "0644"
-    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABfBIX
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
   - name: zabbix-non-supported
     description: Zabbix Official Repository non-supported - $basearch

--- a/roles/zabbix_server/tasks/RedHat.yml
+++ b/roles/zabbix_server/tasks/RedHat.yml
@@ -104,7 +104,7 @@
     gpgcheck: "{{ item.gpgcheck }}"
     gpgkey: "{{ item.gpgkey }}"
     mode: "{{ item.mode | default('0644') }}"
-    priority: "{{ item.priority | default('99') }}"
+    priority: "{{ item.priority | default('98') }}"
     state: "{{ item.state | default('present') }}"
     proxy: "{{ zabbix_http_proxy | default(omit) }}"
   with_items: "{{ zabbix_repo_yum }}"
@@ -213,7 +213,7 @@
   when:
     - zabbix_database_creation
     - zabbix_server_database == 'pgsql'
-    - ansible_distribution_major_version == "9" or ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version|int >= 8
   tags:
     - zabbix-server
 
@@ -232,7 +232,7 @@
   when:
     - zabbix_server_database == 'mysql'
     - zabbix_server_install_database_client
-    - ansible_distribution_major_version == "9" or ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version|int >= 8
   tags:
     - zabbix-server
 

--- a/roles/zabbix_server/tasks/RedHat.yml
+++ b/roles/zabbix_server/tasks/RedHat.yml
@@ -200,7 +200,7 @@
   tags:
     - zabbix-server
 
-- name: "RedHat | Install Ansible module dependencies on RHEL8"
+- name: "RedHat | Install Ansible module dependencies on RHEL9 or RHEL8"
   yum:
     name: python3-psycopg2
     state: present
@@ -213,11 +213,11 @@
   when:
     - zabbix_database_creation
     - zabbix_server_database == 'pgsql'
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version == "9" or ansible_distribution_major_version == "8"
   tags:
     - zabbix-server
 
-- name: "RedHat | Install Mysql Client packages RHEL8"
+- name: "RedHat | Install Mysql Client packages RHEL9 or RHEL8"
   yum:
     name:
       - mysql
@@ -232,7 +232,7 @@
   when:
     - zabbix_server_database == 'mysql'
     - zabbix_server_install_database_client
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version == "9" or ansible_distribution_major_version == "8"
   tags:
     - zabbix-server
 

--- a/roles/zabbix_server/tasks/selinux.yml
+++ b/roles/zabbix_server/tasks/selinux.yml
@@ -112,7 +112,7 @@
   become: true
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version|int >- '8'
+    - ansible_distribution_major_version|int >= 8
   tags:
     - zabbix-server
 

--- a/roles/zabbix_server/tasks/selinux.yml
+++ b/roles/zabbix_server/tasks/selinux.yml
@@ -40,7 +40,7 @@
   tags:
     - zabbix-server
 
-- name: "SELinux | RedHat | Install related SELinux package on RHEL8"
+- name: "SELinux | RedHat | Install related SELinux package on RHEL9 and RHEL8"
   yum:
     name:
       - python3-libsemanage
@@ -54,7 +54,7 @@
   when:
     - ansible_os_family == "RedHat"
     - selinux_allow_zabbix_can_network
-    - ansible_distribution_major_version == "9" or ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version|int >= 8
   tags:
     - zabbix-server
 

--- a/roles/zabbix_server/tasks/selinux.yml
+++ b/roles/zabbix_server/tasks/selinux.yml
@@ -54,7 +54,7 @@
   when:
     - ansible_os_family == "RedHat"
     - selinux_allow_zabbix_can_network
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version == "9" or ansible_distribution_major_version == "8"
   tags:
     - zabbix-server
 
@@ -97,7 +97,7 @@
   tags:
     - zabbix-server
 
-- name: "SELinux | RedHat | Install related SELinux package to fix issues on RHEL8"
+- name: "SELinux | RedHat | Install related SELinux package on RHEL9 and RHEL8"
   yum:
     name:
       - policycoreutils
@@ -112,7 +112,7 @@
   become: true
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version == "9" or ansible_distribution_major_version == "8"
   tags:
     - zabbix-server
 

--- a/roles/zabbix_server/tasks/selinux.yml
+++ b/roles/zabbix_server/tasks/selinux.yml
@@ -112,7 +112,7 @@
   become: true
   when:
     - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version == "9" or ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version|int >- '8'
   tags:
     - zabbix-server
 

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -33,6 +33,7 @@ zabbix_php_fpm_conf_enable_user: true
 zabbix_php_fpm_conf_enable_group: true
 zabbix_php_fpm_conf_mode: "0664"
 zabbix_php_fpm_conf_enable_mode: true
+zabbix_php_install_state: present
 
 zabbix_apache_vhost_port: 80
 zabbix_apache_vhost_tls_port: 443

--- a/roles/zabbix_web/tasks/RedHat.yml
+++ b/roles/zabbix_web/tasks/RedHat.yml
@@ -135,7 +135,7 @@
     name: php
     state: "{{ zabbix_php_install_state }}"
   when:
-    - zabbix_version is version('5.0', '>=')
+    - zabbix_version is version('6.0', '>=')
     - ansible_distribution_major_version == '9'
     - zabbix_vhost
 

--- a/roles/zabbix_web/tasks/RedHat.yml
+++ b/roles/zabbix_web/tasks/RedHat.yml
@@ -30,7 +30,7 @@
     gpgcheck: "{{ item.gpgcheck }}"
     gpgkey: "{{ item.gpgkey }}"
     mode: "{{ item.mode | default('0644') }}"
-    priority: "{{ item.priority | default('99') }}"
+    priority: "{{ item.priority | default('98') }}"
     state: "{{ item.state | default('present') }}"
     proxy: "{{ zabbix_http_proxy | default(omit) }}"
   with_items: "{{ zabbix_5_repo_yum }}"
@@ -61,7 +61,8 @@
   when:
     - zabbix_version is version('5.0', '>=')
     - zabbix_web_centos_release
-    - ansible_distribution_major_version != '9' or ansible_distribution_major_version != '8'
+    - ansible_distribution_major_version != '9' 
+    - ansible_distribution_major_version != '8'
     - ansible_distribution == "CentOS"
   tags:
     - zabbix-web
@@ -84,7 +85,8 @@
   when:
     - zabbix_version is version('5.0', '>=')
     - zabbix_web_centos_release
-    - ansible_distribution_major_version != '9' or ansible_distribution_major_version != '8'
+    - ansible_distribution_major_version != '9'
+    - ansible_distribution_major_version != '8'
     - ansible_distribution == "RedHat"
   tags:
     - zabbix-web
@@ -105,14 +107,15 @@
   become: true
   when:
     - zabbix_version is version('5.0', '>=')
-    - ansible_distribution_major_version != '9' or ansible_distribution_major_version != '8'
+    - ansible_distribution_major_version != '9'
+    - ansible_distribution_major_version != '8'
     - zabbix_websrv == 'apache'
   tags:
     - zabbix-web
 
 - name: "RedHat | Install zabbix-web-{{ zabbix_server_database }}"
   yum:
-    pkg: zabbix-web-{{ zabbix_server_database }}{{ '-scl' if zabbix_version is version('5.0', '>=') and (ansible_distribution_major_version != '8' or ansible_distribution_major_version != '9') else '' }}-{{ zabbix_web_version }}.{{ zabbix_web_version_minor }}
+    pkg: zabbix-web-{{ zabbix_server_database }}{{ '-scl' if zabbix_version is version('5.0', '>=') and ansible_distribution_major_version|int < 8 else '' }}-{{ zabbix_web_version }}.{{ zabbix_web_version_minor }}
     state: "{{ zabbix_web_package_state }}"
     update_cache: true
     disablerepo: "{{ '*' if (zabbix_repo_yum_enabled | length>0) else omit }}"

--- a/roles/zabbix_web/tasks/RedHat.yml
+++ b/roles/zabbix_web/tasks/RedHat.yml
@@ -9,7 +9,7 @@
     gpgcheck: "{{ item.gpgcheck }}"
     gpgkey: "{{ item.gpgkey }}"
     mode: "{{ item.mode | default('0644') }}"
-    priority: "{{ item.priority | default('99') }}"
+    priority: "{{ item.priority | default('98') }}"
     state: "{{ item.state | default('present') }}"
     proxy: "{{ zabbix_http_proxy | default(omit) }}"
   with_items: "{{ zabbix_repo_yum }}"
@@ -38,7 +38,8 @@
   when:
     - zabbix_repo == "zabbix"
     - zabbix_version is version('5.0', '>=')
-    - ansible_distribution_major_version != '8' or ansible_distribution_major_version != '9'
+    - ansible_distribution_major_version != '8'
+    - ansible_distribution_major_version != '9'
   notify:
     - "clean repo files from proxy creds"
   tags:

--- a/roles/zabbix_web/tasks/RedHat.yml
+++ b/roles/zabbix_web/tasks/RedHat.yml
@@ -38,7 +38,7 @@
   when:
     - zabbix_repo == "zabbix"
     - zabbix_version is version('5.0', '>=')
-    - ansible_distribution_major_version != '8'
+    - ansible_distribution_major_version != '8' or ansible_distribution_major_version != '9'
   notify:
     - "clean repo files from proxy creds"
   tags:
@@ -61,7 +61,7 @@
   when:
     - zabbix_version is version('5.0', '>=')
     - zabbix_web_centos_release
-    - ansible_distribution_major_version != '8'
+    - ansible_distribution_major_version != '9' or ansible_distribution_major_version != '8'
     - ansible_distribution == "CentOS"
   tags:
     - zabbix-web
@@ -84,7 +84,7 @@
   when:
     - zabbix_version is version('5.0', '>=')
     - zabbix_web_centos_release
-    - ansible_distribution_major_version != '8'
+    - ansible_distribution_major_version != '9' or ansible_distribution_major_version != '8'
     - ansible_distribution == "RedHat"
   tags:
     - zabbix-web
@@ -105,14 +105,14 @@
   become: true
   when:
     - zabbix_version is version('5.0', '>=')
-    - ansible_distribution_major_version != '8'
+    - ansible_distribution_major_version != '9' or ansible_distribution_major_version != '8'
     - zabbix_websrv == 'apache'
   tags:
     - zabbix-web
 
 - name: "RedHat | Install zabbix-web-{{ zabbix_server_database }}"
   yum:
-    pkg: zabbix-web-{{ zabbix_server_database }}{{ '-scl' if zabbix_version is version('5.0', '>=') and ansible_distribution_major_version != '8' else '' }}-{{ zabbix_web_version }}.{{ zabbix_web_version_minor }}
+    pkg: zabbix-web-{{ zabbix_server_database }}{{ '-scl' if zabbix_version is version('5.0', '>=') and (ansible_distribution_major_version != '8' or ansible_distribution_major_version != '9') else '' }}-{{ zabbix_web_version }}.{{ zabbix_web_version_minor }}
     state: "{{ zabbix_web_package_state }}"
     update_cache: true
     disablerepo: "{{ '*' if (zabbix_repo_yum_enabled | length>0) else omit }}"
@@ -125,6 +125,15 @@
   become: true
   tags:
     - zabbix-web
+
+- name: RedHat 9 | Install PHP"
+  package:
+    name: php
+    state: "{{ zabbix_php_install_state }}"
+  when:
+    - zabbix_version is version('5.0', '>=')
+    - ansible_distribution_major_version == '9'
+    - zabbix_vhost
 
 - name: "RedHat | Install PHP"
   template:

--- a/roles/zabbix_web/tasks/selinux.yml
+++ b/roles/zabbix_web/tasks/selinux.yml
@@ -18,7 +18,7 @@
   tags:
     - zabbix-web
 
-- name: "SELinux | RedHat | Install related SELinux package on RHEL8"
+- name: "SELinux | RedHat | Install related SELinux package on RHEL9 and RHEL8"
   yum:
     name:
       - python3-libsemanage
@@ -32,7 +32,7 @@
   when:
     - ansible_os_family == "RedHat"
     - selinux_allow_zabbix_can_network
-    - ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version == "9" or ansible_distribution_major_version == "8"
   tags:
     - zabbix-web
 

--- a/roles/zabbix_web/tasks/selinux.yml
+++ b/roles/zabbix_web/tasks/selinux.yml
@@ -32,7 +32,7 @@
   when:
     - ansible_os_family == "RedHat"
     - selinux_allow_zabbix_can_network
-    - ansible_distribution_major_version|int >= '8'
+    - ansible_distribution_major_version|int >= 8
   tags:
     - zabbix-web
 

--- a/roles/zabbix_web/tasks/selinux.yml
+++ b/roles/zabbix_web/tasks/selinux.yml
@@ -32,7 +32,7 @@
   when:
     - ansible_os_family == "RedHat"
     - selinux_allow_zabbix_can_network
-    - ansible_distribution_major_version == "9" or ansible_distribution_major_version == "8"
+    - ansible_distribution_major_version|int >= '8'
   tags:
     - zabbix-web
 

--- a/roles/zabbix_web/vars/RedHat-9.yml
+++ b/roles/zabbix_web/vars/RedHat-9.yml
@@ -1,0 +1,8 @@
+---
+_php_fpm_dir: /etc/php-fpm.d
+_php_fpm_session: /var/lib/php/session
+_php_fpm_listen: "/run/php-fpm/zabbix.sock"
+
+_zabbix_php_version: 8.0
+_zabbix_php_fpm_session: /var/lib/php/session
+_zabbix_php_fpm_listen: /run/php-fpm/zabbix.sock


### PR DESCRIPTION
##### SUMMARY
Upgrades Community to support RHEL 9 distributions.  

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

Updates Zabbix-agent, zabbix-server, Zabbix-web, Zabbix-proxy, and zabbix-javagateway to support RHEL 9.  

*I will admit, In my testing I was unable to validate proxy and javagateway changes as I don't have those environments in my setup.  Zabbix-server and web were fully tested using Rocky 9. *

##### ADDITIONAL INFORMATION

I did modify the repository priority levels to `98` because it was identified on RHEL 9, the EPEL repo on Rocky 9 will take priority over the zabbix repo and hence you can get a different package version installed than if using the zabbix repo.  

While `PHP-FPM` may get installed as a dependency by Zabbix-web, I thought it would be safer to install `PHP` as well to guarantee all dependencies are installed to support the application.  
