### PR TITLE
Fix check mode always changed

### DIFF
--- a/molecule/zabbix_agent_tests/common/playbooks/prepare.yml
+++ b/molecule/zabbix_agent_tests/common/playbooks/prepare.yml
@@ -47,6 +47,7 @@
   hosts: docker
   tasks:
     - name: "Download Docker CE repo file"
+      when: not ansible_check_mode  # Because get_url always has changed status
       ansible.builtin.get_url:
         url: https://download.docker.com/linux/centos/docker-ce.repo
         dest: /etc/yum.repos.d/docker-ce.repo

--- a/molecule/zabbix_agent_tests/common/playbooks/prepare.yml
+++ b/molecule/zabbix_agent_tests/common/playbooks/prepare.yml
@@ -47,7 +47,7 @@
   hosts: docker
   tasks:
     - name: "Download Docker CE repo file"
-      when: not ansible_check_mode  # Because get_url always has changed status
+      when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
       ansible.builtin.get_url:
         url: https://download.docker.com/linux/centos/docker-ce.repo
         dest: /etc/yum.repos.d/docker-ce.repo

--- a/roles/zabbix_agent/molecule/with-server/prepare.yml
+++ b/roles/zabbix_agent/molecule/with-server/prepare.yml
@@ -75,7 +75,7 @@
   hosts: docker
   tasks:
     - name: "Download Docker CE repo file"
-      when: not ansible_check_mode  # Because get_url always has changed status
+      when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
       ansible.builtin.get_url:
         url: https://download.docker.com/linux/centos/docker-ce.repo
         dest: /etc/yum.repos.d/docker-ce.repo

--- a/roles/zabbix_agent/molecule/with-server/prepare.yml
+++ b/roles/zabbix_agent/molecule/with-server/prepare.yml
@@ -75,6 +75,7 @@
   hosts: docker
   tasks:
     - name: "Download Docker CE repo file"
+      when: not ansible_check_mode  # Because get_url always has changed status
       ansible.builtin.get_url:
         url: https://download.docker.com/linux/centos/docker-ce.repo
         dest: /etc/yum.repos.d/docker-ce.repo

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -65,7 +65,7 @@
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
 
 - name: "Debian | Download gpg key"
-  when: not ansible_check_mode  # Because get_url always has changed status
+  when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -65,6 +65,7 @@
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
 
 - name: "Debian | Download gpg key"
+  when: not ansible_check_mode  # Because get_url always has changed status
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -46,6 +46,7 @@
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
 
 - name: "Debian | Download gpg key"
+  when: not ansible_check_mode  # Because get_url always has changed status
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -46,7 +46,7 @@
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
 
 - name: "Debian | Download gpg key"
-  when: not ansible_check_mode  # Because get_url always has changed status
+  when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -71,7 +71,7 @@
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
 
 - name: "Debian | Download gpg key"
-  when: not ansible_check_mode  # Because get_url always has changed status
+  when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -71,6 +71,7 @@
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
 
 - name: "Debian | Download gpg key"
+  when: not ansible_check_mode  # Because get_url always has changed status
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -70,7 +70,7 @@
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
 
 - name: "Debian | Download gpg key"
-  when: not ansible_check_mode  # Because get_url always has changed status
+  when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -70,6 +70,7 @@
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
 
 - name: "Debian | Download gpg key"
+  when: not ansible_check_mode  # Because get_url always has changed status
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -88,6 +88,7 @@
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
 
 - name: "Debian | Download gpg key"
+  when: not ansible_check_mode  # Because get_url always has changed status
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -88,7 +88,7 @@
       (ansible_distribution == "Debian" and ansible_distribution_major_version < "12")
 
 - name: "Debian | Download gpg key"
-  when: not ansible_check_mode  # Because get_url always has changed status
+  when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
     url: http://repo.zabbix.com/zabbix-official-repo.key
     dest: "{{ zabbix_gpg_key }}"


### PR DESCRIPTION
##### SUMMARY
Prevent `ansible.builtin.get_url` from causing check_mode (`--check`) from being always 'changed'.
The problem is described in the [get_url module documentation](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#attribute-check_mode), see the **check_mode** attibute.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- zabbix_agent
- zabbix_javagateway
- zabbix_proxy
- zabbix_server
- zabbix_web

##### ADDITIONAL INFORMATION
We run our playbooks with `--check` every night. 
The goal is to see where there is anything not compiant.
We noticed `zabbix_agent`, `zabbix_web` and `zabbix_server` were always 'changed'.
This is a fix / workaround.
