### PR TITLE
zabbix_hostmacro module updated: add description property for Host macro

### DIFF
--- a/changelogs/fragments/hostmacro_modules.yml
+++ b/changelogs/fragments/hostmacro_modules.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_hostmacro module - Add description property for Host macro creation/update. Allow to set/update description of Zabbix host macros.

--- a/plugins/modules/zabbix_hostmacro.py
+++ b/plugins/modules/zabbix_hostmacro.py
@@ -184,7 +184,7 @@ class HostMacro(ZabbixBase):
         try:
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
-            self._zapi.usermacro.update({"hostmacroid": host_macro_id, "value": macro_value, "type": macro_type}, "description": macro_description})
+            self._zapi.usermacro.update({"hostmacroid": host_macro_id, "value": macro_value, "type": macro_type, "description": macro_description})
             self._module.exit_json(changed=True, result="Successfully updated host macro %s" % macro_name)
         except Exception as e:
             self._module.fail_json(msg="Failed to update host macro %s: %s" % (macro_name, e))

--- a/plugins/modules/zabbix_hostmacro.py
+++ b/plugins/modules/zabbix_hostmacro.py
@@ -179,7 +179,8 @@ class HostMacro(ZabbixBase):
         host_macro_id = host_macro_obj["hostmacroid"]
         if host_macro_obj["macro"] == macro_name:
             # no change only when macro type == 0. when type = 1 or 2 zabbix will not output value of it.
-            if host_macro_obj["type"] == "0" and macro_type == "0" and host_macro_obj["value"] == macro_value and host_macro_obj["description"] == macro_description:
+            if (host_macro_obj["type"] == "0" and macro_type == "0" and host_macro_obj["value"] == macro_value
+                    and host_macro_obj["description"] == macro_description):
                 self._module.exit_json(changed=False, result="Host macro %s already up to date" % macro_name)
         try:
             if self._module.check_mode:

--- a/plugins/modules/zabbix_hostmacro.py
+++ b/plugins/modules/zabbix_hostmacro.py
@@ -43,6 +43,11 @@ options:
         required: false
         choices: ["text", "secret", "vault"]
         default: "text"
+    macro_description:
+        description:
+            - Text Description of the global macro.
+        type: str
+        default: ""
     state:
         description:
             - State of the macro.
@@ -90,6 +95,7 @@ EXAMPLES = r"""
     host_name: ExampleHost
     macro_name: EXAMPLE.MACRO
     macro_value: Example value
+    macro_description: Example description
     state: present
 
 # Values with curly brackets need to be quoted otherwise they will be interpreted as a dictionary
@@ -107,6 +113,7 @@ EXAMPLES = r"""
     host_name: ExampleHost
     macro_name: "{$EXAMPLE.MACRO}"
     macro_value: Example value
+    macro_description: Example description
     state: present
 
 - name: Delete existing host macro
@@ -158,26 +165,26 @@ class HostMacro(ZabbixBase):
             self._module.fail_json(msg="Failed to get host macro %s: %s" % (macro_name, e))
 
     # create host macro
-    def create_host_macro(self, macro_name, macro_value, macro_type, host_id):
+    def create_host_macro(self, macro_name, macro_value, macro_type, macro_description, host_id):
         try:
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
-            self._zapi.usermacro.create({"hostid": host_id, "macro": macro_name, "value": macro_value, "type": macro_type})
+            self._zapi.usermacro.create({"hostid": host_id, "macro": macro_name, "value": macro_value, "type": macro_type}, "description": macro_description})
             self._module.exit_json(changed=True, result="Successfully added host macro %s" % macro_name)
         except Exception as e:
             self._module.fail_json(msg="Failed to create host macro %s: %s" % (macro_name, e))
 
     # update host macro
-    def update_host_macro(self, host_macro_obj, macro_name, macro_value, macro_type):
+    def update_host_macro(self, host_macro_obj, macro_name, macro_value, macro_type, macro_description):
         host_macro_id = host_macro_obj["hostmacroid"]
         if host_macro_obj["macro"] == macro_name:
             # no change only when macro type == 0. when type = 1 or 2 zabbix will not output value of it.
-            if host_macro_obj["type"] == "0" and macro_type == "0" and host_macro_obj["value"] == macro_value:
+            if host_macro_obj["type"] == "0" and macro_type == "0" and host_macro_obj["value"] == macro_value and host_macro_obj["description"] == macro_description:
                 self._module.exit_json(changed=False, result="Host macro %s already up to date" % macro_name)
         try:
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
-            self._zapi.usermacro.update({"hostmacroid": host_macro_id, "value": macro_value, "type": macro_type})
+            self._zapi.usermacro.update({"hostmacroid": host_macro_id, "value": macro_value, "type": macro_type}, "description": macro_description})
             self._module.exit_json(changed=True, result="Successfully updated host macro %s" % macro_name)
         except Exception as e:
             self._module.fail_json(msg="Failed to update host macro %s: %s" % (macro_name, e))
@@ -217,6 +224,7 @@ def main():
         macro_name=dict(type="str", required=True),
         macro_value=dict(type="str", required=False),
         macro_type=dict(type="str", default="text", choices=["text", "secret", "vault"]),
+        macro_description=dict(type="str", default=""),
         state=dict(type="str", default="present", choices=["present", "absent"]),
         force=dict(type="bool", default=True)
     ))
@@ -231,6 +239,7 @@ def main():
     host_name = module.params["host_name"]
     macro_name = normalize_macro_name(module.params["macro_name"])
     macro_value = module.params["macro_value"]
+    macro_description = module.params["macro_description"]
     state = module.params["state"]
     force = module.params["force"]
     if module.params["macro_type"] == "secret":
@@ -255,10 +264,10 @@ def main():
     else:
         if not host_macro_obj:
             # create host macro
-            host_macro_class_obj.create_host_macro(macro_name, macro_value, macro_type, host_id)
+            host_macro_class_obj.create_host_macro(macro_name, macro_value, macro_type, macro_description, host_id)
         elif force:
             # update host macro
-            host_macro_class_obj.update_host_macro(host_macro_obj, macro_name, macro_value, macro_type)
+            host_macro_class_obj.update_host_macro(host_macro_obj, macro_name, macro_value, macro_type, macro_description)
         else:
             module.exit_json(changed=False, result="Host macro %s already exists and force is set to no" % macro_name)
 

--- a/plugins/modules/zabbix_hostmacro.py
+++ b/plugins/modules/zabbix_hostmacro.py
@@ -169,7 +169,7 @@ class HostMacro(ZabbixBase):
         try:
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
-            self._zapi.usermacro.create({"hostid": host_id, "macro": macro_name, "value": macro_value, "type": macro_type}, "description": macro_description})
+            self._zapi.usermacro.create({"hostid": host_id, "macro": macro_name, "value": macro_value, "type": macro_type, "description": macro_description})
             self._module.exit_json(changed=True, result="Successfully added host macro %s" % macro_name)
         except Exception as e:
             self._module.fail_json(msg="Failed to create host macro %s: %s" % (macro_name, e))

--- a/tests/integration/targets/test_zabbix_hostmacro/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_hostmacro/tasks/main.yml
@@ -14,6 +14,7 @@
     host_name: zbx_hmacro_host01
     macro_name: zbxhmacro_test01
     macro_value: 123
+    macro_description: Global Macro description
   register: zbxhmacro_new
 
 - name: assert that macro was created
@@ -25,6 +26,7 @@
     host_name: zbx_hmacro_host01
     macro_name: zbxhmacro_test01
     macro_value: 123
+    macro_description: Global Macro description
   register: zbxhmacro_existing
 
 - name: assert that nothing has been changed
@@ -36,6 +38,7 @@
     host_name: zbx_hmacro_host01
     macro_name: "{$ZBXHMACRO_TEST01}"
     macro_value: 123
+    macro_description: Global Macro description
   register: zbxhmacro_existing_native
 
 - name: assert that nothing has been changed
@@ -47,6 +50,7 @@
     host_name: zbx_hmacro_host01
     macro_name: "{$ZBXHMACRO_TEST02}"
     macro_value: abcd
+    macro_description: Global Macro description
   register: zbxhmacro_new_native
 
 - name: assert that nothing macro was created
@@ -58,6 +62,7 @@
     host_name: zbx_hmacro_host01
     macro_name: zbxhmacro_test01
     macro_value: abc
+    macro_description: Global Macro description
     force: false
   register: zbxhmacro_update_noforce
 
@@ -70,6 +75,7 @@
     host_name: zbx_hmacro_host01
     macro_name: zbxhmacro_test01
     macro_value: abc
+    macro_description: Global Macro description
   register: zbxhmacro_update
   ignore_errors: true
 
@@ -82,6 +88,7 @@
     host_name: zbx_hmacro_host01
     macro_name: low_space_limit:/home
     macro_value: 10
+    macro_description: Global Macro description
   register: zbxhmacro_context_new
 
 - name: assert that macro was created
@@ -93,6 +100,7 @@
     host_name: zbx_hmacro_host01
     macro_name: LOW_SPACE_LIMIT:/home
     macro_value: 10
+    macro_description: Global Macro description
   register: zbxhmacro_context_existing
 
 - name: assert that nothing has been changed
@@ -132,6 +140,7 @@
     macro_name: zbxhmacro_test03
     macro_value: abcd
     macro_type: secret
+    macro_description: Global Macro description
   register: zbxhmacro_update
   ignore_errors: true
 
@@ -145,6 +154,7 @@
     macro_name: zbxhmacro_test03
     macro_value: abcd
     macro_type: secret
+    macro_description: Global Macro description
   register: zbxhmacro_update
   ignore_errors: true
 


### PR DESCRIPTION
##### SUMMARY

Add description property for Host macro creation/update: allow to set/update description of Zabbix host macros.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

zabbix_hostmacro module

##### ADDITIONAL INFORMATION

This Add 'description' property for Host Macro module (https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_hostmacro_module.html)

It uses 'description' property described in: https://www.zabbix.com/documentation/current/en/manual/api/reference/usermacro/object#host-macro