### PR TITLE
Remove unnecessary apt-get clean command

### DIFF
--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -102,16 +102,6 @@
   tags:
     - install
 
-- name: "Debian | apt-get clean"
-  ansible.builtin.shell: apt-get clean; apt-get update
-  args:
-    warn: "{{ produce_warn | default(omit) }}"
-  changed_when: false
-  become: true
-  tags:
-    - skip_ansible_lint
-    - install
-
 - name: "Debian | Installing zabbix-agent"
   ansible.builtin.apt:
     pkg: "{{ zabbix_agent_package }}"

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -106,16 +106,6 @@
   tags:
     - install
 
-- name: "Debian | apt-get clean"
-  ansible.builtin.shell: apt-get clean; apt-get update
-  args:
-    warn: "{{ produce_warn | default(omit) }}"
-  changed_when: false
-  become: true
-  tags:
-    - skip_ansible_lint
-    - install
-
 # On certain 18.04 images, such as docker or lxc, dpkg is configured not to
 # install files into paths /usr/share/doc/*
 # Since this is where Zabbix installs its database schemas, we need to allow

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -122,16 +122,6 @@
   tags:
     - install
 
-- name: "Debian | apt-get clean"
-  ansible.builtin.shell: apt-get clean; apt-get update
-  args:
-    warn: "{{ produce_warn | default(omit) }}"
-  changed_when: false
-  become: true
-  tags:
-    - skip_ansible_lint
-    - install
-
 - name: "Debian | Install zabbix-web"
   ansible.builtin.apt:
     pkg: "zabbix-frontend-php"


### PR DESCRIPTION
Fixes Remove `apt-get clean` roles #1133