### PR TITLE
Move to deb822 formatting and allow debian repo selection

### DIFF
--- a/changelogs/fragments/deb822.yml
+++ b/changelogs/fragments/deb822.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - all roles - Updated Debian repository format to 822 standard
+  - all roles - Re-added ability to override Debian repo source

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -134,6 +134,8 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_repo_yum`: A list with Yum repository configuration.
 * `zabbix_repo_yum_schema`: Default: `https`. Option to change the web schema for the yum repository(http/https)
 * `zabbix_agent_disable_repo`: A list of repos to disable during install.  Default `epel`.
+* `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}`
+* `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
 
 ### SElinux
 

--- a/docs/ZABBIX_JAVAGATEWAY_ROLE.md
+++ b/docs/ZABBIX_JAVAGATEWAY_ROLE.md
@@ -60,6 +60,8 @@ The `zabbix_javagateway_version` is optional. The latest available major.minor v
 * `zabbix_javagateway_disable_repo`: A list of repos to disable during install.  Default `epel`.
 * `zabbix_javagateway_package_state`: Default: `present`. Can be overridden to `latest` to update packages when needed.
 * `zabbix_javagateway_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
+* `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}`
+* `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
 
 ### Java Gatewaty
 

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -130,6 +130,8 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_proxy_disable_repo`: A list of repos to disable during install.  Default `epel`.
 * `zabbix_proxy_apt_priority`: APT priority for the zabbix repository
 * `*zabbix_proxy_package_state`: Default: `present`. Can be overridden to `latest` to update packages
+* `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_distribution.lower() }}`
+* `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
 ### SElinux
 
 * `zabbix_proxy_selinux`: Default: `False`. Enables an SELinux policy so that the Proxy will run.

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -107,6 +107,8 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_server_disable_repo`: A list of repos to disable during install.  Default `epel`.
 * `zabbix_service_state`: Default: `started`. Can be overridden to stopped if needed
 * `zabbix_service_enabled`: Default: `True` Can be overridden to `False` if needed
+* `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}`
+* `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
 
 ### SElinux
 

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -92,6 +92,8 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_package_state`: Default: `present`. Can be overridden to `latest` to update packages when needed.
 * `zabbix_web_doubleprecision`: Default: `False`. For upgraded installations, please read database [upgrade notes](https://www.zabbix.com/documentation/current/manual/installation/upgrade_notes_500) (Paragraph "Enabling extended range of numeric (float) values") before enabling this option.
 * `zabbix_web_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
+* `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}`
+* `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
 
 ### Zabbix Web specific
 

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -66,6 +66,8 @@ zabbix_repo_yum:
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
 
+zabbix_repo_deb_component: main
+
 # Zabbix API stuff
 zabbix_api_server_host: localhost
 # zabbix_api_server_port: 80

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -70,7 +70,7 @@
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
-      Architecutres: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
+      Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
       Signed-By: {{ zabbix_gpg_key }}
   become: true
   tags:

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -4,26 +4,15 @@
 - name: "Debian | Set some variables"
   ansible.builtin.set_fact:
     zabbix_short_version: "{{ zabbix_agent_version | regex_replace('\\.', '') }}"
-    zabbix_agent_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}/"
-      - "{{ ansible_distribution_release }}"
-      - "main"
     zabbix_underscore_version: "{{ zabbix_agent_version | regex_replace('\\.', '_') }}"
-  when:
-    - ansible_machine != "aarch64"
   tags:
     - always
 
-- name: "Debian | Set some variables"
+- name: "Debian | Repo URL"
   ansible.builtin.set_fact:
-    zabbix_short_version: "{{ zabbix_agent_version | regex_replace('\\.', '') }}"
-    zabbix_agent_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}-arm64/"
-      - "{{ ansible_distribution_release }}"
-      - "main"
-    zabbix_underscore_version: "{{ zabbix_agent_version | regex_replace('\\.', '_') }}"
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}{{ '-arm64' if ansible_machine == 'aarch64' else ''}}"
   when:
-    - ansible_machine == "aarch64"
+    - zabbix_repo_deb_url is undefined
   tags:
     - always
 
@@ -70,13 +59,20 @@
     - install
 
 - name: "Debian | Installing repository {{ ansible_distribution }}"
-  ansible.builtin.apt_repository:
-    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] {{ zabbix_agent_apt_repository | join(' ') }}"
-    state: present
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/zabbix.sources
+    owner: root
+    group: root
+    mode: 0644
+    content: |
+      Types: deb deb-src
+      Enabled: yes
+      URIs: {{ zabbix_repo_deb_url }}
+      Suites: {{ ansible_distribution_release }}
+      Components: {{ zabbix_repo_deb_component }}
+      Architecutres: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
+      Signed-By: {{ zabbix_gpg_key }}
   become: true
-  with_items:
-    - deb-src
-    - deb
   tags:
     - install
 

--- a/roles/zabbix_agent/vars/Debian.yml
+++ b/roles/zabbix_agent/vars/Debian.yml
@@ -45,3 +45,4 @@ zabbix_valid_agent_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
+_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}"

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -25,6 +25,8 @@ zabbix_repo_yum:
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
 
+zabbix_repo_deb_component: main
+
 zabbix_javagateway_pidfile: /run/zabbix/zabbix_java_gateway.pid
 zabbix_javagateway_listenip: 0.0.0.0
 zabbix_javagateway_listenport: 10052

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -48,7 +48,7 @@
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
-      Architecutres: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
+      Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
       Signed-By: {{ zabbix_gpg_key }}
   become: true
   tags:

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -5,27 +5,13 @@
   tags:
     - always
 
-- name: "Debian | Set some variables"
+- name: "Debian | Repo URL"
   ansible.builtin.set_fact:
-    zabbix_javagateway_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/{{ ansible_distribution.lower() }}/"
-      - "{{ ansible_distribution_release }}"
-      - "main"
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}{{ '-arm64' if ansible_machine == 'aarch64' else ''}}"
   when:
-    - ansible_machine != "aarch64"
+    - zabbix_repo_deb_url is undefined
   tags:
-    - install
-
-- name: "Debian | Set some variables"
-  ansible.builtin.set_fact:
-    zabbix_javagateway_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/{{ ansible_distribution.lower() }}-arm64/"
-      - "{{ ansible_distribution_release }}"
-      - "main"
-  when:
-    - ansible_machine == "aarch64"
-  tags:
-    - install
+    - always
 
 # In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default.
 # It SHOULD be created with permissions 0755 if it is needed and does not already exist.
@@ -50,14 +36,21 @@
   tags:
     - install
 
-- name: "Debian | Installing repository Debian"
-  ansible.builtin.apt_repository:
-    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] {{ zabbix_javagateway_apt_repository | join(' ') }}"
-    state: present
+- name: "Debian | Installing repository {{ ansible_distribution }}"
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/zabbix.sources
+    owner: root
+    group: root
+    mode: 0644
+    content: |
+      Types: deb deb-src
+      Enabled: yes
+      URIs: {{ zabbix_repo_deb_url }}
+      Suites: {{ ansible_distribution_release }}
+      Components: {{ zabbix_repo_deb_component }}
+      Architecutres: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
+      Signed-By: {{ zabbix_gpg_key }}
   become: true
-  with_items:
-    - deb-src
-    - deb
   tags:
     - install
 

--- a/roles/zabbix_javagateway/vars/Debian.yml
+++ b/roles/zabbix_javagateway/vars/Debian.yml
@@ -27,3 +27,4 @@ zabbix_valid_javagateway_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
+_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/{{ ansible_distribution.lower() }}"

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -40,6 +40,7 @@ zabbix_proxy_version_minor: "*"
 # Yum/APT Variables
 zabbix_repo_yum_schema: https
 zabbix_repo_yum_gpgcheck: 0
+zabbix_repo_deb_component: main
 zabbix_proxy_disable_repo:
   - epel
 zabbix_repo_yum:

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -75,7 +75,7 @@
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
-      Architecutres: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
+      Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
       Signed-By: {{ zabbix_gpg_key }}
   become: true
   tags:

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -7,6 +7,14 @@
   tags:
     - always
 
+- name: "Debian | Repo URL"
+  ansible.builtin.set_fact:
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}{{ '-arm64' if ansible_machine == 'aarch64' else ''}}"
+  when:
+    - zabbix_repo_deb_url is undefined
+  tags:
+    - always
+
 - name: "Debian | Set some facts for Zabbix"
   ansible.builtin.set_fact:
     datafiles_path: /usr/share/doc/zabbix-sql-scripts/{{ zabbix_proxy_db_long }}
@@ -56,13 +64,20 @@
     - install
 
 - name: "Debian | Installing repository {{ ansible_distribution }}"
-  ansible.builtin.apt_repository:
-    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_distribution.lower() }}/ {{ ansible_distribution_release }} main"
-    state: present
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/zabbix.sources
+    owner: root
+    group: root
+    mode: 0644
+    content: |
+      Types: deb deb-src
+      Enabled: yes
+      URIs: {{ zabbix_repo_deb_url }}
+      Suites: {{ ansible_distribution_release }}
+      Components: {{ zabbix_repo_deb_component }}
+      Architecutres: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
+      Signed-By: {{ zabbix_gpg_key }}
   become: true
-  with_items:
-    - deb-src
-    - deb
   tags:
     - install
 

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -111,7 +111,7 @@
   ansible.builtin.apt:
     pkg: "zabbix-proxy-{{ zabbix_proxy_database }}"
     update_cache: true
-    cache_valid_time: 3600
+    cache_valid_time: 0
     force: true
     state: "{{ zabbix_proxy_package_state }}"
     default_release: "{{ ansible_distribution_release }}"

--- a/roles/zabbix_proxy/vars/Debian.yml
+++ b/roles/zabbix_proxy/vars/Debian.yml
@@ -52,3 +52,4 @@ mysql_plugin:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
+_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_distribution.lower() }}"

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -39,6 +39,7 @@ zabbix_server_version_minor: "*"
 zabbix_server_package_state: present
 zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https
+zabbix_repo_deb_component: main
 zabbix_server_disable_repo:
   - epel
 zabbix_repo_yum:

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -74,7 +74,7 @@
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
-      Architecutres: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
+      Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
       Signed-By: {{ zabbix_gpg_key }}
   become: true
   tags:

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -2,28 +2,16 @@
 - name: "Debian | Set some variables"
   ansible.builtin.set_fact:
     zabbix_short_version: "{{ zabbix_server_version | regex_replace('\\.', '') }}"
-    zabbix_server_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}/"
-      - "{{ ansible_distribution_release }}"
-      - "main"
     zabbix_underscore_version: "{{ zabbix_server_version | regex_replace('\\.', '_') }}"
     zabbix_python_prefix: "python{% if ansible_python_version is version('3', '>=') %}3{% endif %}"
-  when:
-    - ansible_machine != "aarch64"
   tags:
     - always
 
-- name: "Debian | Set some variables"
+- name: "Debian | Repo URL"
   ansible.builtin.set_fact:
-    zabbix_short_version: "{{ zabbix_server_version | regex_replace('\\.', '') }}"
-    zabbix_server_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}-arm64/"
-      - "{{ ansible_distribution_release }}"
-      - "main"
-    zabbix_underscore_version: "{{ zabbix_server_version | regex_replace('\\.', '_') }}"
-    zabbix_python_prefix: "python{% if ansible_python_version is version('3', '>=') %}3{% endif %}"
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}{{ '-arm64' if ansible_machine == 'aarch64' else ''}}"
   when:
-    - ansible_machine == "aarch64"
+    - zabbix_repo_deb_url is undefined
   tags:
     - always
 
@@ -75,13 +63,20 @@
     - install
 
 - name: "Debian | Installing repository {{ ansible_distribution }}"
-  ansible.builtin.apt_repository:
-    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] {{ zabbix_server_apt_repository | join(' ') }}"
-    state: present
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/zabbix.sources
+    owner: root
+    group: root
+    mode: 0644
+    content: |
+      Types: deb deb-src
+      Enabled: yes
+      URIs: {{ zabbix_repo_deb_url }}
+      Suites: {{ ansible_distribution_release }}
+      Components: {{ zabbix_repo_deb_component }}
+      Architecutres: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
+      Signed-By: {{ zabbix_gpg_key }}
   become: true
-  with_items:
-    - deb-src
-    - deb
   tags:
     - install
 

--- a/roles/zabbix_server/vars/Debian.yml
+++ b/roles/zabbix_server/vars/Debian.yml
@@ -30,3 +30,4 @@ zabbix_valid_server_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
+_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}"

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -52,6 +52,7 @@ zabbix_web_apt_priority:
 zabbix_web_version_minor: "*"
 zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https
+zabbix_repo_deb_component: main
 zabbix_web_disable_repo:
   - epel
 zabbix_repo_yum:

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -8,28 +8,16 @@
 - name: "Debian | Set some variables"
   ansible.builtin.set_fact:
     zabbix_short_version: "{{ zabbix_web_version | regex_replace('\\.', '') }}"
-    zabbix_web_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}/"
-      - "{{ ansible_distribution_release }}"
-      - "main"
     zabbix_underscore_version: "{{ zabbix_web_version | regex_replace('\\.', '_') }}"
     zabbix_python_prefix: "python{% if ansible_python_version is version('3', '>=') %}3{% endif %}"
-  when:
-    - ansible_machine != "aarch64"
   tags:
     - always
 
-- name: "Debian | Set some variables"
+- name: "Debian | Repo URL"
   ansible.builtin.set_fact:
-    zabbix_short_version: "{{ zabbix_web_version | regex_replace('\\.', '') }}"
-    zabbix_web_apt_repository:
-      - "http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}-arm64/"
-      - "{{ ansible_distribution_release }}"
-      - "main"
-    zabbix_underscore_version: "{{ zabbix_web_version | regex_replace('\\.', '_') }}"
-    zabbix_python_prefix: "python{% if ansible_python_version is version('3', '>=') %}3{% endif %}"
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}{{ '-arm64' if ansible_machine == 'aarch64' else ''}}"
   when:
-    - ansible_machine == "aarch64"
+    - zabbix_repo_deb_url is undefined
   tags:
     - always
 
@@ -91,13 +79,20 @@
     - install
 
 - name: "Debian | Installing repository {{ ansible_distribution }}"
-  ansible.builtin.apt_repository:
-    repo: "{{ item }} [signed-by={{ zabbix_gpg_key }}] {{ zabbix_web_apt_repository | join(' ') }}"
-    state: present
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list.d/zabbix.sources
+    owner: root
+    group: root
+    mode: 0644
+    content: |
+      Types: deb deb-src
+      Enabled: yes
+      URIs: {{ zabbix_repo_deb_url }}
+      Suites: {{ ansible_distribution_release }}
+      Components: {{ zabbix_repo_deb_component }}
+      Architecutres: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
+      Signed-By: {{ zabbix_gpg_key }}
   become: true
-  with_items:
-    - deb-src
-    - deb
   tags:
     - install
 

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -90,7 +90,7 @@
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
-      Architecutres: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
+      Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
       Signed-By: {{ zabbix_gpg_key }}
   become: true
   tags:

--- a/roles/zabbix_web/vars/Debian.yml
+++ b/roles/zabbix_web/vars/Debian.yml
@@ -48,3 +48,4 @@ zabbix_valid_web_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
+_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}"


### PR DESCRIPTION
##### SUMMARY
This PR will close out both #1034 and #1001.  It updates all Debian/Ubuntu systems to using the deb822 format and allows the user to fully define the repository address being used to allow for local repositories (which we've had for yum for a while)./

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
All roles
