### PR TITLE
Update Debian.yml

### DIFF
--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -27,7 +27,6 @@
   when:
     - ansible_machine == "aarch64"
 
-
 - name: "Debian | Set some facts"
   set_fact:
     datafiles_path: /usr/share/zabbix-server-{{ zabbix_server_database }}
@@ -131,14 +130,11 @@
     - zabbix_server_apt_priority | int
   become: true
 
-- name: apt-get clean
-  shell: apt-get clean; apt-get update
-  args:
-    warn: false
-  changed_when: false
+- name: Run "apt-get clean & apt-get update"
+  apt:
+    clean: yes
+    update_cache: yes
   become: true
-  tags:
-    - skip_ansible_lint
 
 # On certain 18.04 images, such as docker or lxc, dpkg is configured not to
 # install files into paths /usr/share/doc/*


### PR DESCRIPTION
Replacing shell command with ansible apt module  to perform clean and update as it was throwing error...

"Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: executable, strip_empty_ends, chdir, stdin, _uses_shell, creates, _raw_params, stdin_add_newline, argv, removes."

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes from ansible shell to ansible apt module, I was experiencing an issue as shown below. I believe this should be a proper fix for the error message.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_server/tasks/Debian

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

TASK [community.zabbix.zabbix_server : apt-get clean] ****************************************************************************************************************************************************************************************
fatal: [XXXXXXXX]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: executable, removes, _raw_params, creates, strip_empty_ends, chdir, stdin_add_newline, stdin, argv, _uses_shell."}


```
