### PR TITLE
Added Become to Agent Task

### DIFF
--- a/changelogs/fragments/agent_become.yml
+++ b/changelogs/fragments/agent_become.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - agent role - Added missing become statement to allow run to role as nonroot

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -46,14 +46,15 @@
   tags:
     - install
 
-# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default. 
+# In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default.
 # It SHOULD be created with permissions 0755 if it is needed and does not already exist.
 # See: https://wiki.debian.org/DebianRepository/UseThirdParty
 - name: "Debian | Create /etc/apt/keyrings/ on older versions"
   ansible.builtin.file:
     path: /etc/apt/keyrings/
     state: directory
-    mode: '0755'
+    mode: "0755"
+  become: true
   when:
     - (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < "22") or
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
@@ -62,7 +63,7 @@
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"
-    mode: '0644'
+    mode: "0644"
     force: true
   environment:
     http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"


### PR DESCRIPTION
##### SUMMARY
Update the Agent Role to allow Debian install as non-root user

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Agent Role

##### ADDITIONAL INFORMATION
This PR relates to #1021 