### PR TITLE
fix spelling error in variable

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -75,7 +75,7 @@ zabbix_api_login_pass: !unsafe zabbix
 zabbix_api_validate_certs: false
 ansible_httpapi_pass: "{{ zabbix_api_login_pass }}"
 ansible_httpapi_port: "{{ zabbix_api_server_port }}"
-ensible_httpapi_validate_certs: "{{ zabbix_api_validate_certs }}"
+ansible_httpapi_validate_certs: "{{ zabbix_api_validate_certs }}"
 zabbix_api_timeout: 30
 zabbix_api_create_hostgroup: false
 zabbix_api_create_hosts: false

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -118,7 +118,7 @@ zabbix_api_login_pass: !unsafe zabbix
 zabbix_api_validate_certs: false
 ansible_httpapi_pass: "{{ zabbix_api_login_pass }}"
 ansible_httpapi_port: "{{ zabbix_api_server_port }}"
-ensible_httpapi_validate_certs: "{{ zabbix_api_validate_certs }}"
+ansible_httpapi_validate_certs: "{{ zabbix_api_validate_certs }}"
 zabbix_api_timeout: 30
 zabbix_api_create_proxy: false
 zabbix_proxy_state: present


### PR DESCRIPTION
##### SUMMARY
Fix a small spelling error in the defaults which causes "zabbix_api_validate_certs" to not work.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent & zabbix_proxy

##### ADDITIONAL INFORMATION
This default variable is not defined in the README because it is set by "zabbix_api_validate_certs".
The "ansible_httpapi_validate_certs" variable is not set correctly resulting in:
```
ansible.module_utils.connection.ConnectionError: Could not connect to https://xxx.xxx.xxx.xxx:443/zabbix/api_jsonrpc.php: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: IP address mismatch, certificate is not valid for 'xxx.xxx.xxx.xxx'. (_ssl.c:1002)
```
