### PR TITLE
Use SSL for database connection when zabbix_server_dbtlsconnect is set

### DIFF
--- a/roles/zabbix_server/tasks/mysql.yml
+++ b/roles/zabbix_server/tasks/mysql.yml
@@ -90,6 +90,7 @@
     login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
     login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
     login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
+    check_hostname: "{{ zabbix_server_dbtlsconnect != '' }}"
   delegate_to: "{{ delegated_dbhost }}"
   register: install_mysql_version
   tags:
@@ -104,6 +105,7 @@
     login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
     login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
     login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
+    check_hostname: "{{ zabbix_server_dbtlsconnect != '' }}"
   delegate_to: "{{ delegated_dbhost }}"
   register: mysql_innodb_default_row_format
   when:
@@ -122,6 +124,7 @@
     login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
     login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
     login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
+    check_hostname: "{{ zabbix_server_dbtlsconnect != '' }}"
   when:
     - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload | bool
@@ -143,6 +146,7 @@
     login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
     login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
     login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
+    check_hostname: "{{ zabbix_server_dbtlsconnect != '' }}"
   when:
     - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload | bool
@@ -190,6 +194,7 @@
     collation: "{{ zabbix_server_dbcollation }}"
     state: import
     target: "{{ ls_output_create.stdout }}"
+    check_hostname: "{{ zabbix_server_dbtlsconnect != '' }}"
   when:
     - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload | bool
@@ -209,6 +214,7 @@
     login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
     login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
     login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
+    check_hostname: "{{ zabbix_server_dbtlsconnect != '' }}"
   when:
     - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload | bool
@@ -279,6 +285,7 @@
     collation: "{{ zabbix_server_dbcollation }}"
     state: import
     target: "{{ item.stdout }}"
+    check_hostname: "{{ zabbix_server_dbtlsconnect != '' }}"
   with_items: "{{ ls_output_schema.results }}"
   when:
     - zabbix_version is version('3.0', '<')


### PR DESCRIPTION
##### SUMMARY
I am setting up Zabbix with a database where SSL is enforced. Zabbix itself works fine with this, thanks to the `zabbix_server_dbtlsconnect` parameter, but a few of the playbook's setup tasks try to connect without TLS, which fails. This adds a parameter to enable TLS if the server would also be set to use it.

This isn't a perfect solution, but the `community.mysql` collection doesn't provide a way to use a TLS connection without setting one of `check_hostname`, `ca_cert`, `client_key`, or `client_hostname`, and we don't (can't, in our case) specify a cert/key. This _will_ potentially fail when the host presents a cert with the wrong hostname (which can happen if `zabbix_server_dbtlsconnect` is set to `required` rather than `verify_ca` or `verify_full`). However, there's not a way to enable TLS without setting one of these options without _also_ changing the MySQL collection.

There's some more background on this issue in the `community.mysql` collection: https://github.com/ansible-collections/community.mysql/issues/90

(I'm not convinced this is the right approach, though it does fix our particular use case! If there's another way to fix this that would be better, I'd appreciate the feedback and can try to update the PR if desired.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_server role
