### PR TITLE
Fix variable naming (undefined) in zabbix_web role

### DIFF
--- a/changelogs/fragments/web_role_vars_fix.yml
+++ b/changelogs/fragments/web_role_vars_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_web role - fix variable naming issues (undefined) to zabbix_web_version and zabbix_web_apt_repository

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -8,8 +8,8 @@
 - name: "Debian | Set some variables"
   set_fact:
     zabbix_short_version: "{{ zabbix_web_version | regex_replace('\\.', '') }}"
-    zabbix_server_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}/"
+    zabbix_web_apt_repository:
+      - "http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}/"
       - "{{ ansible_distribution_release }}"
       - "main"
     zabbix_underscore_version: "{{ zabbix_web_version | regex_replace('\\.', '_') }}"
@@ -22,11 +22,11 @@
 - name: "Debian | Set some variables"
   set_fact:
     zabbix_short_version: "{{ zabbix_web_version | regex_replace('\\.', '') }}"
-    zabbix_server_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}-arm64/"
+    zabbix_web_apt_repository:
+      - "http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}-arm64/"
       - "{{ ansible_distribution_release }}"
       - "main"
-    zabbix_underscore_version: "{{ zabbix_server_version | regex_replace('\\.', '_') }}"
+    zabbix_underscore_version: "{{ zabbix_web_version | regex_replace('\\.', '_') }}"
     zabbix_python_prefix: "python{% if ansible_python_version is version('3', '>=') %}3{% endif %}"
   when:
     - ansible_machine == "aarch64"
@@ -92,7 +92,7 @@
 
 - name: "Debian | Installing repository {{ ansible_distribution }}"
   apt_repository:
-    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] {{ zabbix_server_apt_repository | join(' ') }}"
+    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] {{ zabbix_web_apt_repository | join(' ') }}"
     state: present
   become: true
   with_items:


### PR DESCRIPTION
##### SUMMARY
Changed variable names in zabbix_web role to resolve undefined error

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_web role

##### ADDITIONAL INFORMATION
Running the role would error out when setting the Debian apt repository fact: `zabbix_server_version` is undefined.

Fix renames it to `zabbix_web_version` (like everywhere else in the role) and I took the opportunity to rename `zabbix_server_apt_repository` to `zabbix_web_apt_repository`.
