### PR TITLE
Remove installing zabbix-api task from integration-test and 'python version is not 2.7' condition from tox step

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -48,7 +48,7 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Install dependencies
-        run: pip install docker-compose zabbix-api
+        run: pip install docker-compose
 
       - name: Install ansible.netcommon collection
         run: ansible-galaxy collection install ansible.netcommon -p $GITHUB_WORKSPACE

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Run lint test for py3
         run: tox -elinters-py3 -vv
         working-directory: ./ansible_collections/community/zabbix
-        if: matrix.python != '2.7'
 
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Never using dependency and condition exsist on github actions. I'd like to remove it. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- Github action workflows
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
