### PR TITLE
 define postgresql_privs due to priv deprecated in postgresql_user module | Zabbix Proxy

### DIFF
--- a/roles/zabbix_proxy/tasks/postgresql.yml
+++ b/roles/zabbix_proxy/tasks/postgresql.yml
@@ -72,7 +72,6 @@
         name: "{{ zabbix_proxy_dbuser }}"
         password: "{{ ('md5' + (zabbix_proxy_dbpassword + zabbix_proxy_dbuser)|hash('md5')) if zabbix_proxy_dbpassword_hash_method == 'md5' else zabbix_proxy_dbpassword }}"
         port: "{{ zabbix_proxy_dbport }}"
-        priv: ALL
         state: present
         encrypted: true
     - name: PostgreSQL | Remote | GRANT ALL PRIVILEGES ON SCHEMA public TO {{ zabbix_proxy_dbuser }}

--- a/roles/zabbix_proxy/tasks/postgresql.yml
+++ b/roles/zabbix_proxy/tasks/postgresql.yml
@@ -31,9 +31,18 @@
         name: "{{ zabbix_proxy_dbuser }}"
         password: "{{ ('md5' + (zabbix_proxy_dbpassword + zabbix_proxy_dbuser)|hash('md5')) if zabbix_proxy_dbpassword_hash_method == 'md5' else zabbix_proxy_dbpassword }}"
         port: "{{ zabbix_proxy_dbport }}"
-        priv: ALL
         state: present
         encrypted: true
+
+    - name: PostgreSQL | Delegated | GRANT ALL PRIVILEGES ON SCHEMA public TO {{ zabbix_proxy_dbuser }}
+      community.postgresql.postgresql_privs:
+        db: "{{ zabbix_proxy_dbname }}"
+        role: "{{ zabbix_proxy_dbuser }}"
+        privs: ALL
+        type: schema
+        objs: public
+        state: present
+        port: "{{ zabbix_proxy_dbport }}"
   become: true
   become_user: postgres
   delegate_to: "{{ delegated_dbhost }}"
@@ -66,6 +75,17 @@
         priv: ALL
         state: present
         encrypted: true
+    - name: PostgreSQL | Remote | GRANT ALL PRIVILEGES ON SCHEMA public TO {{ zabbix_proxy_dbuser }}
+      community.postgresql.postgresql_privs:
+        login_host: "{{ zabbix_proxy_pgsql_login_host | default(omit) }}"
+        login_user: "{{ zabbix_proxy_pgsql_login_user | default(omit) }}"
+        login_password: "{{ zabbix_proxy_pgsql_login_password | default(omit) }}"
+        db: "{{ zabbix_proxy_dbname }}"
+        role: "{{ zabbix_proxy_dbuser }}"
+        type: schema
+        objs: public
+        state: present
+        port: "{{ zabbix_proxy_dbport }}"
   when:
     - zabbix_proxy_database_creation
     - zabbix_proxy_pgsql_login_host is defined


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When installing Zabbix Proxy with PostgreSQL, due to the deprecation of the "priv" parameter in the "community.postgresql.postgresql_user" module, the required permissions for "zabbix_proxy" are not defined. As a result, the schema import to the database is not performed.
For this reason, the "priv" parameter has been removed, and a new task is defined using the "community.postgresql.postgresql_privs" module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
PostgreSQL | GRANT ALL PRIVILEGES ON SCHEMA public TO zabbix_proxy user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Tested on PostgreSQL 15.5 (Delegated)
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
