### PR TITLE
update example

### DIFF
--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -354,16 +354,6 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-# Set following variables for Zabbix Server host in play or inventory
-- name: Set connection specific variables
-  set_fact:
-    ansible_network_os: community.zabbix.zabbix
-    ansible_connection: httpapi
-    ansible_httpapi_port: 80
-    ansible_httpapi_use_ssl: false
-    ansible_httpapi_validate_certs: false
-    ansible_zabbix_url_path: 'zabbixeu'  # If Zabbix WebUI runs on non-default (zabbix) path ,e.g. http://<FQDN>/zabbixeu
-
 # If you want to use Username and Password to be authenticated by Zabbix Server
 - name: Set credentials to access Zabbix Server API
   set_fact:
@@ -376,7 +366,17 @@ EXAMPLES = r'''
   set_fact:
     ansible_zabbix_auth_key: 8ec0d52432c15c91fcafe9888500cf9a607f44091ab554dbee860f6b44fac895
 
-- name: Create a new host or update an existing host's info
+- name: Create a new host or rewrite an existing host's info
+  vars:
+# Set following variables for Zabbix Server host in task
+    ansible_network_os: community.zabbix.zabbix
+    ansible_connection: httpapi
+    ansible_httpapi_port: 443
+    ansible_httpapi_use_ssl: true
+    ansible_httpapi_validate_certs: false
+    ansible_zabbix_url_path: 'zabbixeu'  # If Zabbix WebUI runs on non-default (zabbix) path ,e.g. http://<FQDN>/zabbixeu
+  become: false
+  delegate_to: zabbix-exaple-fqdn.org
   community.zabbix.zabbix_host:
     host_name: ExampleHost
     visible_name: ExampleName
@@ -436,6 +436,7 @@ EXAMPLES = r'''
     tls_psk_identity: test
     tls_connect: 2
     tls_psk: 123456789abcdef123456789abcdef12
+    force: false
 '''
 
 


### PR DESCRIPTION
change examples to be less confusing with httpapi

##### SUMMARY

set_fact makes variables available until play end and makes following tasks failed due to change ansible_connection method

setting variables in task vars section change it for the current task only

##### ISSUE TYPE
- Docs Pull Request
