### PR TITLE
Fix zabbix_proxy role undefined TLS vars

### DIFF
--- a/changelogs/fragments/proxy_role_fix.yml
+++ b/changelogs/fragments/proxy_role_fix.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - zabbix_proxy role - failed at version validation. Fix adds cast of zabbix_proxy_version to float, similarly to the other roles.
+  - zabbix_proxy role - undefined vars at updating proxy definition. Fix adds null defaults for zabbix_proxy_tlsaccept and zabbix_proxy_tlsconnect.

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -123,3 +123,7 @@ zabbix_api_timeout: 30
 zabbix_api_create_proxy: false
 zabbix_proxy_state: present
 zabbix_proxy_status: active # or passive
+
+# TLS setttings
+zabbix_proxy_tlsaccept:
+zabbix_proxy_tlsconnect:


### PR DESCRIPTION
##### SUMMARY
Undefined vars at updating proxy definition. Fix adds null defaults for zabbix_proxy_tlsaccept and zabbix_proxy_tlsconnect.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_proxy role

##### ADDITIONAL INFORMATION

The following error would happen when running the role with SSL disabled for the API:

```
TASK [community.zabbix.zabbix_proxy : Ensure proxy definition is up-to-date (added/updated/removed)] ***************
fatal: [zabbix_proxy -> zabbix_server]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'zabbix_proxy_tlsaccept' is undefined. 'zabbix_proxy_tlsaccept' is undefined\n\nThe error appears to be in '/home/lvn/.ansible/collections/ansible_collections/community/zabbix/roles/zabbix_proxy/tasks/main.yml': line 126, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Ensure proxy definition is up-to-date (added/updated/removed)\n  ^ here\n"}
```

The fix adds the following defaults, inspired by the agent role:
```yaml
# TLS setttings
zabbix_proxy_tlsaccept:
zabbix_proxy_tlsconnect:
```

The role succeeds after adding these lines.