### PR TITLE
Update apache.yml

### DIFF
--- a/roles/zabbix_web/tasks/apache.yml
+++ b/roles/zabbix_web/tasks/apache.yml
@@ -82,6 +82,6 @@
     group: "{{ zabbix_web_group }}"
     mode: 0644
   become: true
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" and zabbix_web_create_vhost
   tags:
     - config


### PR DESCRIPTION
**SUMMARY**

_HINT:_  

- Apache vhost bug on "zabix_web" role #1051 

_CHANGES:_  
 
- Changed "Apache | Enable Site (Debian Only)" module execution conditions by adding 'and zabbix_web_create_vhost'.



**ISSUE TYPE**

- Bugfix Pull Request

**COMPONENT NAME**

- ROLE : zabbix_web
- TASK: apache.yml
- MODULE: Apache | Enable Site (Debian Only)


**ADDITIONAL INFORMATION**

I made this modification because I noticed that when the var "zabbix_web_create_vhost" is set to false, the "Apache | Enable Site (Debian Only)"  module is executed in "zabbix_web/tasks/apache.yml", which is a module that should only be executed if the "zabbix_web_create_vhost" variable is set to true, which gives an error when the role is executed. With this small modification, the module no longer executes when the variable parameter is set to false.
