### PR TITLE
zabbix_agent - Support Raspbian

### DIFF
--- a/changelogs/fragments/926-support-raspbian.yml
+++ b/changelogs/fragments/926-support-raspbian.yml
@@ -1,0 +1,3 @@
+minor_changes:
+ - zabbix_agent - Add support for Raspbian
+

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -5,12 +5,10 @@
   set_fact:
     zabbix_short_version: "{{ zabbix_agent_version | regex_replace('\\.', '') }}"
     zabbix_agent_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}/"
+      - "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_lsb.id.lower() }}/"
       - "{{ ansible_distribution_release }}"
       - "main"
     zabbix_underscore_version: "{{ zabbix_agent_version | regex_replace('\\.', '_') }}"
-  when:
-    - ansible_machine != "aarch64"
   tags:
     - always
 
@@ -18,12 +16,11 @@
   set_fact:
     zabbix_short_version: "{{ zabbix_agent_version | regex_replace('\\.', '') }}"
     zabbix_agent_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}-arm64/"
+      - "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_lsb.id.lower() }}-arm64/"
       - "{{ ansible_distribution_release }}"
       - "main"
-    zabbix_underscore_version: "{{ zabbix_agent_version | regex_replace('\\.', '_') }}"
   when:
-    - ansible_machine == "aarch64"
+    - ansible_machine == "aarch64" and ansible_lsb.id.lower() == "ubuntu"
   tags:
     - always
 
@@ -69,7 +66,7 @@
   tags:
     - install
 
-- name: "Debian | Installing repository {{ ansible_distribution }}"
+- name: "Debian | Installing repository {{ ansible_lsb.id }}"
   apt_repository:
     repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] {{ zabbix_agent_apt_repository | join(' ') }}"
     state: present


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Zabbix has official support for Raspberry.
Correctly selects the proper Raspbian repo.

See http://repo.zabbix.com/zabbix/6.4/ for the available packages, and notice that the only architecure-variant is for ubuntu. Simplify the repository url detection a bit to most easily match all rapository variants of supported OS within the Debian-family.

'ansible_lsb.id' differentiates between debian and raspbian, so use that instead of the 'ansible_distribution'


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_agent(2)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
