### PR TITLE
molecule: bump netaddr dependency

### DIFF
--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -5,7 +5,7 @@ ansible-core==2.14.2
 docker==6.1.3
 molecule==4.0.4
 molecule-docker==2.1.0
-netaddr==0.8.0
+netaddr==1.2.1
 pytest==7.2.1
 pytest-testinfra==7.0.0
 ipaddr==2.2.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`ansible.utils` currently requires `netaddr` >= 1.0, so the previously pinned version does not work. Fixes #1200.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
CI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->