### PR TITLE
Readd support for secure PostgreSQL password hashes (#1074)

### DIFF
--- a/changelogs/fragments/1136.yml
+++ b/changelogs/fragments/1136.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zabbix_server role - Add variable zabbix_server_dbpassword_hash_method to control whether you want postgresql user password to be hashed with md5 or want to use db default. When zabbix_server_dbpassword_hash_method is set to anything other than md5 then do not hash the password with md5 so you could use postgresql scram-sha-256 hashing method.
+  - zabbix_proxy role - Add variable zabbix_proxy_dbpassword_hash_method to control whether you want postgresql user password to be hashed with md5 or want to use db default. When zabbix_proxy_dbpassword_hash_method is set to anything other than md5 then do not hash the password with md5 so you could use postgresql scram-sha-256 hashing method.

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -115,6 +115,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_proxy_dbname`: Default: zabbix_proxy. The database name which is used by the Zabbix Proxy.
 * `zabbix_proxy_dbuser`: Default: zabbix_proxy. The database username which is used by the Zabbix Proxy. Will be ignored when `sqlite3` is used as database.
 * `zabbix_proxy_dbpassword`: Default: zabbix_proxy. The database user password which is used by the Zabbix Proxy. Will be ignored when `sqlite3` is used as database.
+* `zabbix_proxy_dbpassword_hash_method`: Default: `md5`. Allow switching postgresql user password creation to `scram-sha-256`, when anything other than `md5` is used then ansible won't hash the password with `md5`.
 * `zabbix_proxy_dbport`: The database port which is used by the Zabbix Proxy. Will be ignored when `sqlite3` is used as database.
 * `zabbix_proxy_database_creation`: Default: `True`. When you don't want to create the database including user, you can set it to False.
 * `zabbix_proxy_install_database_client`: Default: `True`. False does not install database client. Default true

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -133,6 +133,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_server_dbname`: The database name which is used by the Zabbix Server.
 * `zabbix_server_dbuser`: The database username which is used by the Zabbix Server.
 * `zabbix_server_dbpassword`: The database user password which is used by the Zabbix Server.
+* `zabbix_server_dbpassword_hash_method`: Default: `md5`. Allow switching postgresql user password creation to `scram-sha-256`, when anything other than `md5` is used then ansible won't hash the password with `md5`.
 * `zabbix_server_dbport`: The database port which is used by the Zabbix Server.
 * `zabbix_server_dbpassword_hash_method`: Default: `md5`. Allow switching postgresql user password creation to `scram-sha-256`, when anything other than `md5` is used then ansible won't hash the password with `md5`.
 * `zabbix_server_database_creation`: Default: `True`. When you don't want to create the database including user, you can set it to False.

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -20,6 +20,7 @@ zabbix_proxy_dbencoding: utf8
 zabbix_proxy_dbhost: localhost
 zabbix_proxy_dbname: zabbix_proxy
 zabbix_proxy_dbpassword: zabbix_proxy
+zabbix_proxy_dbpassword_hash_method: md5
 zabbix_proxy_dbuser: zabbix_proxy
 zabbix_proxy_install_database_client: true
 

--- a/roles/zabbix_proxy/tasks/postgresql.yml
+++ b/roles/zabbix_proxy/tasks/postgresql.yml
@@ -29,7 +29,7 @@
       community.postgresql.postgresql_user:
         db: "{{ zabbix_proxy_dbname }}"
         name: "{{ zabbix_proxy_dbuser }}"
-        password: "md5{{ (zabbix_proxy_dbpassword + zabbix_proxy_dbuser)|hash('md5') }}"
+        password: "{{ ('md5' + (zabbix_proxy_dbpassword + zabbix_proxy_dbuser)|hash('md5')) if zabbix_proxy_dbpassword_hash_method == 'md5' else zabbix_proxy_dbpassword }}"
         port: "{{ zabbix_proxy_dbport }}"
         priv: ALL
         state: present
@@ -61,7 +61,7 @@
         login_password: "{{ zabbix_proxy_pgsql_login_password | default(omit) }}"
         db: "{{ zabbix_proxy_dbname }}"
         name: "{{ zabbix_proxy_dbuser }}"
-        password: "md5{{ (zabbix_proxy_dbpassword + zabbix_proxy_dbuser)|hash('md5') }}"
+        password: "{{ ('md5' + (zabbix_proxy_dbpassword + zabbix_proxy_dbuser)|hash('md5')) if zabbix_proxy_dbpassword_hash_method == 'md5' else zabbix_proxy_dbpassword }}"
         port: "{{ zabbix_proxy_dbport }}"
         priv: ALL
         state: present

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -17,6 +17,7 @@ zabbix_server_dbcollation: utf8_bin
 zabbix_server_dbschema:
 zabbix_server_dbuser: zabbix-server
 zabbix_server_dbpassword: zabbix-server
+zabbix_server_dbpassword_hash_method: md5
 zabbix_server_dbsocket:
 zabbix_server_dbport: 5432
 zabbix_server_dbhost_run_install: true

--- a/roles/zabbix_server/tasks/postgresql.yml
+++ b/roles/zabbix_server/tasks/postgresql.yml
@@ -29,7 +29,7 @@
       community.postgresql.postgresql_user:
         db: "{{ zabbix_server_dbname }}"
         name: "{{ zabbix_server_dbuser }}"
-        password: "md5{{ (zabbix_server_dbpassword + zabbix_server_dbuser)|hash('md5') }}"
+        password: "{{ ('md5' + (zabbix_server_dbpassword + zabbix_server_dbuser)|hash('md5')) if zabbix_server_dbpassword_hash_method == 'md5' else zabbix_server_dbpassword }}"
         port: "{{ zabbix_server_dbport }}"
         priv: ALL
         state: present
@@ -68,7 +68,7 @@
         login_password: "{{ zabbix_server_pgsql_login_password | default(omit) }}"
         db: "{{ zabbix_server_dbname }}"
         name: "{{ zabbix_server_dbuser }}"
-        password: "md5{{ (zabbix_server_dbpassword + zabbix_server_dbuser)|hash('md5') }}"
+        password: "{{ ('md5' + (zabbix_server_dbpassword + zabbix_server_dbuser)|hash('md5')) if zabbix_server_dbpassword_hash_method == 'md5' else zabbix_server_dbpassword }}"
         port: "{{ zabbix_server_dbport }}"
         priv: ALL
         state: present


### PR DESCRIPTION
##### SUMMARY
Fixes #1074

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
zabbix_server & zabbix_proxy

##### ADDITIONAL INFORMATION
Roles fail on newer PostgreSQL defaults