### PR TITLE
replace depreciated include

### DIFF
--- a/roles/zabbix_agent/tasks/Darwin.yml
+++ b/roles/zabbix_agent/tasks/Darwin.yml
@@ -149,7 +149,7 @@
   become: true
 
 - name: "Install the Docker container"
-  include: Docker.yml
+  include_tasks: Docker.yml
   when:
     - zabbix_agent_docker | bool
 

--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -83,7 +83,7 @@
     - config
 
 - name: "Configure SELinux when enabled"
-  include: selinux.yml
+  include_tasks: selinux.yml
   when:
     - zabbix_selinux | bool
 
@@ -193,17 +193,17 @@
     - include
 
 - name: "Install the Docker container"
-  include: Docker.yml
+  include_tasks: Docker.yml
   when:
     - zabbix_agent_docker | bool
 
 - name: "Configure the firewall(d|iptables)"
-  include: firewall.yml
+  include_tasks: firewall.yml
   when:
     - (zabbix_agent_firewall_enable | bool) or (zabbix_agent_firewalld_enable | bool)
 
 - name: "Remove zabbix-agent installation when zabbix-agent2 is used."
-  include: remove.yml
+  include_tasks: remove.yml
   when:
     - zabbix_agent2 | bool
     - zabbix_agent_package_remove

--- a/roles/zabbix_javagateway/tasks/main.yml
+++ b/roles/zabbix_javagateway/tasks/main.yml
@@ -2,12 +2,12 @@
 # tasks file for zabbix_proxy
 
 - name: "Install the correct repository"
-  include: "RedHat.yml"
+  include_tasks: "RedHat.yml"
   when:
     - ansible_os_family == "RedHat"
 
 - name: "Install the correct repository"
-  include: "Debian.yml"
+  include_tasks: "Debian.yml"
   when:
     - ansible_os_family == "Debian"
 

--- a/roles/zabbix_proxy/tasks/RedHat.yml
+++ b/roles/zabbix_proxy/tasks/RedHat.yml
@@ -318,6 +318,6 @@
     - zabbix-proxy
 
 - name: "Configure SELinux when enabled"
-  include: selinux.yml
+  include_tasks: selinux.yml
   when:
     - zabbix_selinux | bool

--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -31,7 +31,7 @@
   include_tasks: "{{ ansible_os_family }}.yml"
 
 - name: "Installing the {{ zabbix_proxy_database_long }} database"
-  include: "{{ zabbix_proxy_database_long }}.yml"
+  include_tasks: "{{ zabbix_proxy_database_long }}.yml"
 
 - name: "Create include dir zabbix-proxy"
   file:

--- a/roles/zabbix_server/tasks/RedHat.yml
+++ b/roles/zabbix_server/tasks/RedHat.yml
@@ -291,6 +291,6 @@
     - zabbix-server
 
 - name: "Configure SELinux when enabled"
-  include: selinux.yml
+  include_tasks: selinux.yml
   when:
     - zabbix_selinux | bool

--- a/roles/zabbix_server/tasks/main.yml
+++ b/roles/zabbix_server/tasks/main.yml
@@ -42,7 +42,7 @@
     - config
 
 - name: "Add zabbix-server scripts"
-  include: "scripts.yml"
+  include_tasks: "scripts.yml"
   when: ( zabbix_server_alertscripts is defined ) or
     ( zabbix_server_externalscripts is defined )
 

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -103,6 +103,6 @@
     - zabbix_websrv == 'apache'
 
 - name: "Configure SELinux when enabled"
-  include: selinux.yml
+  include_tasks: selinux.yml
   when:
     - zabbix_selinux | bool

--- a/roles/zabbix_web/tasks/RedHat.yml
+++ b/roles/zabbix_web/tasks/RedHat.yml
@@ -62,7 +62,7 @@
   when:
     - zabbix_version is version('5.0', '>=')
     - zabbix_web_centos_release
-    - ansible_distribution_major_version != '9' 
+    - ansible_distribution_major_version != '9'
     - ansible_distribution_major_version != '8'
     - ansible_distribution == "CentOS"
   tags:
@@ -178,6 +178,6 @@
     - nginx
 
 - name: "Configure SELinux when enabled"
-  include: selinux.yml
+  include_tasks: selinux.yml
   when:
     - zabbix_selinux | bool

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -57,13 +57,13 @@
     - zabbix_websrv == 'nginx'
 
 - name: "Install the correct repository"
-  include: "RedHat.yml"
+  include_tasks: "RedHat.yml"
   when: ansible_os_family == "RedHat"
   tags:
     - zabbix-web
 
 - name: "Install the correct repository"
-  include: "Debian.yml"
+  include_tasks: "Debian.yml"
   when: ansible_os_family == "Debian"
   tags:
     - zabbix-web

--- a/tests/integration/targets/test_zabbix_host/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_host/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 - block:
     # setup stuff not testing zabbix_host
-    - include: zabbix_host_setup.yml
+    - include_tasks: zabbix_host_setup.yml
 
     # zabbix_host module tests
-    - include: zabbix_host_tests.yml
+    - include_tasks: zabbix_host_tests.yml
 
     # documentation example tests
-    - include: zabbix_host_doc.yml
+    - include_tasks: zabbix_host_doc.yml
 
     # tear down stuff set up earlier
-    - include: zabbix_host_teardown.yml
+    - include_tasks: zabbix_host_teardown.yml
   always:
   - name: "cleanup if tests failed"
     zabbix_host:

--- a/tests/integration/targets/test_zabbix_template/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template/tasks/main.yml
@@ -253,10 +253,10 @@
 # Import template tests
 # ####
 
-- include: import_54_lower.yml
+- include_tasks: import_54_lower.yml
   when: zabbix_version is version('5.4', '<')
 
-- include: import_54_higher.yml
+- include_tasks: import_54_higher.yml
   when: zabbix_version is version('5.4', '>=')
 
 #

--- a/tests/integration/targets/test_zabbix_user_directory/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_user_directory/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - block:
     # zabbix_host module tests
-    - include: zabbix_user_directory_tests.yml
+    - include_tasks: zabbix_user_directory_tests.yml
 
   always:
   - name: "cleanup if tests failed"


### PR DESCRIPTION
##### SUMMARY
The `include` module was depreciated a long time ago.  This pull request refactors existing `include` statements to use the `include_tasks` module instead.  Ansible 2.16 will remove the `include` module all together and `include_tasks` was added in Ansible 2.4.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
All

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
