### PR TITLE
fix(zabbix-server): misaligned become in selinux

### DIFF
--- a/changelogs/fragments/1165-indent-become.yml
+++ b/changelogs/fragments/1165-indent-become.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_server - proper indentaion of become in selinux.yaml

--- a/roles/zabbix_server/tasks/selinux.yml
+++ b/roles/zabbix_server/tasks/selinux.yml
@@ -126,6 +126,6 @@
     cmd: files/install_semodule.bsx
   args:
     creates: /etc/selinux/targeted/active/modules/400/zabbix_server_add/cil
-    become: true
+  become: true
   tags:
     - config


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix indentation of `become` in selinux.yaml

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
role zabbix_server

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The `zabbix_server` role's "SELinux | RedHat | Add SEmodule to fix SELinux issue: zabbix_server_alerter.sock" fails with the following error on RPM distributions:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Unsupported parameters for (ansible_collections.ansible.builtin.plugins.action.script) module: become. Supported parameters include: _raw_params, chdir, cmd, creates, executable, removes."}
```

It should create the `/etc/selinux/targeted/active/modules/400/zabbix_server_add/cil` file.