### PR TITLE
Allowed creation of php-fpm without vhost creation

### DIFF
--- a/changelogs/fragments/php_fpm_config.yml
+++ b/changelogs/fragments/php_fpm_config.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix web - Allowed the independent configuration of php-fpm without creating vhost.

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -102,6 +102,7 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_url_aliases`: A list with Aliases for the Apache Virtual Host configuration.
 * `zabbix_timezone`: Default: `Europe/Amsterdam`. This is the timezone. The Apache Virtual Host needs this parameter.
 * `zabbix_web_create_vhost`: Default: `true`. When you don't want to create an Apache Virtual Host configuration, you can set it to False.
+* `zabbix_web_create_php_fpm`: Configure php-fpm (Debian hosts only).  Default is to use the same value as `zabbix_web_create_vhost`.
 * `zabbix_web_env`: (Optional) A Dictionary of PHP Environments settings.
 * `zabbix_web_user`: When provided, the user (which should already exist on the host) will be used for ownership for web/php related processes. (Default set to either `apache` (`www-data` for Debian) or `nginx`).
 * `zabbix_web_group`: When provided, the group (which should already exist on the host) will be used for ownership for web/php related processes. (Default set to either `apache` (`www-data` for Debian) or `nginx`).

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -10,6 +10,7 @@ zabbix_api_server_url: zabbix.example.com
 zabbix_web_http_server: apache
 zabbix_url_aliases: []
 zabbix_web_create_vhost: true
+zabbix_web_create_php_fpm: "{{ zabbix_web_create_vhost }}"
 
 zabbix_server_name: "{{ inventory_hostname }}"
 zabbix_server_hostname: "{{ inventory_hostname }}"

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -89,7 +89,7 @@
     mode: 0644
   become: true
   when:
-    - zabbix_web_create_vhost
+    - zabbix_web_create_php_fpm
     - ansible_os_family == "Debian"
   notify:
     - restart php-fpm-version


### PR DESCRIPTION
##### SUMMARY
This PR relates to #1094 and allows for Debian hosts to configure php-fpm even if the vhost is not created.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Web Role