### PR TITLE
Explicit become=false to avoid issues with HTTAPI in certain scenarios

### DIFF
--- a/roles/zabbix_agent/tasks/api.yml
+++ b/roles/zabbix_agent/tasks/api.yml
@@ -1,5 +1,6 @@
 ---
 - name: "API | Create host groups"
+  become: false
   community.zabbix.zabbix_group:
     host_group: "{{ zabbix_host_groups }}"
     state: "{{ zabbix_agent_hostgroups_state }}"
@@ -12,6 +13,7 @@
     - api
 
 - name: "API | Create a new host or update an existing host's info"
+  become: false
   community.zabbix.zabbix_host:
     host_name: "{{ zabbix_agent_hostname }}"
     host_groups: "{{ zabbix_host_groups }}"
@@ -46,6 +48,7 @@
     - api
 
 - name: "API | Create a new host using agent2 or update an existing host's info"
+  become: false
   community.zabbix.zabbix_host:
     host_name: "{{ zabbix_agent2_hostname }}"
     host_groups: "{{ zabbix_host_groups }}"
@@ -80,6 +83,7 @@
     - api
 
 - name: "API | Updating host configuration with macros"
+  become: false
   community.zabbix.zabbix_hostmacro:
     host_name: "{{ (zabbix_agent2 | bool) | ternary(zabbix_agent2_hostname, zabbix_agent_hostname) }}"
     macro_name: "{{ item.macro_key }}"


### PR DESCRIPTION
Hello, I had been on version 1.* of the collection for some time and today I decided to upgrade to version 2.*

Everything has gone pretty well in the transition, but due to the change in the way the Zabbix API is interacted with with this version change, I have lost some time to understand and diagnose a bug that I assume may be affecting many people.

The problem is finally so simple that in addition to explaining it, I send it as PR.

##### SUMMARY

When using httpapi to interact with the Zabbix Server, already indicating a user-password, no type of `become` is necessary for things to work.

However, since in the tasks corresponding to the interaction with the API the `become: false` has not been explicitly indicated, as the role is today, it fails in every project where we do not connect to our Zabbix Server directly as the root user (this is because whatever `become_method` is defined in the project/inventory will interfere with calls originating via HTTPAPI)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent role

##### ADDITIONAL INFORMATION
For example, if for my Zabbix Server host I have these variables defined:
```yml
ansible_ssh_user: an_unprivileged_user
ansible_become_method: su
ansible_become_user: root
```
API tasks fail as follows:
```
TASK [community.zabbix.zabbix_agent : API | Create host groups] ***************************************************************************************************************
FAILED - RETRYING: [example.zabbix.com]: API | Create host groups (3 retries left).
FAILED - RETRYING: [example.zabbix.com]: API | Create host groups (2 retries left).
FAILED - RETRYING: [example.zabbix.com]: API | Create host groups (1 retries left).
fatal: [example.zabbix.com]: FAILED! => {"attempts": 3, "changed": false, "module_stderr": "Password: su: Authentication failure\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```
