### PR TITLE
Update Debian.yml for Ubuntu arm64 compatibility

### DIFF
--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -29,7 +29,7 @@
 
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_os_family == 'Debian' else ''}}"
   when:
     - zabbix_repo_deb_url is undefined
   tags:

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -29,7 +29,7 @@
 
 - name: "Debian | Repo URL"
   ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_os_family == 'Debian' else ''}}"
+    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' else ''}}"
   when:
     - zabbix_repo_deb_url is undefined
   tags:


### PR DESCRIPTION
Use ansible_os_family to determine Ubuntu and Debian flavour.

##### SUMMARY
On ubuntu system (20.04 at least) `ansible_isb.id` value is **ubuntu** not **debian**. Therefore auto-detection for ubuntu `arm64` doesn't work. Considering that **Debian.yml** is included using `{{ansible_os_familiy}}.yml` we can assume that this additional `and` condition is already covered by that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Today if installed on Ubuntu arm64 (20.04 for example) installation of zabbix-agent2 fails as Zabbix default repository does not contain arm64 packages anymore.
  