### PR TITLE
Remove duplicate parameter zabbix_api_use_ssl from documentation

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -255,7 +255,6 @@ Host encryption configuration will be set to match agent configuration.
 * `zabbix_api_timeout`: How many seconds to wait for API response (default 30s).
 * `zabbix_api_create_hosts`: Default: `False`. When you want to enable the Zabbix API to create/delete the host. This has to be set to `True` if you want to make use of `zabbix_agent_host_state`.
 * `zabbix_api_create_hostgroup`: When you want to enable the Zabbix API to create/delete the hostgroups. This has to be set to `True` if you want to make use of `zabbix_agent_hostgroups_state`.Default: `False`
-* `zabbix_api_use_ssl`: yes (Default) if we need to connect to Zabbix server over HTTPS
 * `ansible_zabbix_url_path`: URL path if Zabbix WebUI running on non-default (zabbix) path, e.g. if http://<FQDN>/zabbixeu then set to `zabbixeu`
 * `zabbix_agent_hostgroups_state`: present (Default) if the hostgroup needs to be created or absent if you want to delete it. This only works when `zabbix_api_create_hostgroup` is set to `True`.
 * `zabbix_host_status`: enabled (Default) when host in monitored, disabled when host is disabled for monitoring.

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -277,7 +277,6 @@ These variables need to be overridden when you want to make use of the Zabbix AP
 * `zabbix_api_validate_certs`: yes (Default) if we need to validate tls certificates of the API. Use `no` in case self-signed certificates are used.
 * `zabbix_api_timeout`: timeout for API calls (default to 30 seconds)
 * `ansible_zabbix_url_path`: URL path if Zabbix WebUI running on non-default (zabbix) path, e.g. if http://<FQDN>/zabbixeu then set to `zabbixeu`
-* `zabbix_api_use_ssl`: yes (Default) if we need to connect to Zabbix server over HTTPS
 * `zabbix_api_create_proxy`: When you want to enable the Zabbix API to create/delete the proxy. This has to be set to `True` if you want to make use of `zabbix_proxy_state`. Default: `False`
 * `zabbix_proxy_name`: name of the Zabbix proxy as it is seen by Zabbix server
 * `zabbix_proxy_state`: present (Default) if the proxy needs to be created or absent if you want to delete it. This only works when `zabbix_api_create_proxy` is set to `True`.


### PR DESCRIPTION
##### SUMMARY
Removes duplicate parameter zabbix_api_use_ssl from agent and proxy documentation.

Parameter is already documented earlier in the list. Also the latter definition is wrong by stating that default value is true.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zabbix agent
zabbix proxy

##### ADDITIONAL INFORMATION

GitHub doesn't allow individual line highlights in the same preview so here you go with two separate links:

agent:

first mentioned, https://github.com/ansible-collections/community.zabbix/blob/2.1.0/docs/ZABBIX_AGENT_ROLE.md?plain=1#L248
duplicate, https://github.com/ansible-collections/community.zabbix/blob/2.1.0/docs/ZABBIX_AGENT_ROLE.md?plain=1#L258

proxy:

first mentioned, https://github.com/ansible-collections/community.zabbix/blob/2.1.0/docs/ZABBIX_PROXY_ROLE.md?plain=1#L271
duplicate, https://github.com/ansible-collections/community.zabbix/blob/2.1.0/docs/ZABBIX_PROXY_ROLE.md?plain=1#L280