### PR TITLE
Include SELinux tasks for zabbix_web and refactor selinux variable names

### DIFF
--- a/changelogs/fragments/1220-refactor_selinux_tasks_and_variable_names_role_zabbix_web.yml
+++ b/changelogs/fragments/1220-refactor_selinux_tasks_and_variable_names_role_zabbix_web.yml
@@ -1,0 +1,4 @@
+- bugfixes: 
+    - zabbix_web role, Add missing selinux.yml tasks.
+- minor_changes:
+    - zabbix_web role, Refactored zabbix_selinux variable names to correlate with selinux boolean names.

--- a/changelogs/fragments/1220-refactor_selinux_tasks_and_variable_names_role_zabbix_web.yml
+++ b/changelogs/fragments/1220-refactor_selinux_tasks_and_variable_names_role_zabbix_web.yml
@@ -1,4 +1,4 @@
-- bugfixes: 
-    - zabbix_web role, Add missing selinux.yml tasks.
-- minor_changes:
-    - zabbix_web role, Refactored zabbix_selinux variable names to correlate with selinux boolean names.
+bugfixes: 
+  - zabbix_web role, Add missing selinux.yml tasks.
+minor_changes:
+  - zabbix_web role, Refactored zabbix_selinux variable names to correlate with selinux boolean names.

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -16,6 +16,7 @@
       - [Apache configuration](#apache-configuration)
       - [Nginx configuration](#nginx-configuration)
       - [PHP-FPM](#php-fpm)
+    - [SElinux](#selinux)
     - [Zabbix Server](#zabbix-server)
   * [proxy](#proxy)
 - [Example Playbook](#example-playbook)
@@ -118,7 +119,6 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_vhost_port`: The port on which Zabbix HTTP vhost is running.
 * `zabbix_web_vhost_tls_port`: The port on which Zabbix HTTPS vhost is running.
 * `zabbix_web_vhost_listen_ip`: On which interface the Apache Virtual Host is available.
-* `zabbix_apache_can_connect_ldap`: Default: `false`. Set SELinux boolean to allow httpd to connect to LDAP.
 * `zabbix_web_max_execution_time`: PHP max execution time
 * `zabbix_web_memory_limit`: PHP memory limit
 * `zabbix_web_post_max_size`: PHP maximum post size
@@ -152,6 +152,13 @@ The following properties are specific to Zabbix 5.0 and for the PHP(-FPM) config
 * `zabbix_php_fpm_conf_user`: The owner of the socket file (When `zabbix_php_fpm_listen` contains a patch to a socket file).
 
 * `zabbix_php_fpm_conf_group`: The group of the owner of the socket file (When `zabbix_php_fpm_listen` contains a patch to a socket file).
+
+### SElinux
+
+* `zabbix_web_selinux`: Default: `False`. Enables an SELinux policy so that the web will run.
+* `selinux_allow_httpd_can_connect_zabbix`: Default: `false`. Set SELinux boolean to allow httpd to connect to zabbix.
+* `selinux_allow_httpd_can_connect_ldap`: Default: `false`. Set SELinux boolean to allow httpd to connect to LDAP.
+* `selinux_allow_httpd_can_network_connect_db`: Default: `false` Set SELinux boolean to allow httpd to connect databases over the network.
 
 ### Zabbix Server
 

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -86,12 +86,14 @@ zabbix_server_history_types:
   - "uint"
   - "dbl"
 
-zabbix_selinux: false
+# SELinux specific
+zabbix_web_selinux: false
+selinux_allow_httpd_can_connect_ldap: false
+selinux_allow_httpd_can_network_connect_db: false
+selinux_allow_httpd_can_connect_zabbix: false
 
 zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
 zabbix_repo_deb_include_deb_src: true
-# selinux_allow_zabbix_can_network: false
-# zabbix_apache_can_connect_ldap: false
 
 # SAML certificates
 # zabbix_saml_idp_crt:

--- a/roles/zabbix_web/tasks/RedHat.yml
+++ b/roles/zabbix_web/tasks/RedHat.yml
@@ -57,3 +57,8 @@
     - ansible_distribution_major_version == '9'
   tags:
     - install
+
+- name: "Configure SELinux when enabled"
+  ansible.builtin.include_tasks: selinux.yml
+  when:
+    - zabbix_web_selinux | bool

--- a/roles/zabbix_web/tasks/selinux.yml
+++ b/roles/zabbix_web/tasks/selinux.yml
@@ -12,7 +12,7 @@
   become: true
   when:
     - ansible_os_family == "RedHat"
-    - selinux_allow_zabbix_can_network
+    - ansible_selinux.status == "enabled"
     - ansible_distribution_major_version == "7" or ansible_distribution_major_version == "6"
   tags:
     - install
@@ -30,22 +30,10 @@
   become: true
   when:
     - ansible_os_family == "RedHat"
-    - selinux_allow_zabbix_can_network
+    - ansible_selinux.status == "enabled"
     - ansible_distribution_major_version|int >= 8
   tags:
     - install
-
-- name: "SELinux | RedHat | Enable zabbix_can_network SELinux boolean"
-  ansible.posix.seboolean:
-    name: zabbix_can_network
-    state: true
-    persistent: true
-  become: true
-  when:
-    - ansible_os_family == "RedHat"
-    - selinux_allow_zabbix_can_network
-  tags:
-    - config
 
 - name: "SELinux | Allow httpd to connect to db (SELinux)"
   ansible.posix.seboolean:
@@ -55,7 +43,7 @@
   become: true
   when:
     - ansible_selinux.status == "enabled"
-    - selinux_allow_zabbix_can_network
+    - selinux_allow_httpd_can_network_connect_db | bool
   tags:
     - config
 
@@ -67,7 +55,7 @@
   become: true
   when:
     - ansible_selinux.status == "enabled"
-    - selinux_allow_zabbix_can_network
+    - selinux_allow_httpd_can_connect_zabbix | bool
   tags:
     - config
 
@@ -79,6 +67,6 @@
   become: true
   when:
     - ansible_selinux.status == "enabled"
-    - zabbix_apache_can_connect_ldap | bool
+    - selinux_allow_httpd_can_connect_ldap | bool
   tags:
     - config


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Selinux tasks were not included by zabbix_web role,
seems that include had been dropped by accident (?) on pull request #979 (v2.0.0)

Restored `include_tasks: selinux.yml` to roles/zabbix_web/tasks/RedHat.yml

Refactor `zabbix_selinux` variable to `zabbix_web_selinux` as variable names should be prefixed with role name,
also to use similar pattern with `zabbix_proxy_selinux` and `zabbix_server_selinux` variables.

Refactor selinux related variable names in zabbix_web role to correlate with selinux boolean names.

Refactor `zabbix_apache_can_connect_ldap` to `selinux_allow_httpd_can_connect_ldap` 
as it's not apache specific and not correlating with actual selinux boolean name.

Don't set zabbix_can_network boolean in zabbix_web role as it's not relevant (AFAIK).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_web
