### PR TITLE
Add module for getting events using host groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Click on the name of a plugin or module to view that content's documentation:
     - [zabbix_discovery_rule](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_discovery_rule_module.html)
     - [zabbix_globalmacro](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_globalmacro_module.html)
     - [zabbix_group_info](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_group_info_module.html)
+    - [zabbix_group_events_info](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_group_events_info_module.html)
     - [zabbix_group](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_group_module.html)
     - [zabbix_host_events_info](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_host_events_info_module.html)
     - [zabbix_host_info](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_host_info_module.html)

--- a/changelogs/fragments/module_group_events_info.yml
+++ b/changelogs/fragments/module_group_events_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added zabbix_group_events_info module

--- a/plugins/modules/zabbix_group_events_info.py
+++ b/plugins/modules/zabbix_group_events_info.py
@@ -1,0 +1,312 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) stephane.travassac@fr.clara.net
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+RETURN = """
+---
+triggers_ok:
+    description: Host Zabbix Triggers in OK state
+    returned: On success
+    type: complex
+    contains:
+          comments:
+            description: Additional description of the trigger
+            type: str
+          description:
+            description: Name of the trigger
+            type: str
+          error:
+            description: Error text if there have been any problems when updating the state of the trigger
+            type: str
+          expression:
+            description: Reduced trigger expression
+            type: str
+          flags:
+            description: Origin of the trigger
+            type: int
+          lastchange:
+            description: Time when the trigger last changed its state (timestamp)
+            type: int
+          priority:
+            description: Severity of the trigger
+            type: int
+          state:
+            description: State of the trigger
+            type: int
+          status:
+            description: Whether the trigger is enabled or disabled
+            type: int
+          templateid:
+            description: ID of the parent template trigger
+            type: int
+          triggerid:
+            description: ID of the trigger
+            type: int
+          type:
+            description: Whether the trigger can generate multiple problem events
+            type: int
+          url:
+            description: URL associated with the trigger
+            type: str
+          value:
+            description: Whether the trigger is in OK or problem state
+            type: int
+triggers_problem:
+    description: Host Zabbix Triggers in problem state. See trigger and event objects in API documentation of your zabbix version for more
+    returned: On success
+    type: complex
+    contains:
+          comments:
+            description: Additional description of the trigger
+            type: str
+          description:
+            description: Name of the trigger
+            type: str
+          error:
+            description: Error text if there have been any problems when updating the state of the trigger
+            type: str
+          expression:
+            description: Reduced trigger expression
+            type: str
+          flags:
+            description: Origin of the trigger
+            type: int
+          last_event:
+            description: last event informations
+            type: complex
+            contains:
+                acknowledged:
+                    description: If set to true return only acknowledged events
+                    type: int
+                acknowledges:
+                    description: acknowledges informations
+                    type: complex
+                    contains:
+                        alias:
+                            description: Account who acknowledge
+                            type: str
+                        clock:
+                            description: Time when the event was created (timestamp)
+                            type: int
+                        message:
+                            description: Text of the acknowledgement message
+                            type: str
+                clock:
+                    description: Time when the event was created (timestamp)
+                    type: int
+                eventid:
+                    description: ID of the event
+                    type: int
+                value:
+                    description: State of the related object
+                    type: int
+          lastchange:
+            description: Time when the trigger last changed its state (timestamp)
+            type: int
+          priority:
+            description: Severity of the trigger
+            type: int
+          state:
+            description: State of the trigger
+            type: int
+          status:
+            description: Whether the trigger is enabled or disabled
+            type: int
+          templateid:
+            description: ID of the parent template trigger
+            type: int
+          triggerid:
+            description: ID of the trigger
+            type: int
+          type:
+            description: Whether the trigger can generate multiple problem events
+            type: int
+          url:
+            description: URL associated with the trigger
+            type: str
+          value:
+            description: Whether the trigger is in OK or problem state
+            type: int
+"""
+
+DOCUMENTATION = """
+---
+module: zabbix_host_events_info
+short_description: Get all triggers about a Zabbix host
+description:
+   - This module allows you to see if a Zabbix host have no active alert to make actions on it.
+     For this case use module Ansible "fail" to exclude host in trouble.
+   - Length of "triggers_ok" allow if template's triggers exist for Zabbix Host
+author:
+    - "Stéphane Travassac (@stravassac)"
+requirements:
+    - "python >= 3.9"
+options:
+    host_identifier:
+        description:
+            - Identifier of Zabbix Host
+        required: true
+        type: str
+    host_id_type:
+        description:
+            - Type of host_identifier
+        choices:
+            - hostname
+            - visible_name
+            - hostid
+        required: false
+        default: hostname
+        type: str
+    trigger_severity:
+        description:
+            - Zabbix severity for search filter
+        default: average
+        required: false
+        choices:
+            - not_classified
+            - information
+            - warning
+            - average
+            - high
+            - disaster
+        type: str
+extends_documentation_fragment:
+- community.zabbix.zabbix
+
+"""
+
+EXAMPLES = """
+# If you want to use Username and Password to be authenticated by Zabbix Server
+- name: Set credentials to access Zabbix Server API
+  set_fact:
+    ansible_user: Admin
+    ansible_httpapi_pass: zabbix
+
+# If you want to use API token to be authenticated by Zabbix Server
+# https://www.zabbix.com/documentation/current/en/manual/web_interface/frontend_sections/administration/general#api-tokens
+- name: Set API token
+  set_fact:
+    ansible_zabbix_auth_key: 8ec0d52432c15c91fcafe9888500cf9a607f44091ab554dbee860f6b44fac895
+
+- name: exclude machine if alert active on it
+  # set task level variables as we change ansible_connection plugin here
+  vars:
+      ansible_network_os: community.zabbix.zabbix
+      ansible_connection: httpapi
+      ansible_httpapi_port: 443
+      ansible_httpapi_use_ssl: true
+      ansible_httpapi_validate_certs: false
+      ansible_zabbix_url_path: "zabbixeu"  # If Zabbix WebUI runs on non-default (zabbix) path ,e.g. http://<FQDN>/zabbixeu
+      ansible_host: zabbix-example-fqdn.org
+  community.zabbix.zabbix_host_events_info:
+      host_identifier: "{{inventory_hostname}}"
+      host_id_type: "hostname"
+      timeout: 120
+  register: zbx_host
+  delegate_to: localhost
+- fail:
+    msg: "machine alert in zabbix"
+  when: zbx_host["triggers_problem"]|length > 0
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
+import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
+
+
+class Host(ZabbixBase):
+    def get_host(self, host_identifier, host_inventory, search_key):
+        """ Get host by hostname|visible_name|hostid """
+        host = self._zapi.host.get(
+            {"output": "extend", "selectParentTemplates": ["name"], "filter": {search_key: host_identifier},
+             "selectInventory": host_inventory})
+        if len(host) < 1:
+            self._module.fail_json(msg="Host not found: %s" % host_identifier)
+        else:
+            return host[0]
+
+    def get_triggers_by_host_id_in_problem_state(self, host_id, trigger_severity):
+        """ Get triggers in problem state from a hostid"""
+        output = "extend"
+        triggers_list = self._zapi.trigger.get({"output": output, "hostids": host_id,
+                                                "min_severity": trigger_severity})
+        return triggers_list
+
+    def get_last_event_by_trigger_id(self, triggers_id):
+        """ Get the last event from triggerid"""
+        output = ["eventid", "clock", "acknowledged", "value"]
+        select_acknowledges = ["clock", "alias", "message"]
+        event = self._zapi.event.get({"output": output, "objectids": triggers_id,
+                                      "select_acknowledges": select_acknowledges, "limit": 1, "sortfield": "clock",
+                                      "sortorder": "DESC"})
+        return event[0]
+
+
+def main():
+    argument_spec = zabbix_utils.zabbix_common_argument_spec()
+    argument_spec.update(dict(
+        host_identifier=dict(type="str", required=True),
+        host_id_type=dict(
+            default="hostname",
+            type="str",
+            choices=["hostname", "visible_name", "hostid"]),
+        trigger_severity=dict(
+            type="str",
+            required=False,
+            default="average",
+            choices=["not_classified", "information", "warning", "average", "high", "disaster"]),
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    trigger_severity_map = {"not_classified": 0, "information": 1, "warning": 2, "average": 3, "high": 4, "disaster": 5}
+    host_id = module.params["host_identifier"]
+    host_id_type = module.params["host_id_type"]
+    trigger_severity = trigger_severity_map[module.params["trigger_severity"]]
+
+    host_inventory = "hostid"
+
+    host = Host(module)
+
+    if host_id_type == "hostname":
+        zabbix_host = host.get_host(host_id, host_inventory, "host")
+        host_id = zabbix_host["hostid"]
+
+    elif host_id_type == "visible_name":
+        zabbix_host = host.get_host(host_id, host_inventory, "name")
+        host_id = zabbix_host["hostid"]
+
+    elif host_id_type == "hostid":
+        # check hostid exist
+        zabbix_host = host.get_host(host_id, host_inventory, "hostid")
+
+    triggers = host.get_triggers_by_host_id_in_problem_state(host_id, trigger_severity)
+
+    triggers_ok = []
+    triggers_problem = []
+    for trigger in triggers:
+        # tGet last event for trigger with problem value = 1
+        # https://www.zabbix.com/documentation/3.4/manual/api/reference/trigger/object
+        if int(trigger["value"]) == 1:
+            event = host.get_last_event_by_trigger_id(trigger["triggerid"])
+            trigger["last_event"] = event
+            triggers_problem.append(trigger)
+        else:
+            triggers_ok.append(trigger)
+
+    module.exit_json(ok=True, triggers_ok=triggers_ok, triggers_problem=triggers_problem)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/zabbix_group_events_info.py
+++ b/plugins/modules/zabbix_group_events_info.py
@@ -194,7 +194,7 @@ EXAMPLES = """
       ansible_httpapi_validate_certs: false
       ansible_zabbix_url_path: "zabbixeu"  # If Zabbix WebUI runs on non-default (zabbix) path ,e.g. http://<FQDN>/zabbixeu
       ansible_host: zabbix-example-fqdn.org
-  community.zabbix.zabbix_host_events_info:
+  community.zabbix.zabbix_group_events_info:
       hostgroup_name: "{{ inventory_hostname }}"
   register: zbx_hostgroup
   delegate_to: localhost

--- a/plugins/modules/zabbix_group_events_info.py
+++ b/plugins/modules/zabbix_group_events_info.py
@@ -257,10 +257,12 @@ def main():
 
     host = Host(module)
     host_groups = host.get_group_ids_by_group_names(hostgroup_name)
-    host_group_ids = host_groups[0]["groupid"]
+    triggers = []
 
-    for host_group_id in host_group_ids:
-        triggers = host.get_triggers_by_group_id_in_problem_state(host_group_id, trigger_severity)
+    for host_group in host_groups:
+        host_group_id = host_group["groupid"]
+        host_group_triggers = host.get_triggers_by_group_id_in_problem_state(host_group_id, trigger_severity)
+        triggers = triggers + host_group_triggers
 
     triggers_ok = []
     triggers_problem = []
@@ -274,7 +276,7 @@ def main():
         else:
             triggers_ok.append(trigger)
 
-    module.exit_json(ok=True, triggers_ok=triggers_ok, triggers_problem=triggers_problem)
+    module.exit_json(ok=True, host_groups=host_groups, triggers_ok=triggers_ok, triggers_problem=triggers_problem)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/zabbix_group_events_info.py
+++ b/plugins/modules/zabbix_group_events_info.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# built by Martin Eiswirth (@meis4h) on top of the work by Stéphane Travassac (@stravassac) on zabbix_host_events_info.py and Michael Miko (@RedWhiteMiko) on zabbix_group_info.py
+# built by Martin Eiswirth (@meis4h) on top of the work by Stéphane Travassac (@stravassac) on zabbix_host_events_info.py
+# and Michael Miko (@RedWhiteMiko) on zabbix_group_info.py
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 

--- a/tests/integration/targets/test_zabbix_group_events_info/files/trigger_testing.json
+++ b/tests/integration/targets/test_zabbix_group_events_info/files/trigger_testing.json
@@ -1,0 +1,48 @@
+{
+    "zabbix_export": {
+        "version": "6.0",
+        "date": "2023-09-05T13:58:23Z",
+        "groups": [
+            {
+                "uuid": "6932cc6c283949ee8d4c316e2f30af5f",
+                "name": "Templates"
+            }
+        ],
+        "templates": [
+            {
+                "uuid": "641c10c5445245edb59050c3518e76a0",
+                "template": "Trigger testing",
+                "name": "Trigger testing",
+                "groups": [
+                    {
+                        "name": "Templates"
+                    }
+                ],
+                "items": [
+                    {
+                        "uuid": "0dce402f6f0c44cfb7796c1ea6c4bb86",
+                        "name": "Test Item",
+                        "type": "CALCULATED",
+                        "key": "test",
+                        "delay": "10s",
+                        "params": "1",
+                        "triggers": [
+                            {
+                                "uuid": "11b2645a369946dcaa00b6edc578089f",
+                                "expression": "last(/Trigger testing/test)=0",
+                                "name": "Ok Trigger",
+                                "priority": "AVERAGE"
+                            },
+                            {
+                                "uuid": "f17f4b4f7fe444dfb856bc9d6366d0fe",
+                                "expression": "last(/Trigger testing/test)=1",
+                                "name": "Problem Trigger",
+                                "priority": "AVERAGE"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/integration/targets/test_zabbix_group_events_info/meta/main.yml
+++ b/tests/integration/targets/test_zabbix_group_events_info/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_zabbix

--- a/tests/integration/targets/test_zabbix_group_events_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_group_events_info/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- name: Import trigger test template
+  zabbix_template:
+    template_json: "{{ lookup('file', 'trigger_testing.json') }}"
+    state: present
+
+- name: Create host group
+  zabbix_group:
+    state: present
+    host_groups:
+      - Example group
+
+- name: Create new host with template
+  zabbix_host:
+    host_name: Example host
+    link_templates:
+      - Trigger testing
+    host_groups:
+      - Example group
+
+- name: Wait a minute to ensure triggers are firing
+  ansible.builtin.wait_for:
+    timeout: 60
+
+- name: Get hostgroup events
+  zabbix_group_events_info:
+    hostgroup_name: Example group
+    trigger_severity: not_classified
+  register: hostgroup_events_results
+
+- name: Assert that trigger results are as expected
+  ansible.builtin.assert:
+    that:
+      - hostgroup_events_results.triggers_ok[0].description == "Ok Trigger"
+      - hostgroup_events_results.triggers_ok[0].value == "0"
+      - hostgroup_events_results.triggers_ok[0].status == "0"
+      - hostgroup_events_results.triggers_problem[0].description == "Problem Trigger"
+      - hostgroup_events_results.triggers_problem[0].value == "1"
+      - hostgroup_events_results.triggers_problem[0].status == "0"
+      - hostgroup_events_results.triggers_problem[0].last_event.acknowledged == "0"
+      - hostgroup_events_results.triggers_problem[0].last_event.value == "1"

--- a/tests/integration/targets/test_zabbix_group_events_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_group_events_info/tasks/main.yml
@@ -39,3 +39,19 @@
       - hostgroup_events_results.triggers_problem[0].status == "0"
       - hostgroup_events_results.triggers_problem[0].last_event.acknowledged == "0"
       - hostgroup_events_results.triggers_problem[0].last_event.value == "1"
+
+- name: Clean up host
+  zabbix_host:
+    host_name: Example host
+    state: absent
+
+- name: Clean up host group
+  zabbix_group:
+    host_groups:
+      - Example group
+    state: absent
+
+- name: Clean up template
+  zabbix_template:
+    template_name: "Trigger testing"
+    state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add the module zabbix_group_events_info for getting problems by specifying a hostgroup instead of a host.
This is useful if not all hosts that need to be checked are available in the inventory for example with a host discovery in Zabbix.

This module is basically just a combined version of the existing zabbix_host_events_info and zabbix_group_info modules.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_group_events_info
