### PR TITLE
Fixed typo 'php-acpu' in ZABBIX_WEB_ROLE.md

### DIFF
--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -261,7 +261,7 @@ zabbix.conf.php, for example to add LDAP CA certificates. To do this add a `zabb
       php_packages:
         - php
         - php-fpm
-        - php-acpu
+        - php-apcu
     - role: geerlingguy.apache-php-fpm
     - role: community.zabbix.zabbix_web
       zabbix_api_server_url: zabbix.mydomain.com


### PR DESCRIPTION
##### SUMMARY
Fix of small typo in ZABBIX_WEB_ROLE.md

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Documentation to `community.zabbix.zabbix_web`

##### ADDITIONAL INFORMATION
There is no package `php-acpu`, instead it should be `php-apcu`
