### PR TITLE
debian and ubuntu agent2 plugin add

### DIFF
--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -106,6 +106,7 @@
   when:
     - ansible_distribution == "Debian"
     - zabbix_repo == "zabbix"
+    - zabbix_agent2
   become: true
   tags:
     - zabbix-agent
@@ -121,6 +122,7 @@
   when:
     - ansible_distribution == "Debian"
     - zabbix_repo == "zabbix"
+    - zabbix_agent2
   become: true
   tags:
     - zabbix-agent
@@ -171,6 +173,7 @@
     - ansible_distribution == "Ubuntu"
     - ansible_machine == "aarch64"
     - zabbix_repo == "zabbix"
+    - zabbix_agent2
   become: true
   tags:
     - zabbix-agent
@@ -187,6 +190,7 @@
     - ansible_distribution == "Ubuntu"
     - ansible_machine == "aarch64"
     - zabbix_repo == "zabbix"
+    - zabbix_agent2
   become: true
   tags:
     - zabbix-agent
@@ -237,6 +241,7 @@
     - ansible_distribution == "Ubuntu"
     - ansible_machine != "aarch64"
     - zabbix_repo == "zabbix"
+    - zabbix_agent2
   become: true
   tags:
     - zabbix-agent
@@ -253,6 +258,7 @@
     - ansible_distribution == "Ubuntu"
     - ansible_machine != "aarch64"
     - zabbix_repo == "zabbix"
+    - zabbix_agent2
   become: true
   tags:
     - zabbix-agent

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -95,6 +95,38 @@
     - zabbix-agent
     - init
 
+###debian agent2
+- name: "Debian | Installing deb-src repository Debian"
+  apt_repository:
+    repo: "deb-src https://repo.zabbix.com/zabbix-agent2-plugins/1/debian/ {{ zabbix_agent_distribution_release }} main"
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  when:
+    - ansible_distribution == "Debian"
+    - zabbix_repo == "zabbix"
+  become: true
+  tags:
+    - zabbix-agent
+    - init
+
+- name: "Debian | Installing deb repository Debian"
+  apt_repository:
+    repo: "deb https://repo.zabbix.com/zabbix-agent2-plugins/1/debian/ {{ zabbix_agent_distribution_release }} main"
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  when:
+    - ansible_distribution == "Debian"
+    - zabbix_repo == "zabbix"
+  become: true
+  tags:
+    - zabbix-agent
+    - init
+###
+
 - name: "Debian | Installing deb-src repository Ubuntu Arm64"
   apt_repository:
     repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu-arm64/ {{ zabbix_agent_distribution_release }} main"
@@ -127,6 +159,40 @@
     - zabbix-agent
     - init
 
+###ubuntu arm64 agent2
+- name: "Debian | Installing deb-src repository Ubuntu Arm64"
+  apt_repository:
+    repo: "deb-src https://repo.zabbix.com/zabbix-agent2-plugins/1//ubuntu-arm64/ {{ zabbix_agent_distribution_release }} main"
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_machine == "aarch64"
+    - zabbix_repo == "zabbix"
+  become: true
+  tags:
+    - zabbix-agent
+    - init
+
+- name: "Debian | Installing deb repository Ubuntu Arm64"
+  apt_repository:
+    repo: "deb https://repo.zabbix.com/zabbix-agent2-plugins/1/ubuntu-arm64/ {{ zabbix_agent_distribution_release }} main"
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_machine == "aarch64"
+    - zabbix_repo == "zabbix"
+  become: true
+  tags:
+    - zabbix-agent
+    - init
+####
+
 - name: "Debian | Installing deb-src repository Ubuntu"
   apt_repository:
     repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ zabbix_agent_distribution_release }} main"
@@ -158,6 +224,40 @@
   tags:
     - zabbix-agent
     - init
+
+###ubuntu agent2
+- name: "Debian | Installing deb-src repository Ubuntu"
+  apt_repository:
+    repo: "deb-src https://repo.zabbix.com/zabbix-agent2-plugins/1/ubuntu/ {{ zabbix_agent_distribution_release }} main"
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_machine != "aarch64"
+    - zabbix_repo == "zabbix"
+  become: true
+  tags:
+    - zabbix-agent
+    - init
+
+- name: "Debian | Installing deb repository Ubuntu"
+  apt_repository:
+    repo: "deb https://repo.zabbix.com/zabbix-agent2-plugins/1/ubuntu/ {{ zabbix_agent_distribution_release }} main"
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_machine != "aarch64"
+    - zabbix_repo == "zabbix"
+  become: true
+  tags:
+    - zabbix-agent
+    - init
+###
 
 - name: "Debian | Create /etc/apt/preferences.d/"
   file:


### PR DESCRIPTION
Adding repositories of zabbix agent2 plugins on ubuntu and debian

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 zabbix-agent-2-plugins

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
