### PR TITLE
CI: add ansible-core stable-2.15 to test matrix

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -31,6 +31,7 @@ jobs:
           - stable-2.12
           - stable-2.13
           - stable-2.14
+          - stable-2.15
           - devel
         python:
           - 3.9

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -43,6 +43,7 @@ jobs:
           - stable-2.12
           - stable-2.13
           - stable-2.14
+          - stable-2.15
           - devel
         python:
           - 3.9


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ansible-core devel is 2.16 now, 2.15 is in beta.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test

##### ADDITIONAL INFORMATION
https://github.com/ansible-collections/news-for-maintainers/issues/41