### PR TITLE
Updated MariaDB Version

### DIFF
--- a/changelogs/fragments/proxy_mysql.yml
+++ b/changelogs/fragments/proxy_mysql.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxy role - Updated MariaDB version for Centos 7 to 10.11

--- a/roles/zabbix_proxy/tasks/RedHat.yml
+++ b/roles/zabbix_proxy/tasks/RedHat.yml
@@ -100,7 +100,7 @@
         name: mariadb
         description: MariaDB 10.8 CentOS repository list
         file: mariadb
-        baseurl: "https://mirror.rackspace.com/mariadb/yum/10.8/centos{{ ansible_distribution_major_version }}-amd64"
+        baseurl: "https://mirror.rackspace.com/mariadb/yum/10.11/centos{{ ansible_distribution_major_version }}-amd64"
         gpgcheck: no
       when: ansible_distribution_major_version == '7'
 


### PR DESCRIPTION
##### SUMMARY
Fixed bug noted in https://github.com/ansible-collections/community.zabbix/pull/1145 due to EOL for 10.8 of MariaDB.  Closes #1148 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Proxy Role

