### PR TITLE
feat(zabbix_mediatype): expose content_type field for email

### DIFF
--- a/changelogs/fragments/1176-content_type-in-mediatype.yml
+++ b/changelogs/fragments/1176-content_type-in-mediatype.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added content_type for email in zabbix_mediatypes

--- a/plugins/modules/zabbix_mediatype.py
+++ b/plugins/modules/zabbix_mediatype.py
@@ -155,6 +155,15 @@ options:
             - SSL verify peer for SMTP.
             - Can be specified when I(smtp_security=STARTTLS) or I(smtp_security=SSL/TLS)
         default: false
+    content_type:
+        type: "str"
+        description:
+            - Can be used when I(type=email).
+            - Message format.
+        choices:
+            - plaintext
+            - html
+        default: html
     message_text_limit:
         type: "str"
         description:
@@ -525,6 +534,7 @@ class MediaTypeModule(ZabbixBase):
                 smtp_authentication=truths.get(str(self._module.params["smtp_authentication"])),
                 smtp_verify_host=truths.get(str(self._module.params["smtp_verify_host"])),
                 smtp_verify_peer=truths.get(str(self._module.params["smtp_verify_peer"])),
+                content_type={"plaintext": "0", "html": "1"}.get(str(self._module.params["content_type"])),
                 username=self._module.params["username"],
                 passwd=self._module.params["password"]
             ))
@@ -693,6 +703,7 @@ def main():
         smtp_authentication=dict(type="bool", default=False, required=False),
         smtp_verify_host=dict(type="bool", default=False, required=False),
         smtp_verify_peer=dict(type="bool", default=False, required=False),
+        content_type=dict(type="str", choices=["plaintext", "html"], default="html", required=False),
         # EZ Text
         message_text_limit=dict(type="str", required=False, choices=["USA", "Canada"]),
         # Webhook

--- a/tests/integration/targets/test_zabbix_mediatype/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_mediatype/tasks/main.yml
@@ -114,6 +114,29 @@
     - ansible.builtin.assert:
         that: zbxmediatype_reset.changed is sameas True
 
+    - name: test - check email mediatype content_type for html default
+      community.zabbix.zabbix_mediatype:
+        content_type: "html"
+      register: zbxmediatype_verif
+
+    - ansible.builtin.assert:
+        that: zbxmediatype_verif.changed is sameas False
+
+    - name: test - update email mediatype content_type to plaintext
+      community.zabbix.zabbix_mediatype:
+        content_type: "plaintext"
+      register: zbxmediatype_verif
+
+    - ansible.builtin.assert:
+        that: zbxmediatype_verif.changed is sameas True
+
+    - name: test - reset email mediatype content_type to default
+      community.zabbix.zabbix_mediatype:
+      register: zbxmediatype_reset
+
+    - ansible.builtin.assert:
+        that: zbxmediatype_reset.changed is sameas True
+
     - name: test - update email mediatype concurrent settings
       community.zabbix.zabbix_mediatype:
         max_sessions: 99


### PR DESCRIPTION
##### SUMMARY
Adds the `content_type` field in `zabbix_mediatype` and allow configuring Zabbix to send plain text mails.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`zabbix_mediatype`

##### ADDITIONAL INFORMATION
It's called "Message format" in the Zabbix UI and you can choose between HTML and plain text.