### PR TITLE
Delete inventory file from integration test directory

### DIFF
--- a/tests/integration/inventory
+++ b/tests/integration/inventory
@@ -1,2 +1,0 @@
-[testgroup]
-testhost ansible_connection="local" ansible_pipelining="yes" ansible_python_interpreter="/home/ey/env_py39_ans214/bin/python3"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Delete inventory file from integration test directory
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request?

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-test integration
##### ADDITIONAL INFORMATION
- tests/integration/inventory file is not used by GitHub actions.
- `ansible_python_interpreter` fact makes me confused (e.g. `We can test ansible 2.14 only?`).
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
