### PR TITLE
Re-add defaults, documentation entry for the var zabbix_apache_custom_includes

### DIFF
--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -126,6 +126,7 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_SSLSessionCache`: Type of the global/inter-process SSL Session Cache
 * `zabbix_web_SSLSessionCacheTimeout`: Number of seconds before an SSL session expires in the Session Cache
 * `zabbix_web_SSLCryptoDevice`: Enable use of a cryptographic hardware accelerator
+* `zabbix_apache_custom_includes`: Configure custom includes. Default: `[]`
 
 When `zabbix_web_tls_crt`, `zabbix_web_tls_key` and/or `zabbix_web_tls_chain` are used, make sure that these files exists before executing this role. The Zabbix-Web role will not install the mentioned files.
 

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -34,6 +34,7 @@ zabbix_php_fpm_conf_listen: true
 # zabbix_web_upload_max_filesize: 2M
 # zabbix_web_max_input_time: 300
 # zabbix_web_max_input_vars: 10000
+zabbix_apache_custom_includes: []
 
 # Database
 zabbix_server_database: pgsql


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The variable appears to have been accidentally removed in the final 2.0.0 tag release.
I've readded it to what I believe to be the appropriate locations.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #985

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`TASK [community.zabbix.zabbix_web : Apache | Install apache vhost]`
