### PR TITLE
CI: don't hardcode the workspace

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -53,7 +53,7 @@ jobs:
         run: pip install docker-compose zabbix-api
 
       - name: Install ansible.netcommon collection
-        run: ansible-galaxy collection install ansible.netcommon -p /home/runner/work/community.zabbix/community.zabbix
+        run: ansible-galaxy collection install ansible.netcommon -p $GITHUB_WORKSPACE
         working-directory: ./ansible_collections/community/zabbix
 
       # For Zabbix integration tests we need to test against different versions of


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The workspace location is available as a variable, so there's no need to use a static location. This fixes GHA runs in forks that use a different repository name, and is also more future-proof.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
CI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
