### PR TITLE
Run as Non-Root

### DIFF
--- a/changelogs/fragments/non_root.yml
+++ b/changelogs/fragments/non_root.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - all roles - Modified to allow a non-root user to run the role.

--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -233,6 +233,7 @@
     path: /sys/firmware/dmi/tables/DMI
     owner: root
     group: zabbix
+  become: true
   when: zabbix_agent_chassis | bool
   tags:
     - config

--- a/roles/zabbix_agent/tasks/api.yml
+++ b/roles/zabbix_agent/tasks/api.yml
@@ -8,7 +8,6 @@
   register: zabbix_api_hostgroup_created
   until: zabbix_api_hostgroup_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
-  become: false
   tags:
     - api
 
@@ -42,7 +41,6 @@
   register: zabbix_api_host_created
   until: zabbix_api_host_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
-  become: false
   changed_when: false
   tags:
     - api
@@ -77,7 +75,6 @@
   register: zabbix_api_host_created
   until: zabbix_api_host_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
-  become: false
   changed_when: false
   tags:
     - api
@@ -95,6 +92,5 @@
   register: zabbix_api_hostmarcro_created
   until: zabbix_api_hostmarcro_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
-  become: false
   tags:
     - api

--- a/roles/zabbix_agent/tasks/selinux.yml
+++ b/roles/zabbix_agent/tasks/selinux.yml
@@ -102,6 +102,7 @@
     name: zabbix_run_sudo
     persistent: true
     state: true
+  become: true
   when:
     - ansible_selinux.status == "enabled"
     - selinux_allow_zabbix_run_sudo|bool

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -32,14 +32,15 @@
   tags:
     - install
 
-# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default. 
+# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default.
 # It SHOULD be created with permissions 0755 if it is needed and does not already exist.
 # See: https://wiki.debian.org/DebianRepository/UseThirdParty
 - name: "Debian | Create /etc/apt/keyrings/ on older versions"
   ansible.builtin.file:
     path: /etc/apt/keyrings/
     state: directory
-    mode: '0755'
+    mode: "0755"
+  become: true
   when:
     - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "22") or
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
@@ -48,7 +49,7 @@
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"
-    mode: '0644'
+    mode: "0644"
     force: true
   become: true
   tags:
@@ -87,6 +88,7 @@
     state: stopped
     enabled: true
     daemon_reload: true
+  become: true
   when:
     - zabbix_java_gateway_install.changed
   tags:

--- a/roles/zabbix_javagateway/tasks/main.yml
+++ b/roles/zabbix_javagateway/tasks/main.yml
@@ -36,6 +36,7 @@
     owner: zabbix
     group: zabbix
     mode: "{{ zabbix_java_gateway_conf_mode }}"
+  become: true
   notify:
     - zabbix-java-gateway restarted
   tags:
@@ -47,5 +48,6 @@
     state: started
     enabled: true
     daemon_reload: true
+  become: true
   tags:
     - service

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -35,14 +35,15 @@
   tags:
     - install
 
-# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default. 
+# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default.
 # It SHOULD be created with permissions 0755 if it is needed and does not already exist.
 # See: https://wiki.debian.org/DebianRepository/UseThirdParty
 - name: "Debian | Create /etc/apt/keyrings/ on older versions"
   ansible.builtin.file:
     path: /etc/apt/keyrings/
     state: directory
-    mode: '0755'
+    mode: "0755"
+  become: true
   when:
     - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "22") or
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
@@ -51,7 +52,7 @@
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"
-    mode: '0644'
+    mode: "0644"
     force: true
   register: are_zabbix_proxy_dependency_packages_installed
   until: are_zabbix_proxy_dependency_packages_installed is succeeded

--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -51,6 +51,7 @@
 - name: "Get the file for database schema"
   shell: ls -1 {{ db_file_path[zabbix_short_version] }}
   changed_when: false
+  become: true
   when:
     - zabbix_proxy_database_sqlload
   register: ls_output_schema
@@ -146,7 +147,6 @@
   when:
     - zabbix_api_create_proxy | bool
   delegate_to: "{{ zabbix_api_server_host }}"
-  become: false
   tags:
     - api
 

--- a/roles/zabbix_proxy/tasks/mysql.yml
+++ b/roles/zabbix_proxy/tasks/mysql.yml
@@ -62,6 +62,7 @@
   stat:
     path: /etc/zabbix/schema.done
   register: done_file
+  become: true
   when:
     - zabbix_proxy_database_sqlload
   tags:
@@ -154,6 +155,7 @@
     path: /etc/zabbix/schema.done
     state: touch
     mode: "0644"
+  become: true
   when:
     - zabbix_proxy_database_sqlload
     - not done_file.stat.exists

--- a/roles/zabbix_proxy/tasks/postgresql.yml
+++ b/roles/zabbix_proxy/tasks/postgresql.yml
@@ -89,6 +89,7 @@
     executable: /bin/bash
   environment:
     PGPASSWORD: "{{ zabbix_proxy_dbpassword }}"
+  become: true
   when:
     - zabbix_proxy_database_creation
   tags:

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -54,14 +54,15 @@
   tags:
     - install
 
-# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default. 
+# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default.
 # It SHOULD be created with permissions 0755 if it is needed and does not already exist.
 # See: https://wiki.debian.org/DebianRepository/UseThirdParty
 - name: "Debian | Create /etc/apt/keyrings/ on older versions"
   ansible.builtin.file:
     path: /etc/apt/keyrings/
     state: directory
-    mode: '0755'
+    mode: "0755"
+  become: true
   when:
     - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "22") or
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
@@ -70,7 +71,7 @@
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"
-    mode: '0644'
+    mode: "0644"
     force: true
   register: zabbix_server_repo_files_installed
   until: zabbix_server_repo_files_installed is succeeded
@@ -135,6 +136,7 @@
   failed_when: false
   changed_when: false
   check_mode: false
+  become: true
   tags:
     - install
 

--- a/roles/zabbix_server/tasks/main.yml
+++ b/roles/zabbix_server/tasks/main.yml
@@ -38,6 +38,7 @@
     owner: "{{ zabbix_os_user }}"
     group: "{{ zabbix_os_user }}"
     mode: "{{ zabbix_server_conf_mode }}"
+  become: true
   notify:
     - zabbix-server restarted
   tags:
@@ -50,6 +51,7 @@
     group: "{{ zabbix_os_user }}"
     state: directory
     mode: "{{ zabbix_server_include_mode }}"
+  become: true
   tags:
     - install
     - config
@@ -64,6 +66,7 @@
     name: zabbix-server
     state: "{{ zabbix_service_state }}"
     enabled: "{{ zabbix_service_enabled }}"
+  become: true
   tags:
     - service
   when: zabbix_server_manage_service | bool

--- a/roles/zabbix_server/tasks/mysql.yml
+++ b/roles/zabbix_server/tasks/mysql.yml
@@ -63,6 +63,7 @@
 - name: "MySQL | Get the file for create.sql"
   shell: ls -1 {{ datafiles_path }}/{{ 'create' if zabbix_server_version is version('6.0', '<') else 'server' }}.sq*
   changed_when: false
+  become: true
   when:
     - zabbix_server_database_sqlload | bool
   register: ls_output_create
@@ -75,6 +76,7 @@
     -p'{{ zabbix_server_dbpassword }}' -D '{{ zabbix_server_dbname }}' \
     -e 'SELECT mandatory FROM dbversion;'
   register: mysql_db_version
+  become: true
   changed_when: false
   ignore_errors: true
   tags:
@@ -139,6 +141,7 @@
     src: "{{ ls_output_create.stdout }}"
     dest: /tmp/{{ role_name }}/
     flat: true
+  become: true
   when:
     - delegated_dbhost != inventory_hostname
     - zabbix_server_database_sqlload | bool
@@ -152,6 +155,7 @@
     dest: "{{ ls_output_create.stdout | dirname }}"
     mode: "0640"
   delegate_to: "{{ delegated_dbhost }}"
+  become: true
   when:
     - delegated_dbhost != inventory_hostname
     - zabbix_server_database_sqlload | bool
@@ -201,6 +205,7 @@
     path: /etc/zabbix/create.done
     state: touch
     mode: "0644"
+  become: true
   when:
     - zabbix_server_database_sqlload | bool
     - mysql_schema_empty

--- a/roles/zabbix_server/tasks/postgresql.yml
+++ b/roles/zabbix_server/tasks/postgresql.yml
@@ -107,6 +107,7 @@
     warn: "{{ produce_warn | default(omit) }}"
   environment:
     PGPASSWORD: "{{ zabbix_server_dbpassword }}"
+  become: true
   when:
     - zabbix_server_database_sqlload
   tags:
@@ -129,6 +130,7 @@
     warn: "{{ produce_warn | default(omit) }}"
   environment:
     PGPASSWORD: "{{ zabbix_server_dbpassword }}"
+  become: true
   when:
     - zabbix_server_database_timescaledb
   tags:

--- a/roles/zabbix_server/tasks/scripts.yml
+++ b/roles/zabbix_server/tasks/scripts.yml
@@ -7,6 +7,7 @@
     group: "{{ zabbix_os_user }}"
     mode: 0755
   with_items: "{{ zabbix_server_alertscripts }}"
+  become: true
   when: zabbix_server_alertscripts is defined
   tags:
     - config
@@ -19,6 +20,7 @@
     group: "{{ zabbix_os_user }}"
     mode: 0755
   with_items: "{{ zabbix_server_externalscripts }}"
+  become: true
   when: zabbix_server_externalscripts is defined
   tags:
     - config

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -72,14 +72,15 @@
     - dependencies
     - database
 
-# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default. 
+# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default.
 # It SHOULD be created with permissions 0755 if it is needed and does not already exist.
 # See: https://wiki.debian.org/DebianRepository/UseThirdParty
 - name: "Debian | Create /etc/apt/keyrings/ on older versions"
   ansible.builtin.file:
     path: /etc/apt/keyrings/
     state: directory
-    mode: '0755'
+    mode: "0755"
+  become: true
   when:
     - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "22") or
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
@@ -88,7 +89,7 @@
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"
-    mode: '0644'
+    mode: "0644"
     force: true
   become: true
   tags:
@@ -161,5 +162,6 @@
     src: "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
     path: "/usr/share/zabbix/fonts/graphfont.ttf"
     state: link
+  become: true
   tags:
     - install

--- a/roles/zabbix_web/tasks/apache.yml
+++ b/roles/zabbix_web/tasks/apache.yml
@@ -81,6 +81,7 @@
     owner: "{{ zabbix_web_user }}"
     group: "{{ zabbix_web_group }}"
     mode: 0644
+  become: true
   when: ansible_os_family == "Debian"
   tags:
     - config

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -62,6 +62,7 @@
     group: "{{ zabbix_web_group }}"
     state: directory
     mode: 0755
+  become: true
   tags:
     - install
     - config
@@ -73,6 +74,7 @@
     owner: "{{ zabbix_web_user }}"
     group: "{{ zabbix_web_group }}"
     mode: "{{ zabbix_web_conf_mode }}"
+  become: true
   notify:
     - "restart {{ zabbix_web_http_server }}"
   tags:

--- a/roles/zabbix_web/tasks/nginx.yml
+++ b/roles/zabbix_web/tasks/nginx.yml
@@ -3,7 +3,6 @@
   set_fact:
     zabbix_web_user: "{{ zabbix_web_user if zabbix_web_user is defined else _nginx_user }}"
     zabbix_web_group: "{{ zabbix_web_group if zabbix_web_group is defined else _nginx_group }}"
-
     zabbix_web_vhost_location: "{{ zabbix_web_vhost_location if zabbix_web_vhost_location is defined else _nginx_vhost_location }}"
     zabbix_nginx_log_path: "{{ zabbix_nginx_log_path if zabbix_nginx_log_path is defined else _nginx_log_path }}"
     zabbix_nginx_service: "{{ zabbix_nginx_service if zabbix_nginx_service is defined else _nginx_service }}"


### PR DESCRIPTION
##### SUMMARY
As described in #922 this change allows for all roles to be run as a non-root user and instead uses Become on individual tasks as required.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
All Roles
