### PR TITLE
Remove user type from example

### DIFF
--- a/plugins/modules/zabbix_user.py
+++ b/plugins/modules/zabbix_user.py
@@ -262,7 +262,6 @@ EXAMPLES = r"""
           high: yes
           disaster: yes
         active: no
-    type: Zabbix super admin
     state: present
 
 - name: delete existing zabbix user.


### PR DESCRIPTION
User type can no longer be specified, and leads to an error:

``` 
msg: 'Unsupported parameters for (community.zabbix.zabbix_user) module: type. Supported parameters include: after_login_url, autologin, autologout, http_login_password, http_login_user, lang, name, override_passwd, passwd, refresh, role_name, rows_per_page, state, surname, theme, timezone, user_medias, username, usrgrps.'
```