### PR TITLE
Update python and docker compose for integration tests

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/javagateway.yml
+++ b/.github/workflows/javagateway.yml
@@ -44,10 +44,10 @@ jobs:
           - zabbix_javagateway
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Download Docker-Compose
         run: curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
+      - name: Set Docker Compose Execution
+        run: chmod +x /usr/local/bin/docker-compose
+
       - name: Install ansible.netcommon collection
         run: ansible-galaxy collection install ansible.netcommon -p $GITHUB_WORKSPACE
         working-directory: ./ansible_collections/community/zabbix
@@ -57,11 +60,11 @@ jobs:
       # For Zabbix integration tests we need to test against different versions of
       # the Zabbix server. To do this we spin up a Docker container using the `matrix`
       # of version and ports specified earlier.
-      # - name: Zabbix container server provisioning
-      #   run: docker-compose up -d
-      #   working-directory: ./ansible_collections/community/zabbix
-      #   env:
-      #     zabbix_version: ${{ matrix.zabbix_container.version }}
+      - name: Zabbix container server provisioning
+        run: docker-compose up -d
+        working-directory: ./ansible_collections/community/zabbix
+        env:
+          zabbix_version: ${{ matrix.zabbix_container.version }}
 
       # Run the integration tests
       # As we need to connect to an existing docker container we can't use `--docker` here as the VMs would be on different

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -48,10 +48,10 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Download Docker-Compose
-        run: curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+        run: sudo curl -L "https://github.com/docker/compose/releases/download/2.20.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
       - name: Set Docker Compose Execution
-        run: chmod +x /usr/local/bin/docker-compose
+        run: sudo chmod +x /usr/local/bin/docker-compose
 
       - name: Install ansible.netcommon collection
         run: ansible-galaxy collection install ansible.netcommon -p $GITHUB_WORKSPACE

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -35,12 +35,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ansible_collections/community/zabbix
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -31,7 +31,7 @@ jobs:
           - stable-2.15
           - devel
         python:
-          - 3.9
+          - '3.10'
 
     steps:
       - name: Check out code

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
-      - name: Download Docker-Compose
-        run: sudo curl -L "https://github.com/docker/compose/releases/download/2.20.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+      # - name: Download Docker-Compose
+      #   run: sudo curl -L "https://github.com/docker/compose/releases/download/2.20.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
       # - name: Set Docker Compose Execution
       #   run: sudo chmod +x /usr/local/bin/docker-compose

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -50,19 +50,20 @@ jobs:
       - name: Download Docker-Compose
         run: sudo curl -L "https://github.com/docker/compose/releases/download/2.20.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
-      - name: Set Docker Compose Execution
-        run: sudo chmod +x /usr/local/bin/docker-compose
+      # - name: Set Docker Compose Execution
+      #   run: sudo chmod +x /usr/local/bin/docker-compose
 
-      - name: Install ansible.netcommon collection
-        run: ansible-galaxy collection install ansible.netcommon -p $GITHUB_WORKSPACE
-        working-directory: ./ansible_collections/community/zabbix
+      # - name: Install ansible.netcommon collection
+      #   run: ansible-galaxy collection install ansible.netcommon -p $GITHUB_WORKSPACE
+      #   working-directory: ./ansible_collections/community/zabbix
 
       # For Zabbix integration tests we need to test against different versions of
       # the Zabbix server. To do this we spin up a Docker container using the `matrix`
       # of version and ports specified earlier.
       - name: Zabbix container server provisioning
-        run: docker-compose up -d
-        working-directory: ./ansible_collections/community/zabbix
+        uses: isbang/compose-action@v1.5.0
+        with:
+          compose-file: "./ansible_collections/community/zabbix"
         env:
           zabbix_version: ${{ matrix.zabbix_container.version }}
 

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
-      - name: Install dependencies
-        run: pip install docker-compose
+      - name: Download Docker-Compose
+        run: curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
       - name: Install ansible.netcommon collection
         run: ansible-galaxy collection install ansible.netcommon -p $GITHUB_WORKSPACE
@@ -57,11 +57,11 @@ jobs:
       # For Zabbix integration tests we need to test against different versions of
       # the Zabbix server. To do this we spin up a Docker container using the `matrix`
       # of version and ports specified earlier.
-      - name: Zabbix container server provisioning
-        run: docker-compose up -d
-        working-directory: ./ansible_collections/community/zabbix
-        env:
-          zabbix_version: ${{ matrix.zabbix_container.version }}
+      # - name: Zabbix container server provisioning
+      #   run: docker-compose up -d
+      #   working-directory: ./ansible_collections/community/zabbix
+      #   env:
+      #     zabbix_version: ${{ matrix.zabbix_container.version }}
 
       # Run the integration tests
       # As we need to connect to an existing docker container we can't use `--docker` here as the VMs would be on different

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -47,15 +47,9 @@ jobs:
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
-      # - name: Download Docker-Compose
-      #   run: sudo curl -L "https://github.com/docker/compose/releases/download/2.20.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-
-      # - name: Set Docker Compose Execution
-      #   run: sudo chmod +x /usr/local/bin/docker-compose
-
-      # - name: Install ansible.netcommon collection
-      #   run: ansible-galaxy collection install ansible.netcommon -p $GITHUB_WORKSPACE
-      #   working-directory: ./ansible_collections/community/zabbix
+      - name: Install ansible.netcommon collection
+        run: ansible-galaxy collection install ansible.netcommon -p $GITHUB_WORKSPACE
+        working-directory: ./ansible_collections/community/zabbix
 
       # For Zabbix integration tests we need to test against different versions of
       # the Zabbix server. To do this we spin up a Docker container using the `matrix`

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Zabbix container server provisioning
         uses: isbang/compose-action@v1.5.0
         with:
-          compose-file: "./docker-compose.yml"
+          compose-file: "./ansible_collections/community/zabbix/docker-compose.yml"
         env:
           zabbix_version: ${{ matrix.zabbix_container.version }}
 

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Zabbix container server provisioning
         uses: isbang/compose-action@v1.5.0
         with:
-          compose-file: "./ansible_collections/community/zabbix"
+          compose-file: "./docker-compose.yml"
         env:
           zabbix_version: ${{ matrix.zabbix_container.version }}
 

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -48,10 +48,10 @@ jobs:
             version: v62
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -52,12 +52,12 @@ jobs:
       # .../ansible_collections/NAMESPACE/COLLECTION_NAME/
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ansible_collections/community/zabbix
 
       - name: Set up Python ${{ matrix.ansible }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.9
+          - '3.10'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -45,7 +45,7 @@ jobs:
           - stable-2.15
           - devel
         python:
-          - 3.10
+          - '3.10'
     runs-on: ubuntu-latest
     steps:
       # ansible-test requires the collection to be in a directory in the form

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.10
+          - 3.9
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.9
+          - 3.10
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -45,7 +45,7 @@ jobs:
           - stable-2.15
           - devel
         python:
-          - 3.9
+          - 3.10
     runs-on: ubuntu-latest
     steps:
       # ansible-test requires the collection to be in a directory in the form

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -52,10 +52,10 @@ jobs:
             version: v64
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -54,10 +54,10 @@ jobs:
             version: v62
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 


### PR DESCRIPTION
Ansible Devel requires python 3.10 or higher but when we changed that the current method of installing docker-compose for the integration tests broke.