### PR TITLE
Update to allow zabbix-agent task to run cleanly without failure while package is not installed.

### DIFF
--- a/roles/zabbix_agent/handlers/main.yml
+++ b/roles/zabbix_agent/handlers/main.yml
@@ -10,6 +10,7 @@
   when:
     - not zabbix_agent_docker
     - zabbix_agent_os_family != "Windows" and zabbix_agent_os_family != "Darwin"
+    - zabbix_agent_package_installed | bool
 
 - name: firewalld-reload
   command: "firewall-cmd --reload"

--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -216,6 +216,7 @@
   become: true
   when:
     - not (zabbix_agent_docker | bool)
+    - zabbix_agent_package_installed | bool
   tags:
     - init
     - service

--- a/roles/zabbix_agent/tasks/api.yml
+++ b/roles/zabbix_agent/tasks/api.yml
@@ -7,6 +7,7 @@
     timeout: "{{ zabbix_api_timeout }}"
   when:
     - zabbix_api_create_hostgroup | bool
+    - zabbix_agent_package_installed | bool
   register: zabbix_api_hostgroup_created
   until: zabbix_api_hostgroup_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
@@ -43,6 +44,7 @@
     tags: "{{ zabbix_agent_tags }}"
   when:
     - not zabbix_agent2
+    - zabbix_agent_package_installed | bool
   register: zabbix_api_host_created
   until: zabbix_api_host_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
@@ -80,6 +82,7 @@
     tags: "{{ zabbix_agent_tags }}"
   when:
     - zabbix_agent2 | bool
+    - zabbix_agent_package_installed | bool
   register: zabbix_api_host_created
   until: zabbix_api_host_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
zabbix-agent role fails with failures at various points when the zabbix-agent package is not installed and running in check mode. This PR just skips some tasks when the package is not yet installed allowing the role to run without failure in check mode.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix-agent

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [community.zabbix.zabbix_agent : Make sure the zabbix-agent service is running] *********************************************************************************************************************************************************
fatal: [XXXXXXXXXXXX]: FAILED! => {"changed": false, "msg": "Could not find the requested service zabbix-agent2: host"}


```
