### PR TITLE
feat: add raspberry pi spport

### DIFF
--- a/changelogs/fragments/raspberrypi.yml
+++ b/changelogs/fragments/raspberrypi.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix-{agent, javagateway, proxy, server, web} - support raspberry pi without repository url specification

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -8,6 +8,20 @@
   tags:
     - always
 
+- name: "Debian | Installing lsb-release"
+  ansible.builtin.apt:
+    pkg: lsb-release
+    update_cache: true
+    cache_valid_time: 3600
+    force: true
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  become: true
+  tags:
+    - install
+
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
     zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -22,6 +22,11 @@
   tags:
     - install
 
+- name: "Debian | Update ansible_lsb fact"
+  ansible.builtin.setup:
+    gather_subset:
+      - lsb
+
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
     zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -10,7 +10,7 @@
 
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}{{ '-arm64' if ansible_machine == 'aarch64' else ''}}"
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"
   when:
     - zabbix_repo_deb_url is undefined
   tags:

--- a/roles/zabbix_agent/vars/Debian.yml
+++ b/roles/zabbix_agent/vars/Debian.yml
@@ -45,4 +45,4 @@ zabbix_valid_agent_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
-_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}"
+_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}"

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -7,7 +7,7 @@
 
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}{{ '-arm64' if ansible_machine == 'aarch64' else ''}}"
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"
   when:
     - zabbix_repo_deb_url is undefined
   tags:

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -5,6 +5,20 @@
   tags:
     - always
 
+- name: "Debian | Installing lsb-release"
+  ansible.builtin.apt:
+    pkg: lsb-release
+    update_cache: true
+    cache_valid_time: 3600
+    force: true
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  become: true
+  tags:
+    - install
+
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
     zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -19,6 +19,11 @@
   tags:
     - install
 
+- name: "Debian | Update ansible_lsb fact"
+  ansible.builtin.setup:
+    gather_subset:
+      - lsb
+
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
     zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"

--- a/roles/zabbix_javagateway/vars/Debian.yml
+++ b/roles/zabbix_javagateway/vars/Debian.yml
@@ -27,4 +27,4 @@ zabbix_valid_javagateway_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
-_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/{{ ansible_distribution.lower() }}"
+_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}"

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -7,6 +7,20 @@
   tags:
     - always
 
+- name: "Debian | Installing lsb-release"
+  ansible.builtin.apt:
+    pkg: lsb-release
+    update_cache: true
+    cache_valid_time: 3600
+    force: true
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  become: true
+  tags:
+    - install
+
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
     zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -9,7 +9,7 @@
 
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}{{ '-arm64' if ansible_machine == 'aarch64' else ''}}"
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"
   when:
     - zabbix_repo_deb_url is undefined
   tags:

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -21,6 +21,11 @@
   tags:
     - install
 
+- name: "Debian | Update ansible_lsb fact"
+  ansible.builtin.setup:
+    gather_subset:
+      - lsb
+
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
     zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"

--- a/roles/zabbix_proxy/vars/Debian.yml
+++ b/roles/zabbix_proxy/vars/Debian.yml
@@ -52,6 +52,6 @@ mysql_plugin:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
-_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_distribution.lower() }}"
+_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}"
 _zabbix_proxy_fping6location: /usr/bin/fping6
 _zabbix_proxy_fpinglocation: /usr/bin/fping

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -7,6 +7,20 @@
   tags:
     - always
 
+- name: "Debian | Installing lsb-release"
+  ansible.builtin.apt:
+    pkg: lsb-release
+    update_cache: true
+    cache_valid_time: 3600
+    force: true
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  become: true
+  tags:
+    - install
+
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
     zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -9,7 +9,7 @@
 
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}{{ '-arm64' if ansible_machine == 'aarch64' else ''}}"
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"
   when:
     - zabbix_repo_deb_url is undefined
   tags:

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -21,6 +21,11 @@
   tags:
     - install
 
+- name: "Debian | Update ansible_lsb fact"
+  ansible.builtin.setup:
+    gather_subset:
+      - lsb
+
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
     zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"

--- a/roles/zabbix_server/vars/Debian.yml
+++ b/roles/zabbix_server/vars/Debian.yml
@@ -30,6 +30,6 @@ zabbix_valid_server_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
-_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}"
+_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}"
 _zabbix_server_fping6location: /usr/bin/fping6
 _zabbix_server_fpinglocation: /usr/bin/fping

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -15,7 +15,7 @@
 
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}{{ '-arm64' if ansible_machine == 'aarch64' else ''}}"
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"
   when:
     - zabbix_repo_deb_url is undefined
   tags:

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -13,6 +13,11 @@
   tags:
     - always
 
+- name: "Debian | Update ansible_lsb fact"
+  ansible.builtin.setup:
+    gather_subset:
+      - lsb
+
 - name: "Debian | Installing lsb-release"
   ansible.builtin.apt:
     pkg: lsb-release

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -13,6 +13,20 @@
   tags:
     - always
 
+- name: "Debian | Installing lsb-release"
+  ansible.builtin.apt:
+    pkg: lsb-release
+    update_cache: true
+    cache_valid_time: 3600
+    force: true
+    state: present
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+  become: true
+  tags:
+    - install
+
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
     zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"

--- a/roles/zabbix_web/vars/Debian.yml
+++ b/roles/zabbix_web/vars/Debian.yml
@@ -48,4 +48,4 @@ zabbix_valid_web_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
-_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}"
+_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}"


### PR DESCRIPTION
##### SUMMARY
in case raspberry pi, role scripts mis-detect os type as debian and try to add debian repo url.
This PR change the detection to detect rasberry pi os to get right repo url.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
{agent, javagateway, web, server} role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
