### PR TITLE
Removed dependency of mysql group definition

### DIFF
--- a/changelogs/fragments/pymysql.yml
+++ b/changelogs/fragments/pymysql.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxy role - Removed requirement for mysql group definition.

--- a/roles/zabbix_proxy/tasks/mysql.yml
+++ b/roles/zabbix_proxy/tasks/mysql.yml
@@ -28,8 +28,8 @@
     name: PyMySQL
   register: installation_dependencies
   until: installation_dependencies is succeeded
-  when:
-    - inventory_hostname in groups['mysql']
+  tags:
+    - database
 
 - name: "MySQL | Create database"
   community.mysql.mysql_db:


### PR DESCRIPTION
##### SUMMARY
This relates to #1115 and fixes a minor bug in the proxy role which will cause a failure if mysql is used, but the the 'mysql' group is not defined.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxy role
