### PR TITLE
fix: force become: false in zabbix-agent role api calling

### DIFF
--- a/roles/zabbix_agent/tasks/api.yml
+++ b/roles/zabbix_agent/tasks/api.yml
@@ -8,6 +8,7 @@
   register: zabbix_api_hostgroup_created
   until: zabbix_api_hostgroup_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
+  become: false
   tags:
     - api
 
@@ -41,6 +42,7 @@
   register: zabbix_api_host_created
   until: zabbix_api_host_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
+  become: false
   changed_when: false
   tags:
     - api
@@ -75,6 +77,7 @@
   register: zabbix_api_host_created
   until: zabbix_api_host_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
+  become: false
   changed_when: false
   tags:
     - api
@@ -92,5 +95,6 @@
   register: zabbix_api_hostmarcro_created
   until: zabbix_api_hostmarcro_created is succeeded
   delegate_to: "{{ zabbix_api_server_host }}"
+  become: false
   tags:
     - api


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
in zabbix-agent role, some task require sudo. but sudo is not needed in api calling so I added became: false flag.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

zabbix-agent role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
