### PR TITLE
fix issue with userparameters failing when trying to deploy a script

### DIFF
--- a/changelogs/fragments/1205-fix-zabbix-agent-scripts.yml
+++ b/changelogs/fragments/1205-fix-zabbix-agent-scripts.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_agent - Fixed issue to where scripts can be deployed alongside userparameters

--- a/roles/zabbix_agent/tasks/userparameter.yml
+++ b/roles/zabbix_agent/tasks/userparameter.yml
@@ -7,6 +7,7 @@
       notify:
         - restart win zabbix agent
       with_items: "{{ zabbix_agent_userparameters }}"
+      when: item.scripts_dir is not defined
 
     - name: "Windows | Installing user-defined scripts"
       ansible.windows.win_copy:
@@ -33,6 +34,7 @@
         - restart mac zabbix agent
       become: true
       with_items: "{{ zabbix_agent_userparameters }}"
+      when: item.scripts_dir is not defined
 
     - name: "Installing user-defined scripts"
       ansible.builtin.copy:
@@ -66,6 +68,7 @@
         - restart mac zabbix agent
       become: true
       with_items: "{{ zabbix_agent_userparameters }}"
+      when: item.scripts_dir is not defined
 
     - name: "Installing user-defined scripts"
       ansible.builtin.copy:


### PR DESCRIPTION
##### SUMMARY
When deploying scripts, ansible was attempting to create userparameters, rather than deploying the script file.  This change adds an additional conditional where the userparameters task does not try use defined scripts.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.zabbix.roles.zabbix_agent, all userparameter tasks in tasks/userparameters.yml

##### ADDITIONAL INFORMATION
Currently, while the module states it supports deploying zabbix scripts, it does not work and fails the ansible run.
