### PR TITLE
[Zabbix web] Remove "ssl on" config in nginx_vhost.conf.j2

### DIFF
--- a/changelogs/fragments/nginx_ssl_fix.yml
+++ b/changelogs/fragments/nginx_ssl_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_web role - removed 'ssl on;' nginx configuration, which is no longer supported since nginx version 1.25.1.

--- a/roles/zabbix_web/templates/nginx_vhost.conf.j2
+++ b/roles/zabbix_web/templates/nginx_vhost.conf.j2
@@ -68,7 +68,6 @@ server {
     server_tokens off;
     server_name {{ zabbix_api_server_url }} {% for alias in zabbix_url_aliases -%}{{ alias -}} {% endfor %};
 
-    ssl on;
     ssl_certificate {{ zabbix_web_tls_crt }};
     ssl_certificate_key {{ zabbix_web_tls_key }};
     {{ (zabbix_web_ssl_cipher_suite is defined and zabbix_web_ssl_cipher_suite is not none) | ternary('', '# ') }}ssl_ciphers {{ zabbix_web_ssl_cipher_suite | default('') }}


### PR DESCRIPTION
##### SUMMARY
Remove `ssl on;` parameter, it is no longer a valid nginx option since nginx v1.25.1, see: https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam

Keeping it prevent recent nginx from starting.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_web
