### PR TITLE
Make Zabbix repository gpg key URL customizable

### DIFF
--- a/changelogs/fragments/1186-custom_gpg_key_url.yml
+++ b/changelogs/fragments/1186-custom_gpg_key_url.yml
@@ -1,7 +1,8 @@
 minor_changes:
-  - agent, javagateway, proxy, server, and web role - introduced default variable zabbix_<role>_gpg_key_url with value http://repo.zabbix.com/zabbix-official-repo.key
-  - agent, javagateway, proxy, server, and web role - used zabbix_<role>_gpg_key_url in "Debian | Download gpg key" instead of hardcoded url
+  - agent, javagateway, proxy, server, and web role - introduced default variable zabbix_repo_deb_gpg_key_url with value http://repo.zabbix.com/zabbix-official-repo.key
+  - agent, javagateway, proxy, server, and web role - used zabbix_repo_deb_gpg_key_url in "Debian | Download gpg key" instead of hardcoded url
   - agent, javagateway, proxy, server, and web role - added the http_proxy and https_proxy environment variables to "Debian | Download gpg key" analog to other tasks
-  - agent, javagateway, proxy, server, and web role - introduced default variable zabbix_<role>_include_deb_src with value true
-  - agent, javagateway, proxy, server, and web role - used variable zabbix_<role>_include_deb_src in "Debian | Installing repository" to determine whether deb-src should be added to /etc/apt/sources.list.d/zabbix.sources
+  - agent, javagateway, proxy, server, and web role - introduced default variable zabbix_repo_deb_include_deb_src with value true
+  - agent, javagateway, proxy, server, and web role - used variable zabbix_repo_deb_include_deb_src in "Debian | Installing repository" to determine whether deb-src should be added to /etc/apt/sources.list.d/zabbix.sources
   - agent, javagateway, proxy, server, and web role - removed superfluous slash in zabbix_gpg_key of the Debian vars and renamed key to zabbix-repo instead of zabbix-official-repo
+  - agent, javagateway, proxy, server, and web role - updated readme with the two new variables "zabbix_repo_deb_gpg_key_url" and "zabbix_repo_deb_include_deb_src"

--- a/changelogs/fragments/1186-custom_gpg_key_url.yml
+++ b/changelogs/fragments/1186-custom_gpg_key_url.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - agent, javagateway, proxy, server, and web role - introduced default variable zabbix_<role>_gpg_key_url with value http://repo.zabbix.com/zabbix-official-repo.key
+  - agent, javagateway, proxy, server, and web role - used zabbix_<role>_gpg_key_url in "Debian | Download gpg key" instead of hardcoded url
+  - agent, javagateway, proxy, server, and web role - added the http_proxy and https_proxy environment variables to "Debian | Download gpg key" analog to other tasks
+  - agent, javagateway, proxy, server, and web role - introduced default variable zabbix_<role>_include_deb_src with value true
+  - agent, javagateway, proxy, server, and web role - used variable zabbix_<role>_include_deb_src in "Debian | Installing repository" to determine whether deb-src should be added to /etc/apt/sources.list.d/zabbix.sources
+  - agent, javagateway, proxy, server, and web role - removed superfluous slash in zabbix_gpg_key of the Debian vars and renamed key to zabbix-repo instead of zabbix-official-repo

--- a/changelogs/fragments/1186-custom_gpg_key_url.yml
+++ b/changelogs/fragments/1186-custom_gpg_key_url.yml
@@ -5,4 +5,3 @@ minor_changes:
   - agent, javagateway, proxy, server, and web role - introduced default variable zabbix_repo_deb_include_deb_src with value true
   - agent, javagateway, proxy, server, and web role - used variable zabbix_repo_deb_include_deb_src in "Debian | Installing repository" to determine whether deb-src should be added to /etc/apt/sources.list.d/zabbix.sources
   - agent, javagateway, proxy, server, and web role - removed superfluous slash in zabbix_gpg_key of the Debian vars and renamed key to zabbix-repo instead of zabbix-official-repo
-  - agent, javagateway, proxy, server, and web role - updated readme with the two new variables "zabbix_repo_deb_gpg_key_url" and "zabbix_repo_deb_include_deb_src"

--- a/changelogs/fragments/custom_gpg_key_url.yml
+++ b/changelogs/fragments/custom_gpg_key_url.yml
@@ -1,6 +1,0 @@
-minor_changes:
-  - agent, javagateway, proxy, server, and web role - introduced default variable zabbix_<role>_gpg_key_url with value http://repo.zabbix.com/zabbix-official-repo.key
-  - agent, javagateway, proxy, server, and web role - used zabbix_<role>_gpg_key_url in Debian Task instead of hardcoded url
-  - agent, javagateway, proxy, server, and web role - introduced default variable zabbix_<role>_include_deb_src with value true
-  - agent, javagateway, proxy, server, and web role - used variable zabbix_<role>_include_deb_src in Debian Task to determine whether deb-src should be added to /etc/apt/sources.list.d/zabbix.sources
-  - agent, javagateway, proxy, server, and web role - removed superfluous slash in zabbix_gpg_key of the Debian vars and renamed key to zabbix-repo instead of zabbix-official-repo

--- a/changelogs/fragments/custom_gpg_key_url.yml
+++ b/changelogs/fragments/custom_gpg_key_url.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - agent, javagateway, proxy, server, and web role - introduced default variable zabbix_<role>_gpg_key_url with value http://repo.zabbix.com/zabbix-official-repo.key
+  - agent, javagateway, proxy, server, and web role - used zabbix_<role>_gpg_key_url in Debian Task instead of hardcoded url
+  - agent, javagateway, proxy, server, and web role - introduced default variable zabbix_<role>_include_deb_src with value true
+  - agent, javagateway, proxy, server, and web role - used variable zabbix_<role>_include_deb_src in Debian Task to determine whether deb-src should be added to /etc/apt/sources.list.d/zabbix.sources
+  - agent, javagateway, proxy, server, and web role - removed superfluous slash in zabbix_gpg_key of the Debian vars and renamed key to zabbix-repo instead of zabbix-official-repo

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -136,6 +136,8 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_agent_disable_repo`: A list of repos to disable during install.  Default `epel`.
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
+* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
+* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default 'true'.
 
 ### SElinux
 

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -137,7 +137,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
 * `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
-* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default 'true'.
+* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default `true`.
 
 ### SElinux
 

--- a/docs/ZABBIX_JAVAGATEWAY_ROLE.md
+++ b/docs/ZABBIX_JAVAGATEWAY_ROLE.md
@@ -62,6 +62,8 @@ The `zabbix_javagateway_version` is optional. The latest available major.minor v
 * `zabbix_javagateway_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
+* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
+* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default 'true'.
 
 ### Java Gatewaty
 

--- a/docs/ZABBIX_JAVAGATEWAY_ROLE.md
+++ b/docs/ZABBIX_JAVAGATEWAY_ROLE.md
@@ -63,7 +63,7 @@ The `zabbix_javagateway_version` is optional. The latest available major.minor v
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
 * `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
-* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default 'true'.
+* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default `true`.
 
 ### Java Gatewaty
 

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -134,7 +134,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
 * `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
-* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default 'true'.
+* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default `true`.
 
 ### SElinux
 

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -133,6 +133,9 @@ The following is an overview of all available configuration default for this rol
 * `*zabbix_proxy_package_state`: Default: `present`. Can be overridden to `latest` to update packages
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
+* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
+* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default 'true'.
+
 ### SElinux
 
 * `zabbix_proxy_selinux`: Default: `False`. Enables an SELinux policy so that the Proxy will run.

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -109,6 +109,8 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_service_enabled`: Default: `True` Can be overridden to `False` if needed
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
+* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
+* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default 'true'.
 
 ### SElinux
 

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -110,7 +110,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
 * `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
-* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default 'true'.
+* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default `true`.
 
 ### SElinux
 

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -94,6 +94,8 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
+* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
+* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default 'true'.
 
 ### Zabbix Web specific
 

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -95,7 +95,7 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
 * `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
-* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default 'true'.
+* `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default `true`.
 
 ### Zabbix Web specific
 

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -26,8 +26,8 @@ zabbix_agent2_deny_key: "{{ zabbix_agent_deny_key }}"
 # Selinux related vars
 selinux_allow_zabbix_run_sudo: false
 
-zabbix_agent_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
-zabbix_agent_include_deb_src: true
+zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+zabbix_repo_deb_include_deb_src: true
 
 zabbix_agent_install_agent_only: false
 zabbix_agent_packages:

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -27,6 +27,7 @@ zabbix_agent2_deny_key: "{{ zabbix_agent_deny_key }}"
 selinux_allow_zabbix_run_sudo: false
 
 zabbix_agent_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+zabbix_agent_include_deb_src: true
 
 zabbix_agent_install_agent_only: false
 zabbix_agent_packages:

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -26,6 +26,8 @@ zabbix_agent2_deny_key: "{{ zabbix_agent_deny_key }}"
 # Selinux related vars
 selinux_allow_zabbix_run_sudo: false
 
+zabbix_agent_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+
 zabbix_agent_install_agent_only: false
 zabbix_agent_packages:
   - "{{ zabbix_agent_package }}"

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -65,7 +65,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb
+      Types: deb{{ ' deb-src' if zabbix_agent_include_deb_src }}
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -65,7 +65,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb deb-src
+      Types: deb
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -47,7 +47,7 @@
 
 - name: "Debian | Download gpg key"
   ansible.builtin.get_url:
-    url: http://repo.zabbix.com/zabbix-official-repo.key
+    url: "{{ zabbix_agent_gpg_key_url }}"
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -67,7 +67,7 @@
 - name: "Debian | Download gpg key"
   when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
-    url: "{{ zabbix_agent_gpg_key_url }}"
+    url: "{{ zabbix_repo_deb_gpg_key_url }}"
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
@@ -85,7 +85,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb{{ ' deb-src' if zabbix_agent_include_deb_src }}
+      Types: deb{{ ' deb-src' if zabbix_repo_deb_include_deb_src }}
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_agent/vars/Debian.yml
+++ b/roles/zabbix_agent/vars/Debian.yml
@@ -44,5 +44,5 @@ zabbix_valid_agent_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.gpg"
 _zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}"

--- a/roles/zabbix_agent/vars/Debian.yml
+++ b/roles/zabbix_agent/vars/Debian.yml
@@ -44,5 +44,5 @@ zabbix_valid_agent_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.gpg"
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
 _zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}"

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -32,5 +32,5 @@ zabbix_javagateway_listenip: 0.0.0.0
 zabbix_javagateway_listenport: 10052
 zabbix_javagateway_startpollers: 5
 
-zabbix_javagateway_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
-zabbix_javagateway_include_deb_src: true
+zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+zabbix_repo_deb_include_deb_src: true

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -33,3 +33,4 @@ zabbix_javagateway_listenport: 10052
 zabbix_javagateway_startpollers: 5
 
 zabbix_javagateway_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+zabbix_javagateway_include_deb_src: true

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -31,3 +31,5 @@ zabbix_javagateway_pidfile: /run/zabbix/zabbix_java_gateway.pid
 zabbix_javagateway_listenip: 0.0.0.0
 zabbix_javagateway_listenport: 10052
 zabbix_javagateway_startpollers: 5
+
+zabbix_javagateway_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -48,7 +48,7 @@
 - name: "Debian | Download gpg key"
   when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
-    url: "{{ zabbix_javagateway_gpg_key_url }}"
+    url: "{{ zabbix_repo_deb_gpg_key_url }}"
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
@@ -66,7 +66,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb{{ ' deb-src' if zabbix_javagateway_include_deb_src }}
+      Types: deb{{ ' deb-src' if zabbix_repo_deb_include_deb_src }}
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -32,6 +32,9 @@
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
   become: true
   tags:
     - install

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -46,7 +46,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb deb-src
+      Types: deb
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -28,7 +28,7 @@
 
 - name: "Debian | Download gpg key"
   ansible.builtin.get_url:
-    url: http://repo.zabbix.com/zabbix-official-repo.key
+    url: "{{ zabbix_javagateway_gpg_key_url }}"
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -46,7 +46,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb
+      Types: deb{{ ' deb-src' if zabbix_javagateway_include_deb_src }}
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_javagateway/vars/Debian.yml
+++ b/roles/zabbix_javagateway/vars/Debian.yml
@@ -26,5 +26,5 @@ zabbix_valid_javagateway_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.gpg"
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
 _zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/{{ ansible_distribution.lower() }}"

--- a/roles/zabbix_javagateway/vars/Debian.yml
+++ b/roles/zabbix_javagateway/vars/Debian.yml
@@ -26,5 +26,5 @@ zabbix_valid_javagateway_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.gpg"
 _zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/{{ ansible_distribution.lower() }}"

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -38,7 +38,6 @@ zabbix_proxy_tls_config:
   cert: "certificate"
 zabbix_proxy_version_minor: "*"
 
-
 # Yum/APT Variables
 zabbix_repo_yum_schema: https
 zabbix_repo_yum_gpgcheck: 0

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -38,6 +38,8 @@ zabbix_proxy_tls_config:
   cert: "certificate"
 zabbix_proxy_version_minor: "*"
 
+zabbix_proxy_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+
 # Yum/APT Variables
 zabbix_repo_yum_schema: https
 zabbix_repo_yum_gpgcheck: 0

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -62,8 +62,8 @@ zabbix_repo_yum:
     state: present
 zabbix_proxy_apt_priority:
 zabbix_proxy_package_state: present
-zabbix_proxy_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
-zabbix_proxy_include_deb_src: true
+zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+zabbix_repo_deb_include_deb_src: true
 
 # Proxy Configuration Variables (Only ones with role provided defaults)
 zabbix_proxy_allowroot: 0

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -38,7 +38,6 @@ zabbix_proxy_tls_config:
   cert: "certificate"
 zabbix_proxy_version_minor: "*"
 
-zabbix_proxy_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
 
 # Yum/APT Variables
 zabbix_repo_yum_schema: https
@@ -63,6 +62,8 @@ zabbix_repo_yum:
     state: present
 zabbix_proxy_apt_priority:
 zabbix_proxy_package_state: present
+zabbix_proxy_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+zabbix_proxy_include_deb_src: true
 
 # Proxy Configuration Variables (Only ones with role provided defaults)
 zabbix_proxy_allowroot: 0

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -73,7 +73,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb deb-src
+      Types: deb
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -53,7 +53,7 @@
 
 - name: "Debian | Download gpg key"
   ansible.builtin.get_url:
-    url: http://repo.zabbix.com/zabbix-official-repo.key
+    url: "{{ zabbix_proxy_gpg_key_url }}"
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -57,6 +57,9 @@
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
   register: are_zabbix_proxy_dependency_packages_installed
   until: are_zabbix_proxy_dependency_packages_installed is succeeded
   become: true

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -73,7 +73,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb
+      Types: deb{{ ' deb-src' if zabbix_proxy_include_deb_src }}
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -73,7 +73,7 @@
 - name: "Debian | Download gpg key"
   when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
-    url: "{{ zabbix_proxy_gpg_key_url }}"
+    url: "{{ zabbix_repo_deb_gpg_key_url }}"
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
@@ -93,7 +93,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb{{ ' deb-src' if zabbix_proxy_include_deb_src }}
+      Types: deb{{ ' deb-src' if zabbix_repo_deb_include_deb_src }}
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_proxy/vars/Debian.yml
+++ b/roles/zabbix_proxy/vars/Debian.yml
@@ -51,7 +51,7 @@ mysql_plugin:
   "10": mysql_native_password
 
 debian_keyring_path: /etc/apt/keyrings/
-zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.gpg"
 _zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_distribution.lower() }}"
 _zabbix_proxy_fping6location: /usr/bin/fping6
 _zabbix_proxy_fpinglocation: /usr/bin/fping

--- a/roles/zabbix_proxy/vars/Debian.yml
+++ b/roles/zabbix_proxy/vars/Debian.yml
@@ -51,7 +51,7 @@ mysql_plugin:
   "10": mysql_native_password
 
 debian_keyring_path: /etc/apt/keyrings/
-zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.gpg"
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
 _zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_distribution.lower() }}"
 _zabbix_proxy_fping6location: /usr/bin/fping6
 _zabbix_proxy_fpinglocation: /usr/bin/fping

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -62,6 +62,7 @@ zabbix_server_apt_priority:
 zabbix_server_install_recommends: true
 zabbix_server_conf_mode: 0640
 zabbix_server_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+zabbix_server_include_deb_src: true
 
 # Server Configuration Variables (Only ones with role provided defaults)
 zabbix_server_alertscriptspath: /usr/lib/zabbix/alertscripts

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -61,8 +61,8 @@ zabbix_repo_yum:
 zabbix_server_apt_priority:
 zabbix_server_install_recommends: true
 zabbix_server_conf_mode: 0640
-zabbix_server_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
-zabbix_server_include_deb_src: true
+zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+zabbix_repo_deb_include_deb_src: true
 
 # Server Configuration Variables (Only ones with role provided defaults)
 zabbix_server_alertscriptspath: /usr/lib/zabbix/alertscripts

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -61,6 +61,7 @@ zabbix_repo_yum:
 zabbix_server_apt_priority:
 zabbix_server_install_recommends: true
 zabbix_server_conf_mode: 0640
+zabbix_server_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
 
 # Server Configuration Variables (Only ones with role provided defaults)
 zabbix_server_alertscriptspath: /usr/lib/zabbix/alertscripts

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -52,10 +52,13 @@
 
 - name: "Debian | Download gpg key"
   ansible.builtin.get_url:
-    url: http://repo.zabbix.com/zabbix-official-repo.key
+    url: "{{ zabbix_server_gpg_key_url }}"
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
   register: zabbix_server_repo_files_installed
   until: zabbix_server_repo_files_installed is succeeded
   become: true

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -72,7 +72,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb deb-src
+      Types: deb
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -72,7 +72,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb
+      Types: deb{{ ' deb-src' if zabbix_server_include_deb_src }}
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -72,7 +72,7 @@
 - name: "Debian | Download gpg key"
   when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
-    url: "{{ zabbix_server_gpg_key_url }}"
+    url: "{{ zabbix_repo_deb_gpg_key_url }}"
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
@@ -92,7 +92,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb{{ ' deb-src' if zabbix_server_include_deb_src }}
+      Types: deb{{ ' deb-src' if zabbix_repo_deb_include_deb_src }}
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_server/vars/Debian.yml
+++ b/roles/zabbix_server/vars/Debian.yml
@@ -29,7 +29,7 @@ zabbix_valid_server_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.gpg"
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
 _zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}"
 _zabbix_server_fping6location: /usr/bin/fping6
 _zabbix_server_fpinglocation: /usr/bin/fping

--- a/roles/zabbix_server/vars/Debian.yml
+++ b/roles/zabbix_server/vars/Debian.yml
@@ -29,7 +29,7 @@ zabbix_valid_server_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.gpg"
 _zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}"
 _zabbix_server_fping6location: /usr/bin/fping6
 _zabbix_server_fpinglocation: /usr/bin/fping

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -88,8 +88,8 @@ zabbix_server_history_types:
 
 zabbix_selinux: false
 
-zabbix_web_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
-zabbix_web_include_deb_src: true
+zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+zabbix_repo_deb_include_deb_src: true
 # selinux_allow_zabbix_can_network: false
 # zabbix_apache_can_connect_ldap: false
 

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -89,6 +89,7 @@ zabbix_server_history_types:
 zabbix_selinux: false
 
 zabbix_web_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
+zabbix_web_include_deb_src: true
 # selinux_allow_zabbix_can_network: false
 # zabbix_apache_can_connect_ldap: false
 

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -87,6 +87,8 @@ zabbix_server_history_types:
   - "dbl"
 
 zabbix_selinux: false
+
+zabbix_web_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
 # selinux_allow_zabbix_can_network: false
 # zabbix_apache_can_connect_ldap: false
 

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -88,7 +88,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb deb-src
+      Types: deb
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -74,6 +74,9 @@
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
+  environment:
+    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
   become: true
   tags:
     - install

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -88,7 +88,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb
+      Types: deb{{ ' deb-src' if zabbix_web_include_deb_src }}
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -90,7 +90,7 @@
 - name: "Debian | Download gpg key"
   when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
-    url: "{{ zabbix_web_gpg_key_url }}"
+    url: "{{ zabbix_repo_deb_gpg_key_url }}"
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
@@ -108,7 +108,7 @@
     group: root
     mode: 0644
     content: |
-      Types: deb{{ ' deb-src' if zabbix_web_include_deb_src }}
+      Types: deb{{ ' deb-src' if zabbix_repo_deb_include_deb_src }}
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -70,7 +70,7 @@
 
 - name: "Debian | Download gpg key"
   ansible.builtin.get_url:
-    url: http://repo.zabbix.com/zabbix-official-repo.key
+    url: "{{ zabbix_web_gpg_key_url }}"
     dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true

--- a/roles/zabbix_web/vars/Debian.yml
+++ b/roles/zabbix_web/vars/Debian.yml
@@ -47,5 +47,5 @@ zabbix_valid_web_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.gpg"
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
 _zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}"

--- a/roles/zabbix_web/vars/Debian.yml
+++ b/roles/zabbix_web/vars/Debian.yml
@@ -47,5 +47,5 @@ zabbix_valid_web_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-zabbix_gpg_key: "{{ debian_keyring_path }}/zabbix-official-repo.asc"
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.gpg"
 _zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The proposed change introduces a variable in the agent, javagateway, proxy, server, and web role, which replaces the hardcoded string in the "Debian | Download gpg key" task. The default value of the "zabbix_repo_deb_gpg_key_url" variable is the previously hardcoded string: http://repo.zabbix.com/zabbix-official-repo.key

Additionally, a second variable "zabbix_repo_deb_include_deb_src" with default value "true" was introduced to toggle adding deb-src in the "Debian | Installing repository {{ ansible_distribution }}" task. 

Rationale: We are deploying Zabbix via Ansible in an environment without Internet access. We are using our own package mirror, which is configurable via the "zabbix_repo_deb_url". Unfortunately, without the proposed changes, we are unable to change the download location of the gpg key from the official repo to our own mirror. The second change, making deb-src optional is another change that makes the role easier to use with a custom package mirror. In our testing, it turned out that the deb-src repo was not required. Overall, both changes should not change the current functionality given that only hardcoded parts were replaced by variables with default values.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles: zabbix_agent, zabbix_javagateway, zabbix_proxy, zabbix_server, and zabbix_web

##### ADDITIONAL INFORMATION
I was unsure if I set the variables at the right location (currently defaults/main.yml) of each role. One could also argue to put them in vars/Debian.yml of each role. In the current repo, the defaults already contained some os dependent vars, for example, the # Yum/APT  Variables section, therefore I added them there. I am always open to moving or renaming them. For now, I stuck with the naming scheme that prefixes the role name, but it could be confusing since, for example, "zabbix_repo_deb_url" does not stick to this naming scheme and is kind of related.
