### PR TITLE
Fix slash in nginx vhost files against path traversal

### DIFF
--- a/changelogs/fragments/1183-nginx-fix-against-path-traversal.yml
+++ b/changelogs/fragments/1183-nginx-fix-against-path-traversal.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add slash at the end of the location directives, to prevent path traversal attacks.

--- a/roles/zabbix_web/templates/nginx_vhost.conf.j2
+++ b/roles/zabbix_web/templates/nginx_vhost.conf.j2
@@ -20,7 +20,7 @@ server {
         try_files       $uri $uri/ =404;
     }
 
-    location /assets {
+    location /assets/ {
         access_log      off;
         expires         10d;
     }
@@ -85,7 +85,7 @@ server {
         try_files       $uri $uri/ =404;
     }
 
-    location /assets {
+    location /assets/ {
         access_log      off;
         expires         10d;
     }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Append slash in nginx vhost files against path traversal

Fix #1183 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Zabbix Web

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
n/d
```
