### PR TITLE
Allow using other hash methods for postgresql user

### DIFF
--- a/changelogs/fragments/871.yml
+++ b/changelogs/fragments/871.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zabbix_proxy_dbpassword - when zabbix_proxy_dbpassword_hash_method is set to anything other than md5 then do not hash the password with md5 so you could use postgresql scram-sha-256 hashing method
+  - zabbix_proxy_dbpassword_hash_method - add variable to control whether you want postgresql user password to be hashed with md5 or want to use db default

--- a/changelogs/fragments/871.yml
+++ b/changelogs/fragments/871.yml
@@ -1,3 +1,2 @@
 minor_changes:
-  - zabbix_proxy_dbpassword - when zabbix_proxy_dbpassword_hash_method is set to anything other than md5 then do not hash the password with md5 so you could use postgresql scram-sha-256 hashing method
-  - zabbix_proxy_dbpassword_hash_method - add variable to control whether you want postgresql user password to be hashed with md5 or want to use db default
+  - zabbix_proxy role - Add variable zabbix_proxy_dbpassword_hash_method to control whether you want postgresql user password to be hashed with md5 or want to use db default. When zabbix_proxy_dbpassword_hash_method is set to anything other than md5 then do not hash the password with md5 so you could use postgresql scram-sha-256 hashing method. 

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -161,6 +161,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_proxy_dbencoding`: Default: `utf8`. The encoding for the MySQL database.
 * `zabbix_proxy_dbcollation`: Default: `utf8_bin`. The collation for the MySQL database.zabbix_proxy_
 * `zabbix_server_allowunsupporteddbversions`: Allow proxy to work with unsupported database versions.
+* `zabbix_proxy_dbpassword_hash_method`: Default: `md5`. Allow switching postgresql user password creation to `scram-sha-256`, when anything other than `md5` is used then ansible won't hash the password with `md5`.
 
 ### TLS Specific configuration
 

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -86,6 +86,7 @@ zabbix_proxy_dbuser: zabbix_proxy
 zabbix_proxy_dbpassword: zabbix_proxy
 zabbix_proxy_dbsocket:
 zabbix_proxy_dbport: 5432
+zabbix_proxy_dbpassword_hash_method: md5
 zabbix_proxy_startodbcpollers: 1
 zabbix_proxy_dbhost_run_install: true
 zabbix_proxy_privileged_host: localhost

--- a/roles/zabbix_proxy/tasks/postgresql.yml
+++ b/roles/zabbix_proxy/tasks/postgresql.yml
@@ -24,7 +24,7 @@
       postgresql_user:
         db: "{{ zabbix_proxy_dbname }}"
         name: "{{ zabbix_proxy_dbuser }}"
-        password: "md5{{ (zabbix_proxy_dbpassword + zabbix_proxy_dbuser)|hash('md5') }}"
+        password: "{{ ('md5' + (zabbix_proxy_dbpassword + zabbix_proxy_dbuser)|hash('md5')) if zabbix_proxy_dbpassword_hash_method == 'md5' else zabbix_proxy_dbpassword }}"
         port: "{{ zabbix_proxy_dbport }}"
         priv: ALL
         state: present
@@ -57,7 +57,7 @@
         login_password: "{{ zabbix_proxy_pgsql_login_password | default(omit) }}"
         db: "{{ zabbix_proxy_dbname }}"
         name: "{{ zabbix_proxy_dbuser }}"
-        password: "md5{{ (zabbix_proxy_dbpassword + zabbix_proxy_dbuser)|hash('md5') }}"
+        password: "{{ ('md5' + (zabbix_proxy_dbpassword + zabbix_proxy_dbuser)|hash('md5')) if zabbix_proxy_dbpassword_hash_method == 'md5' else zabbix_proxy_dbpassword }}"
         port: "{{ zabbix_proxy_dbport }}"
         priv: ALL
         state: present


### PR DESCRIPTION
##### SUMMARY
Added option for zabbix-proxy role to not hash the password md5 so we could use postgresql default of scram-sha-256.

Added a variable and edited the task to only apply when the default is changed 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zabbix-proxy postgresql

##### ADDITIONAL INFORMATION
Added a new default as to not break existing installs

```paste below

```
