### PR TITLE
Update zabbix-server debian task for apt-get clean and update to remove warn args

### DIFF
--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -133,8 +133,6 @@
 
 - name: apt-get clean
   shell: apt-get clean; apt-get update
-  args:
-    warn: false
   changed_when: false
   become: true
   tags:


### PR DESCRIPTION
ansible-core 2.13 removed the args warn option.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
removal of the warn argument as it was removed in ansible-core > 2.13
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_server/tasks/Debian

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```TASK [community.zabbix.zabbix_server : apt-get clean] ****************************************************************************************************************************************************************************************
fatal: [XXXXXXXX]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: executable, removes, _raw_params, creates, strip_empty_ends, chdir, stdin_add_newline, stdin, argv, _uses_shell."}
```
