### PR TITLE
fix ssl params semicolon in zabbix_web

### DIFF
--- a/changelogs/fragments/1206-fix-nginx-template-ssl-params.yml
+++ b/changelogs/fragments/1206-fix-nginx-template-ssl-params.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_web - Added missing semicolon to nginx vhost template.

--- a/roles/zabbix_web/templates/nginx_vhost.conf.j2
+++ b/roles/zabbix_web/templates/nginx_vhost.conf.j2
@@ -70,9 +70,9 @@ server {
 
     ssl_certificate {{ zabbix_web_tls_crt }};
     ssl_certificate_key {{ zabbix_web_tls_key }};
-    {{ (zabbix_web_ssl_cipher_suite is defined and zabbix_web_ssl_cipher_suite is not none) | ternary('', '# ') }}ssl_ciphers {{ zabbix_web_ssl_cipher_suite | default('') }}
-    {{ (zabbix_web_SSLSessionCache is defined and zabbix_web_SSLSessionCache is not none) | ternary('', '# ') }}ssl_session_cache  {{ zabbix_web_SSLSessionCache | default('') }}
-    {{ (zabbix_web_SSLSessionCacheTimeout is defined and zabbix_web_SSLSessionCacheTimeout is not none) | ternary('', '# ') }}ssl_session_timeout {{ zabbix_web_SSLSessionCacheTimeout | default('') }}
+    {{ (zabbix_web_ssl_cipher_suite is defined and zabbix_web_ssl_cipher_suite is not none) | ternary('', '# ') }}ssl_ciphers {{ zabbix_web_ssl_cipher_suite | default('') }};
+    {{ (zabbix_web_SSLSessionCache is defined and zabbix_web_SSLSessionCache is not none) | ternary('', '# ') }}ssl_session_cache  {{ zabbix_web_SSLSessionCache | default('') }};
+    {{ (zabbix_web_SSLSessionCacheTimeout is defined and zabbix_web_SSLSessionCacheTimeout is not none) | ternary('', '# ') }}ssl_session_timeout {{ zabbix_web_SSLSessionCacheTimeout | default('') }};
     root    /usr/share/zabbix;
 
     index   index.php;


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added missing semicolon to nginx vhost template.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.zabbix.roles.zabbix_web

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

resolved #1198 


