### PR TITLE
Finish task with failed if host_group parameter is empty list

### DIFF
--- a/changelogs/fragments/1168-finish-task-with-failed-if-host_group-parameter-is-empty_list.yml
+++ b/changelogs/fragments/1168-finish-task-with-failed-if-host_group-parameter-is-empty_list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_host - Finish task with failed if host_group parameter is empty list

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -1038,8 +1038,11 @@ def main():
 
     group_ids = []
 
-    if host_groups:
-        group_ids = host.get_group_ids_by_group_names(host_groups)
+    if host_groups is not None:
+        if len(host_groups) >= 1:
+            group_ids = host.get_group_ids_by_group_names(host_groups)
+        else:
+            module.fail_json(msg="host_groups must be not empty list.")
 
     interfaces, ip = host.construct_host_interfaces(interfaces)
 

--- a/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
+++ b/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
@@ -1403,6 +1403,23 @@
     that:
       - "zabbix_ipmi_host is not changed"
 
+- name: "test: create host with host group(empty list)"
+  community.zabbix.zabbix_host:
+    host_name: ExampleHost
+    visible_name: ExampleName
+    description: My ExampleHost Description
+    host_groups: []
+    status: disabled
+    state: present
+  ignore_errors: true
+  register: zbx_host_create_hostgroup_empty_list
+
+- name: expect to fail updating
+  ansible.builtin.assert:
+    that:
+      - zbx_host_create_hostgroup_empty_list is failed
+      - zbx_host_create_hostgroup_empty_list.msg == "host_groups must be not empty list."
+
 - name: "cleanup"
   community.zabbix.zabbix_host:
     host_name: ExampleHost


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Finish task with failed if host_group parameter is empty_list.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- Fixes #1163
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host module
