### PR TITLE
fix: `found` used before assignment

### DIFF
--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -719,8 +719,12 @@ class Host(ZabbixBase):
         if len(exist_interfaces) != len(interfaces):
             return True
 
+        # If there are no interfaces and we require none (when using active checks only)
+        if len(exist_interfaces) == 0 and len(interfaces) == 0:
+            return False
+
+        found = False
         for iface in interfaces:
-            found = False
             for e_int in exist_interfaces:
                 diff_dict = {}
                 zabbix_utils.helper_cleanup_data(zabbix_utils.helper_compare_dictionaries(iface, e_int, diff_dict))


### PR DESCRIPTION
##### SUMMARY
When specifying no interfaces, `found` is used before it is assigned (because the list is empty. 
This introduces an issue where the task is always changed if the requested interface list is empty and the actual interface is empty as well.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ADDITIONAL INFORMATION
I don't use the normal agent, since IP addresses change every reboot. I only use active checks, so no interface is required.
If I do supply an interface, the hosts show up as "unknown", which is confusing. 
This PR allows managing hosts to be monitored using active checks only.
