### PR TITLE
fix: add consideration of string result(yaml, xml,...) to httpapi plugin

### DIFF
--- a/plugins/httpapi/zabbix.py
+++ b/plugins/httpapi/zabbix.py
@@ -171,11 +171,9 @@ class HttpApi(HttpApiBase):
             except ValueError:
                 raise ConnectionError("Invalid JSON response: %s" % value)
 
-            try:
-                # Some methods return bool not a dict in "result"
-                iter(json_data)
-            except TypeError:
-                # Do not try to find "error" if it is not a dict
+            # Some methods return bool or string(xml, yaml...)
+            # Is this case, do not try to find "error"
+            if isinstance(json_data, bool) or isinstance(json_data, str):
                 return response.getcode(), json_data
 
             if "error" in json_data:


### PR DESCRIPTION
##### SUMMARY

close #888 

Some API returns XML, Yaml String, not only dict/bool.
But httpapi.zabbix.HttpApi.send_request didnt care this case.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

HttpApi

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
