### PR TITLE
Fixed IPMI authentication algorithm default setting

### DIFF
--- a/changelogs/fragments/1188-agent_ipmi_authtype_fix.yml
+++ b/changelogs/fragments/1188-agent_ipmi_authtype_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_agent - Fixed IPMI authentication algorithm default setting

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -337,7 +337,7 @@ Keep in mind that using the Zabbix Agent in a Container requires changes to the 
 
 ## IPMI variables
 
-* `zabbix_agent_ipmi_authtype`: IPMI authentication algorithm. Possible values are 1 (callback), 2 (user), 3 (operator), 4 (admin), 5 (OEM), with 2 being the API default.
+* `zabbix_agent_ipmi_authtype`: IPMI authentication algorithm. Possible values are -1 (default), 0 (none), 1 (MD2), 2 (MD5), 4 (straight), 5 (OEM), 6 (RMCP+), with -1 being the API default.
 * `zabbix_agent_ipmi_password`: IPMI password.
 * `zabbix_agent_ipmi_privilege`: IPMI privilege level. Possible values are 1 (callback), 2 (user), 3 (operator), 4 (admin), 5 (OEM), with 2 being the API default.
 * `zabbix_agent_ipmi_username`: IPMI username.

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -165,7 +165,7 @@ zabbix_agent_tls_config:
   cert: "4"
 
 # IPMI settings
-zabbix_agent_ipmi_authtype: 2
+zabbix_agent_ipmi_authtype: -1
 zabbix_agent_ipmi_password:
 zabbix_agent_ipmi_privilege: 2
 zabbix_agent_ipmi_username:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
roles/zabbix_agent

##### ADDITIONAL INFORMATION
zabbix_agent_ipmi_authtype description and default value are duplicating those of zabbix_agent_ipmi_privilege. This is obviously wrong. See [Host object API documentation](https://www.zabbix.com/documentation/current/en/manual/api/reference/host/object). You have it correct in [plugins/modules/zabbix_proxy_info.py](https://github.com/ansible-collections/community.zabbix/blob/main/plugins/modules/zabbix_proxy_info.py#L99). To reproduce the issue assign a zabbix_agent role to a host, don't set IPMI variables, and observe IPMI field in Zabbix to get set to MD5, not left as default.


It is hypothetically possible that someone might have relied on the wrong default setting and didn't set it explicitly in their inventory, so _technically_ it's a breaking change.