### PR TITLE
Add current_passwd optional parameter to zabbix_user module 

### DIFF
--- a/changelogs/fragments/current_passwd_user_module.yml
+++ b/changelogs/fragments/current_passwd_user_module.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_user module - add current_passwd optional parameter to enable password updating of the currently logged in user (https://www.zabbix.com/documentation/6.4/en/manual/api/reference/user/update)

--- a/plugins/modules/zabbix_user.py
+++ b/plugins/modules/zabbix_user.py
@@ -52,6 +52,13 @@ options:
             - Password will not be updated on subsequent runs without setting this value to yes.
         default: no
         type: bool
+    current_passwd:
+        description:
+            - Current password for the user when overriding its password.
+            - Required when overriding the logged in user's password.
+            - https://www.zabbix.com/documentation/6.4/en/manual/api/reference/user/update
+        required: false
+        type: str
     lang:
         description:
             - Language code of the user's language.
@@ -605,6 +612,7 @@ class User(ZabbixBase):
         timezone,
         role_name,
         override_passwd,
+        current_passwd,
     ):
 
         user_ids = {}
@@ -626,6 +634,8 @@ class User(ZabbixBase):
 
         if override_passwd:
             request_data["passwd"] = passwd
+            if current_passwd:
+                request_data["current_passwd"] = current_passwd
 
         request_data["roleid"] = (
             self.get_roleid_by_name(role_name) if role_name else None
@@ -685,6 +695,7 @@ def main():
             override_passwd=dict(
                 type="bool", required=False, default=False, no_log=False
             ),
+            current_passwd=dict(type="str", required=False, no_log=True),
             lang=dict(
                 type="str",
                 choices=[
@@ -760,6 +771,7 @@ def main():
     usrgrps = module.params["usrgrps"]
     passwd = module.params["passwd"]
     override_passwd = module.params["override_passwd"]
+    current_passwd = module.params["current_passwd"]
     lang = module.params["lang"]
     theme = module.params["theme"]
     autologin = module.params["autologin"]
@@ -833,6 +845,7 @@ def main():
                     timezone,
                     role_name,
                     override_passwd,
+                    current_passwd,
                 )
         else:
             diff_check_result = True


### PR DESCRIPTION
##### SUMMARY
The API call would fail when attempting to update (override) the password of the user currently using the API ("Current password is mandatory").
This adds the option to specify it and send it to the API when attempting to update the logged in user's password.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_user module

##### ADDITIONAL INFORMATION
When using the `passwd` and `override_passwd` parameters to update the password of the user currently logged in with the API, the task would fail with the following error:
```paste below
TASK [Set Admin password] **********
fatal: [zabbix_server]: FAILED! => {"changed": false, "msg": "connection error occurred: REST API returned {'code': -32602, 'message': 'Invalid params.', 'data': 'Current password is mandatory.'} when sending {\"jsonrpc\": \"2.0\", \"method\": \"user.update\", \"id\": \"68cd0113-86dd-4b37-8ac9-1c7ab748ada9\", \"params\": {\"userid\": \"1\", \"username\": \"Admin\", \"usrgrps\": [{\"usrgrpid\": \"7\"}, {\"usrgrpid\": \"13\"}], \"passwd\": \"********\"}, \"auth\": \"********\"}"}
```

The fix adds `current_passwd` as an optional parameter so that it can be given to the API when needed, as per https://www.zabbix.com/documentation/6.4/en/manual/api/reference/user/update.
With the fix, the task succeeds.

Here is an example of its use (`omit` is being used to only specify the password when the `ansible_user` is the same, which can be set conditionnally):
```yaml
  - name: Set Admin password
    zabbix_user:
      username: Admin
      passwd: "{{ zabbix_admin_password }}"
      current_passwd: "{{ omit if ansible_user != 'Admin' else zabbix_admin_default_password }}"
      override_passwd: true
```