### PR TITLE
Bump requests from 2.28.2 to 2.31.0

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -10,4 +10,4 @@ pytest==7.2.1
 pytest-testinfra==7.0.0
 ipaddr==2.2.0
 ipaddress==1.0.23
-requests==2.28.2
+requests==2.31.0

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -2,7 +2,7 @@
 ansible==7.0.0
 ansible-compat==3.0.0
 ansible-core==2.14.2
-docker==6.0.1
+docker==6.1.3
 molecule==4.0.4
 molecule-docker==2.1.0
 netaddr==0.8.0


### PR DESCRIPTION
##### SUMMARY

I bumped requests library 2.28.2 to 2.31.0, because my environment dependabot alert to requests 2.28.2.
I understood this code is part of testing and this has no effect.
But this is annoying warning for users with dependabot enabled.

this is just suggestion, if this project decide to don't care it, please just close this PR. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

molecule(testing tool)

##### ADDITIONAL INFORMATION

https://github.com/advisories/GHSA-j8r2-6x86-q33q
