### PR TITLE
Fix zabbix_proxy role version validation

### DIFF
--- a/changelogs/fragments/proxy_role_fix.yml
+++ b/changelogs/fragments/proxy_role_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_proxy role - failed at version validation. Fix adds cast of zabbix_proxy_version to float, similarly to the other roles.

--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -15,7 +15,7 @@
 - name: Set More Variables
   set_fact:
     zabbix_proxy_db_long: "{{ 'postgresql' if zabbix_proxy_database == 'pgsql' else zabbix_proxy_database }}"
-    zabbix_valid_version: "{{ zabbix_proxy_version in zabbix_valid_proxy_versions[ansible_distribution_major_version] }}"
+    zabbix_valid_version: "{{ zabbix_proxy_version|float in zabbix_valid_proxy_versions[ansible_distribution_major_version] }}"
     zabbix_short_version: "{{ zabbix_proxy_version | regex_replace('\\.', '') }}"
   tags:
     - always


### PR DESCRIPTION
##### SUMMARY
zabbix_proxy role failed at version validation. Fix adds cast of zabbix_proxy_version to float, similarly to the other roles.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_proxy role

##### ADDITIONAL INFORMATION
Attempted default install of the Zabbix proxy on Debian 11 but fails:
```
PLAY [Install Zabbix Proxy] ***********************************************************************************

TASK [Gathering Facts] ****************************************************************************************
ok: [proxy]

TASK [debug] **************************************************************************************************
ok: [proxy] => {
    "ansible_distribution_major_version": "11"
}

TASK [community.zabbix.zabbix_proxy : Include OS-specific variables] ******************************************
ok: [proxy] => {"ansible_facts": {"debian_keyring_path": "/etc/apt/keyrings/", "mysql_client_pkgs": {"10": ["mariadb-client", "{{ zabbix_python_prefix }}-mysqldb"], "11": ["mycli", "{{ zabbix_python_prefix }}-mysqldb"], "18": ["mycli", "{{ zabbix_python_prefix }}-mysqldb"], "20": ["mycli", "{{ zabbix_python_prefix }}-mysqldb"], "22": ["mycli", "{{ zabbix_python_prefix }}-mysqldb"]}, "mysql_plugin": {"10": "mysql_native_password", "18": "mysql_native_password"}, "zabbix_gpg_key": "{{ debian_keyring_path }}/zabbix-official-repo.asc", "zabbix_valid_proxy_versions": {"10": [6.4, 6.2, 6.0], "11": [6.4, 6.2, 6.0], "18": [6.4, 6.2, 6.0], "20": [6.4, 6.2, 6.0], "22": [6.4, 6.2, 6.0]}}, "ansible_included_var_files": ["/usr/local/lib/python3.10/dist-packages/ansible_collections/community/zabbix/roles/zabbix_proxy/vars/Debian.yml"], "changed": false}

TASK [community.zabbix.zabbix_proxy : Determine Latest Supported Zabbix Version] ******************************
ok: [proxy] => {"ansible_facts": {"zabbix_proxy_version": "6.4"}, "changed": false}

TASK [community.zabbix.zabbix_proxy : Set More Variables] *****************************************************
ok: [proxy] => {"ansible_facts": {"zabbix_proxy_db_long": "sqlite3", "zabbix_short_version": "64", "zabbix_valid_version": false}, "changed": false}

TASK [community.zabbix.zabbix_proxy : Stopping Install of Invalid Version] ************************************
fatal: [proxy]: FAILED! => {"changed": false, "msg": "Zabbix version 6.4 is not supported on Debian 11"}
```
Role succeeds after fix.
