### PR TITLE
Possibility to add custom includes in apache vhost config (zabbix_web)

### DIFF
--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -150,6 +150,7 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_apache_SSLSessionCache`: Type of the global/inter-process SSL Session Cache
 * `zabbix_apache_SSLSessionCacheTimeout`: Number of seconds before an SSL session expires in the Session Cache
 * `zabbix_apache_SSLCryptoDevice`: Enable use of a cryptographic hardware accelerator
+* `zabbix_apache_custom_includes`: Configure custom includes. Default: `[]`
 
 When `zabbix_apache_tls_crt`, `zabbix_apache_tls_key` and/or `zabbix_apache_tls_chain` are used, make sure that these files exists before executing this role. The Zabbix-Web role will not install the mentioned files.
 

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -49,6 +49,7 @@ zabbix_apache_SSLPassPhraseDialog: exec:/usr/libexec/httpd-ssl-pass-dialog
 zabbix_apache_SSLSessionCache: shmcb:/run/httpd/sslcache(512000)
 zabbix_apache_SSLSessionCacheTimeout: 300
 zabbix_apache_SSLCryptoDevice: builtin
+zabbix_apache_custom_includes: []
 
 zabbix_nginx_vhost_port: 80
 zabbix_nginx_vhost_tls_port: 443

--- a/roles/zabbix_web/templates/apache_vhost.conf.j2
+++ b/roles/zabbix_web/templates/apache_vhost.conf.j2
@@ -7,7 +7,7 @@
   ## Vhost docroot
   DocumentRoot "/usr/share/zabbix"
 
-{% if zabbix_apache_custom_includes | length > 0 %}
+{% if zabbix_apache_custom_includes %}
   {% for include in zabbix_apache_custom_includes %}
   {{ include }}
   {% endfor %}
@@ -108,7 +108,7 @@ SSLCryptoDevice {{ zabbix_apache_SSLCryptoDevice }}
   ## Vhost docroot
   DocumentRoot "/usr/share/zabbix"
 
-{% if zabbix_apache_custom_includes | length > 0 %}
+{% if zabbix_apache_custom_includes %}
   {% for include in zabbix_apache_custom_includes %}
   {{ include }}
   {% endfor %}

--- a/roles/zabbix_web/templates/apache_vhost.conf.j2
+++ b/roles/zabbix_web/templates/apache_vhost.conf.j2
@@ -7,6 +7,12 @@
   ## Vhost docroot
   DocumentRoot "/usr/share/zabbix"
 
+{% if zabbix_apache_custom_includes | length > 0 %}
+  {% for include in zabbix_apache_custom_includes %}
+  {{ include }}
+  {% endfor %}
+{% endif %}
+
 {% if zabbix_apache_redirect and zabbix_apache_tls %}
   RewriteEngine On
   RewriteCond %{HTTPS} !=on
@@ -101,6 +107,12 @@ SSLCryptoDevice {{ zabbix_apache_SSLCryptoDevice }}
 
   ## Vhost docroot
   DocumentRoot "/usr/share/zabbix"
+
+{% if zabbix_apache_custom_includes | length > 0 %}
+  {% for include in zabbix_apache_custom_includes %}
+  {{ include }}
+  {% endfor %}
+{% endif %}
 
   SSLEngine on
   SSLCipherSuite {{ apache_ssl_cipher_suite }}

--- a/roles/zabbix_web/templates/apache_vhost.conf.j2
+++ b/roles/zabbix_web/templates/apache_vhost.conf.j2
@@ -7,7 +7,7 @@
   ## Vhost docroot
   DocumentRoot "/usr/share/zabbix"
 
-{% if zabbix_apache_custom_includes %}
+{% if zabbix_apache_custom_includes is iterable and (zabbix_apache_custom_includes | length>0) %}
   {% for include in zabbix_apache_custom_includes %}
   {{ include }}
   {% endfor %}
@@ -108,7 +108,7 @@ SSLCryptoDevice {{ zabbix_apache_SSLCryptoDevice }}
   ## Vhost docroot
   DocumentRoot "/usr/share/zabbix"
 
-{% if zabbix_apache_custom_includes %}
+{% if zabbix_apache_custom_includes is iterable and (zabbix_apache_custom_includes | length>0) %}
   {% for include in zabbix_apache_custom_includes %}
   {{ include }}
   {% endfor %}


### PR DESCRIPTION
##### SUMMARY
This features requests opens the possiblity to add custom rules should as headers to the apache_vhosts config such as:

```
Header always set Strict-Transport-Security "max-age=31536000; includeSubdomains;"
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
- role: zabbix_web

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

**playbook**

```
- hosts: zabbix
  roles:
   - role: geerlingguy.apache
      apache_mods_enabled:
        - headers
  - role: zabbix_web
      zabbix_apache_custom_includes:
        - Header always set Strict-Transport-Security "max-age=31536000; includeSubdomains;"
```