### PR TITLE
Replaced deprecated apt_key

### DIFF
--- a/changelogs/fragments/969_replace_apt_key.yml
+++ b/changelogs/fragments/969_replace_apt_key.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Replaced usage of deprecated apt key management in Debian based distros - See https://wiki.debian.org/DebianRepository/UseThirdParty

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -40,10 +40,24 @@
   until: gnupg_installed is succeeded
   become: true
 
-- name: "Debian | Install gpg key"
-  apt_key:
-    id: "{{ sign_keys[zabbix_short_version][zabbix_agent_distribution_release]['sign_key'] }}"
+# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default. 
+# It SHOULD be created with permissions 0755 if it is needed and does not already exist.
+# See: https://wiki.debian.org/DebianRepository/UseThirdParty
+- name: "Debian | Create /etc/apt/keyrings/ on older versions"
+  ansible.builtin.file:
+    path: /etc/apt/keyrings/
+    state: directory
+    mode: '0755'
+  when:
+    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "22") or
+      (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
+
+- name: "Debian | Download gpg key"
+  ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
+    dest: "{{ zabbix_gpg_key }}"
+    mode: '0644'
+    force: true
   environment:
     http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
     https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
@@ -54,7 +68,7 @@
 
 - name: "Debian | Installing repository {{ ansible_distribution }}"
   apt_repository:
-    repo: "{{ item }} {{ zabbix_agent_apt_repository | join(' ') }}"
+    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] {{ zabbix_agent_apt_repository | join(' ') }}"
     state: present
   become: true
   with_items:

--- a/roles/zabbix_agent/vars/Debian.yml
+++ b/roles/zabbix_agent/vars/Debian.yml
@@ -37,8 +37,6 @@ zabbix_valid_agent_versions:
     - 6.4
     - 6.2
     - 6.0
-    - 5.0
-    - 4.0
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"

--- a/roles/zabbix_agent/vars/Debian.yml
+++ b/roles/zabbix_agent/vars/Debian.yml
@@ -37,3 +37,8 @@ zabbix_valid_agent_versions:
     - 6.4
     - 6.2
     - 6.0
+    - 5.0
+    - 4.0
+
+debian_keyring_path: /etc/apt/keyrings/
+zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -24,15 +24,29 @@
   when:
     - ansible_machine == "aarch64"
 
-- name: "Debian | Install gpg key"
-  apt_key:
-    id: "{{ sign_keys[zabbix_short_version][ansible_distribution_release]['sign_key'] }}"
+# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default. 
+# It SHOULD be created with permissions 0755 if it is needed and does not already exist.
+# See: https://wiki.debian.org/DebianRepository/UseThirdParty
+- name: "Debian | Create /etc/apt/keyrings/ on older versions"
+  ansible.builtin.file:
+    path: /etc/apt/keyrings/
+    state: directory
+    mode: '0755'
+  when:
+    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "22") or
+      (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
+
+- name: "Debian | Download gpg key"
+  ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
+    dest: "{{ zabbix_gpg_key }}"
+    mode: '0644'
+    force: true
   become: true
 
 - name: "Debian | Installing repository Debian"
   apt_repository:
-    repo: "{{ item }} {{ zabbix_javagateway_apt_repository | join(' ') }}"
+    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] {{ zabbix_javagateway_apt_repository | join(' ') }}"
     state: present
   become: true
   with_items:

--- a/roles/zabbix_javagateway/vars/Debian.yml
+++ b/roles/zabbix_javagateway/vars/Debian.yml
@@ -21,3 +21,6 @@ zabbix_valid_javagateway_versions:
     - 6.4
     - 6.2
     - 6.0
+
+debian_keyring_path: /etc/apt/keyrings/
+zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -30,13 +30,26 @@
   until: gnupg_installed is succeeded
   become: true
 
-- name: "Debian | Install gpg key"
-  apt_key:
-    id: "{{ sign_keys[zabbix_short_version][ansible_distribution_release]['sign_key'] }}"
+# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default. 
+# It SHOULD be created with permissions 0755 if it is needed and does not already exist.
+# See: https://wiki.debian.org/DebianRepository/UseThirdParty
+- name: "Debian | Create /etc/apt/keyrings/ on older versions"
+  ansible.builtin.file:
+    path: /etc/apt/keyrings/
+    state: directory
+    mode: '0755'
+  when:
+    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "22") or
+      (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
+
+- name: "Debian | Download gpg key"
+  ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
+    dest: "{{ zabbix_gpg_key }}"
+    mode: '0644'
+    force: true
   register: are_zabbix_proxy_dependency_packages_installed
   until: are_zabbix_proxy_dependency_packages_installed is succeeded
-
   become: true
   tags:
     - zabbix-proxy
@@ -44,7 +57,7 @@
 
 - name: "Debian | Installing repository {{ ansible_distribution }}"
   apt_repository:
-    repo: "{{ item }} http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_distribution.lower() }}/ {{ ansible_distribution_release }} main"
+    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_distribution.lower() }}/ {{ ansible_distribution_release }} main"
     state: present
   become: true
   with_items:

--- a/roles/zabbix_proxy/vars/Debian.yml
+++ b/roles/zabbix_proxy/vars/Debian.yml
@@ -43,3 +43,6 @@ mysql_client_pkgs:
 mysql_plugin:
   "18": mysql_native_password
   "10": mysql_native_password
+
+debian_keyring_path: /etc/apt/keyrings/
+zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -60,10 +60,24 @@
   until: gnupg_installed is succeeded
   become: true
 
-- name: "Debian | Install gpg key"
-  apt_key:
-    id: "{{ sign_keys[zabbix_short_version][ansible_distribution_release]['sign_key'] }}"
+# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default. 
+# It SHOULD be created with permissions 0755 if it is needed and does not already exist.
+# See: https://wiki.debian.org/DebianRepository/UseThirdParty
+- name: "Debian | Create /etc/apt/keyrings/ on older versions"
+  ansible.builtin.file:
+    path: /etc/apt/keyrings/
+    state: directory
+    mode: '0755'
+  when:
+    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "22") or
+      (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
+
+- name: "Debian | Download gpg key"
+  ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
+    dest: "{{ zabbix_gpg_key }}"
+    mode: '0644'
+    force: true
   register: zabbix_server_repo_files_installed
   until: zabbix_server_repo_files_installed is succeeded
   become: true
@@ -73,7 +87,7 @@
 
 - name: "Debian | Installing repository {{ ansible_distribution }}"
   apt_repository:
-    repo: "{{ item }} {{ zabbix_server_apt_repository | join(' ') }}"
+    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] {{ zabbix_server_apt_repository | join(' ') }}"
     state: present
   become: true
   with_items:

--- a/roles/zabbix_server/vars/Debian.yml
+++ b/roles/zabbix_server/vars/Debian.yml
@@ -24,3 +24,6 @@ zabbix_valid_server_versions:
     - 6.0
   "18":
     - 6.0
+
+debian_keyring_path: /etc/apt/keyrings/
+zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -65,10 +65,24 @@
     - init
     - config
 
-- name: "Debian | Install gpg key"
-  apt_key:
-    id: "{{ sign_keys[zabbix_short_version][ansible_distribution_release]['sign_key'] }}"
+# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default. 
+# It SHOULD be created with permissions 0755 if it is needed and does not already exist.
+# See: https://wiki.debian.org/DebianRepository/UseThirdParty
+- name: "Debian | Create /etc/apt/keyrings/ on older versions"
+  ansible.builtin.file:
+    path: /etc/apt/keyrings/
+    state: directory
+    mode: '0755'
+  when:
+    - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "22") or
+      (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
+
+- name: "Debian | Download gpg key"
+  ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
+    dest: "{{ zabbix_gpg_key }}"
+    mode: '0644'
+    force: true
   become: true
   tags:
     - zabbix-web
@@ -77,7 +91,7 @@
 
 - name: "Debian | Installing repository {{ ansible_distribution }}"
   apt_repository:
-    repo: "{{ item }} {{ zabbix_server_apt_repository | join(' ') }}"
+    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] {{ zabbix_server_apt_repository | join(' ') }}"
     state: present
   become: true
   with_items:

--- a/roles/zabbix_web/vars/Debian.yml
+++ b/roles/zabbix_web/vars/Debian.yml
@@ -42,3 +42,6 @@ zabbix_valid_web_versions:
     - 6.0
   "18":
     - 6.0
+
+debian_keyring_path: /etc/apt/keyrings/
+zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Replaced the usage of the deprecated `apt_key` Fixes #801

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* zabbix_agent
* zabbix_javagateway
* zabbix_proxy
* zabbix_server
* zabbix_web

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [community.zabbix.zabbix_agent : Debian | Create /etc/apt/keyrings/ on older versions] *****************
skipping: [localhost]

TASK [community.zabbix.zabbix_agent : Debian | Download gpg key] ********************************************
changed: [localhost]```
