### PR TITLE
Avoid to update user-directory configuration in dry run.

### DIFF
--- a/changelogs/fragments/1156-bugfix_zabbix_user_directory_dryrun.yml
+++ b/changelogs/fragments/1156-bugfix_zabbix_user_directory_dryrun.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Avoid to update user-directory configuration in dry run.

--- a/plugins/modules/zabbix_user_directory.py
+++ b/plugins/modules/zabbix_user_directory.py
@@ -691,6 +691,8 @@ def main():
     else:
         # User Directory with given name exists
         if state == "absent":
+            if module.check_mode:
+                module.exit_json(changed=True)
             user_directory._zapi.userdirectory.delete([directory[0]["userdirectoryid"]])
             module.exit_json(
                 changed=True,
@@ -705,6 +707,8 @@ def main():
                 parameters, directory[0], diff_dict
             ):
                 parameters["userdirectoryid"] = directory[0]["userdirectoryid"]
+                if module.check_mode:
+                    module.exit_json(changed=True)
                 user_directory._zapi.userdirectory.update(parameters)
                 module.exit_json(
                     changed=True,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Avoid to update user-directory configuration in dry run.
- Fixes #1144 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- zabbix_user_directory
