### PR TITLE
zabbix_agent - Fix MacOS (Darwin) installation

### DIFF
--- a/changelogs/fragments/897.yml
+++ b/changelogs/fragments/897.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_agent role - Fix MacOS install never executed because of the missing include_tasks "Darwin.yml" in the "main.yml" task file and wrong user permission on folder/files.

--- a/roles/zabbix_agent/tasks/Darwin.yml
+++ b/roles/zabbix_agent/tasks/Darwin.yml
@@ -91,7 +91,7 @@
   template:
     src: zabbix_agentd.conf.j2
     dest: "/usr/local/etc/zabbix/{{ zabbix_agent_conf }}"
-    owner: root
+    owner: zabbix
     group: wheel
     mode: 0644
   notify:
@@ -130,7 +130,7 @@
 - name: "Create include dir zabbix-agent"
   file:
     path: "{{ zabbix_agent_include }}"
-    owner: root
+    owner: zabbix
     group: zabbix
     mode: 0750
     state: directory

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -107,6 +107,13 @@
     - always
 
 - name: "Configure Agent"
+  include_tasks: Darwin.yml
+  when:
+    - zabbix_agent_os_family == "Darwin"
+  tags:
+    - always
+
+- name: "Configure Agent"
   include_tasks: Linux.yml
   when:
     - (zabbix_agent_os_family != "Windows" and zabbix_agent_os_family != "Darwin") or (zabbix_agent_docker | bool)


### PR DESCRIPTION
##### SUMMARY

The `zabbix_agent` role does not correctly install and configure the `zabbix_agentd` on MacOS nodes. The macos dedicated tasks exist, except they're never executed through Ansible because of the missing include_tasks entry in the tasks/main.yml file.

By adding the include_tasks directive in the main.yml, I can successfully install and configure the Zabbix agent, but it still fails because of some permission denied to"{{ zabbix_agent_include }}" and config file (both owned by root).

Changing those permissions to user `zabbix` fix the issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent - MacOS (Darwin)

##### ADDITIONAL INFORMATION

```
ProductName:    macOS
ProductVersion: 12.4
```
