### PR TITLE
Add missing variants for SNMPv3 authprotocol and privprotocol.

### DIFF
--- a/changelogs/fragments/880.yml
+++ b/changelogs/fragments/880.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - lineinfile - Added missing variants for SNMPv3 authprotocol and privprotocol introduced by Zabbix 6
+  - zabbix_host - add missing variants for SNMPv3 authprotocol and privprotocol introduced by Zabbix 6

--- a/changelogs/fragments/880.yml
+++ b/changelogs/fragments/880.yml
@@ -1,0 +1,2 @@
+bug_fixes:
+  - zabbix_host - Added missing variants for SNMPv3 authprotocol and privprotocol introduced by Zabbix 6

--- a/changelogs/fragments/880.yml
+++ b/changelogs/fragments/880.yml
@@ -1,2 +1,2 @@
-bug_fixes:
-  - zabbix_host - Added missing variants for SNMPv3 authprotocol and privprotocol introduced by Zabbix 6
+minor_changes:
+  - lineinfile - Added missing variants for SNMPv3 authprotocol and privprotocol introduced by Zabbix 6

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -191,6 +191,7 @@ options:
                         description:
                             - SNMPv3 authentication protocol.
                             - Used when I(securitylevel=1)(authNoPriv) or I(securitylevel=2)(AuthPriv).
+                            - Variants 2,3,4,5 are supported only on Zabbix 5.4 or greater
                             - 0 (MD5), 1 (SHA1), 2 (SHA224), 3 (SHA256), 4 (SHA384), 5 (SHA512)
                         default: 0
                         choices: [0, 1, 2, 3, 4, 5]
@@ -205,6 +206,7 @@ options:
                         description:
                             - SNMPv3 privacy protocol.
                             - Used when I(securitylevel=2)(authPriv).
+                            - Variants 2,3,4,5 are supported only on Zabbix 5.4 or greater
                             - 0 (DES), 1 (AES128), 2 (AES192), 3 (AES256), 4 (AES192C), 5 (AES256C)
                         default: 0
                         choices: [0, 1, 2, 3, 4, 5]

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -191,9 +191,9 @@ options:
                         description:
                             - SNMPv3 authentication protocol.
                             - Used when I(securitylevel=1)(authNoPriv) or I(securitylevel=2)(AuthPriv).
-                            - 0 (MD5), 1 (SHA)
+                            - 0 (MD5), 1 (SHA1), 2 (SHA224), 3 (SHA256), 4 (SHA384), 5 (SHA512)
                         default: 0
-                        choices: [0, 1]
+                        choices: [0, 1, 2, 3, 4, 5]
                     authpassphrase:
                         type: str
                         description:
@@ -205,9 +205,9 @@ options:
                         description:
                             - SNMPv3 privacy protocol.
                             - Used when I(securitylevel=2)(authPriv).
-                            - 0 (DES), 1 (AES)
+                            - 0 (DES), 1 (AES128), 2 (AES192), 3 (AES256), 4 (AES192C), 5 (AES256C)
                         default: 0
-                        choices: [0, 1]
+                        choices: [0, 1, 2, 3, 4, 5]
                     privpassphrase:
                         type: str
                         description:
@@ -1004,9 +1004,9 @@ def main():
                         securityname=dict(type='str', default=''),
                         contextname=dict(type='str', default=''),
                         securitylevel=dict(type='int', choices=[0, 1, 2], default=0),
-                        authprotocol=dict(type='int', choices=[0, 1], default=0),
+                        authprotocol=dict(type='int', choices=[0, 1, 2, 3, 4, 5], default=0),
                         authpassphrase=dict(type='str', default='', no_log=True),
-                        privprotocol=dict(type='int', choices=[0, 1], default=0),
+                        privprotocol=dict(type='int', choices=[0, 1, 2, 3, 4, 5], default=0),
                         privpassphrase=dict(type='str', default='', no_log=True)
                     )
                 )

--- a/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
+++ b/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
@@ -896,9 +896,9 @@
               contextname: snmp_context
               securityname: SNMP3 sec name
               securitylevel: 2
-              authprotocol: {{ 2 if zabbix_version | float >= 5.4 else 0 }}
+              authprotocol: "{{ 2 if zabbix_version | float >= 5.4 else 0 }}"
               authpassphrase: secret_auth_passphrase
-              privprotocol: {{ 2 if zabbix_version | float >= 5.4 else 0 }}
+              privprotocol: "{{ 2 if zabbix_version | float >= 5.4 else 0 }}"
               privpassphrase: secret_priv_passphrase
       register: zabbix_host1
 

--- a/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
+++ b/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
@@ -896,9 +896,9 @@
               contextname: snmp_context
               securityname: SNMP3 sec name
               securitylevel: 2
-              authprotocol: 0
+              authprotocol: {{ 2 if zabbix_version | float >= 5.4 else 0 }}
               authpassphrase: secret_auth_passphrase
-              privprotocol: 0
+              privprotocol: {{ 2 if zabbix_version | float >= 5.4 else 0 }}
               privpassphrase: secret_priv_passphrase
       register: zabbix_host1
 


### PR DESCRIPTION


##### SUMMARY
Current zabbix_host module allows to set SNMPv3 authprotocol and privprotocol only to values 0,1,2 as it was possible in Zabbix 5.0. Zabbix 6.0 allow to set 6 variants as described on page https://www.zabbix.com/documentation/6.0/en/manual/api/reference/hostinterface/object
This pull request adds missing variants

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
module zabbix_host

##### ADDITIONAL INFORMATION
I have modified only zabbix_host.py file, please check if this change needs to be done also in other places (documentation?)
