### PR TITLE
Correct minimum dependency for ansible.netcommon

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,7 +18,7 @@ homepage: https://github.com/ansible-collections/community.zabbix
 issues: https://github.com/ansible-collections/community.zabbix/issues
 dependencies:
   ansible.windows: "*"
-  ansible.netcommon: "*"
+  ansible.netcommon: ">=3.1.1"
   ansible.posix: "*"
   community.general: "*"
   community.mysql: "*"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Connection plugin options are broken in ansible.netcommon < 3.1.1, so settings like `ansible_zabbix_url_path` have no effect.

Possibly related issues: ~~#950~~ #946 #894

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
galaxy.yml