### PR TITLE
Correct minimum ansible version

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.12'
 action_groups:
   zabbix:
     - zabbix_action


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Versions less than 2.12 are not tested, which has already allowed at least [one](https://github.com/ansible-collections/community.zabbix/commit/c28d5c850e68e8a4bc8f3c457d92d06673e8a1fe) breaking change through (`ansible.module_utils.compat.version` was [added](https://github.com/ansible/ansible/pull/74644) in ansible-core 2.12.)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
runtime.yml