### PR TITLE
Swap tls connect/accept parameters when creating proxy

### DIFF
--- a/changelogs/fragments/526-swap-tls-accept-connect-in-proxy.yaml
+++ b/changelogs/fragments/526-swap-tls-accept-connect-in-proxy.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - zabbix_proxy - swap configuration of tls_accept and tls_connect
+  - zabbix_proxy - correctly provision tls_accept and tls_connect on Zabbix backend

--- a/changelogs/fragments/526-swap-tls-accept-connect-in-proxy.yaml
+++ b/changelogs/fragments/526-swap-tls-accept-connect-in-proxy.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_proxy - swap configuration of tls_accept and tls_connect

--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -116,8 +116,8 @@
     tls_psk: "{{ zabbix_proxy_tlspsk_secret | default(omit) }}"
     tls_psk_identity: "{{ zabbix_proxy_tlspskidentity | default(omit) }}"
     tls_subject: "{{ zabbix_proxy_tls_subject | default(omit) }}"
-    tls_accept: "{{ zabbix_proxy_tls_config[zabbix_proxy_tlsaccept if zabbix_proxy_tlsaccept else 'no_encryption'] }}"
-    tls_connect: "{{ zabbix_proxy_tls_config[zabbix_proxy_tlsconnect if zabbix_proxy_tlsconnect else 'no_encryption'] }}"
+    tls_connect: "{{ zabbix_proxy_tls_config[zabbix_proxy_tlsaccept if zabbix_proxy_tlsaccept else 'no_encryption'] }}"
+    tls_accept: "{{ zabbix_proxy_tls_config[zabbix_proxy_tlsconnect if zabbix_proxy_tlsconnect else 'no_encryption'] }}"
   when:
     - zabbix_api_create_proxy | bool
   delegate_to: "{{ zabbix_api_server_host }}"


### PR DESCRIPTION
.. at least on the backend ansible-collections#526

##### SUMMARY


When configuring encrypted communication between proxy and server, there's a mismatch of tls accept/connect params between the config file and the definition created on the Zabbix backend.

In my test I encrypt communications between proxy and server but I allow unencrypted ones between agents and proxy. This is my config:

```
TLSConnect=psk
TLSAccept=unencrypted

```


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* zabbix_proxy


##### ADDITIONAL INFORMATION

more details on #526 