### PR TITLE
specify ldap_userdirectory in the example

### DIFF
--- a/plugins/modules/zabbix_authentication.py
+++ b/plugins/modules/zabbix_authentication.py
@@ -384,6 +384,7 @@ EXAMPLES = """
       - any
     http_case_sensitive: true
     ldap_auth_enabled: true
+    ldap_userdirectory: TestUserDirectory
     ldap_case_sensitive: true
     saml_auth_enabled: true
     saml_case_sensitive: true


### PR DESCRIPTION
##### SUMMARY
As the example sets ldap_auth_enabled to true, also specify ldap_userdirectory, which is required.
Use the example name from zabbix_user_directory .

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zabbix_authentication