### PR TITLE
zabbix_proxy: Do not set ServerPort config parameter on Zabbix >= 6.0

### DIFF
--- a/changelogs/fragments/850-proxy-serverport.yml
+++ b/changelogs/fragments/850-proxy-serverport.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - zabbix_proxy - do not set ServerPort config parameter which was removed in Zabbix 6.0

--- a/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
+++ b/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
@@ -8,7 +8,7 @@
 
 ProxyMode={{ zabbix_proxy_mode }}
 Server={{ zabbix_proxy_server }}
-{% if zabbix_version is version('6.0', '<=') %}
+{% if zabbix_version is version('6.0', '<') %}
 ServerPort={{ zabbix_proxy_serverport }}
 {% endif %}
 {% if zabbix_proxy_hostname is defined and zabbix_proxy_hostname %}


### PR DESCRIPTION
##### SUMMARY
Do not set ServerPort config parameter in proxy configuration parameter on Zabbix >= 6.0 as it was removed.

Fixes #798

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_proxy