### PR TITLE
Enable skipping versions check

### DIFF
--- a/changelogs/fragments/1224-enable-version-check.yml
+++ b/changelogs/fragments/1224-enable-version-check.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Introduce flag `enable_version_check` to allow installations on non-supported platforms.

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -102,6 +102,7 @@ See the following list of supported Operating systems with the Zabbix releases:
 | Debian 11 bullseye  |  V  |  V  |  V  |
 | Debian 10 buster    |  V  |  V  |  V  |
 
+You can bypass this matrix by setting `enable_version_check: false`
 
 # Getting started
 

--- a/docs/ZABBIX_JAVAGATEWAY_ROLE.md
+++ b/docs/ZABBIX_JAVAGATEWAY_ROLE.md
@@ -46,6 +46,8 @@ See the following list of supported Operating systems with the Zabbix releases.
 | Debian 11 bullseye  |  V  |  V  |  V  |
 | Debian 10 buster    |  V  |  V  |  V  |
 
+You can bypass this matrix by setting `enable_version_check: false`
+
 # Role Variables
 
 ## Main variables

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -89,6 +89,8 @@ See the following list of supported Operating systems with the Zabbix releases.
 | Debian 11 bullseye  |  V  |  V  |  V  |
 | Debian 10 buster    |  V  |  V  |  V  |
 
+You can bypass this matrix by setting `enable_version_check: false`
+
 # Role Variables
 
 ## Main variables

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -86,6 +86,8 @@ See the following list of supported Operating systems with the Zabbix releases:
 | Debian 11 bullseye  |  V  |  V  |  V  |
 | Debian 10 buster    |     |     |  V  |
 
+You can bypass this matrix by setting `enable_version_check: false`
+
 # Installation
 
 Installing this role is very simple: `ansible-galaxy install community.zabbix.zabbix_server`

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -65,6 +65,8 @@ See the following list of supported Operating Systems with the Zabbix releases.
 | Debian 11 bullseye  |  V  |  V  |  V  |
 | Debian 10 buster    |     |     |  V  |
 
+You can bypass this matrix by setting `enable_version_check: false`
+
 # Installation
 
 Installing this role is very simple: `ansible-galaxy install community.zabbix.zabbix_web`

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -12,16 +12,12 @@
   tags:
     - always
 
-- name: Set More Variables
-  ansible.builtin.set_fact:
-    zabbix_valid_version: "{{ zabbix_agent_version|float in zabbix_valid_agent_versions[ansible_distribution_major_version] }}"
-  tags:
-    - always
-
-- name: Stopping Install of Invalid Version
-  ansible.builtin.fail:
-    msg: Zabbix version {{ zabbix_agent_version }} is not supported on {{ ansible_distribution }} {{ ansible_distribution_major_version }}
-  when: not zabbix_valid_version
+- name: Check that version is supported
+  when: enable_version_check | default(true) | bool
+  ansible.builtin.assert:
+    that:
+      - "{{ zabbix_agent_version|float in zabbix_valid_agent_versions[ansible_distribution_major_version] }}"
+    fail_msg: Zabbix version {{ zabbix_agent_version }} is not supported on {{ ansible_distribution }} {{ ansible_distribution_major_version }}
   tags:
     - always
 

--- a/roles/zabbix_javagateway/tasks/main.yml
+++ b/roles/zabbix_javagateway/tasks/main.yml
@@ -13,16 +13,12 @@
   tags:
     - always
 
-- name: Set More Variables
-  ansible.builtin.set_fact:
-    zabbix_valid_version: "{{ zabbix_javagateway_version|float in zabbix_valid_javagateway_versions[ansible_distribution_major_version] }}"
-  tags:
-    - always
-
-- name: Stopping Install of Invalid Version
-  ansible.builtin.fail:
-    msg: Zabbix version {{ zabbix_javagateway_version }} is not supported on {{ ansible_distribution }} {{ ansible_distribution_major_version }}
-  when: not zabbix_valid_version
+- name: Check that version is supported
+  when: enable_version_check | default(true) | bool
+  ansible.builtin.assert:
+    that:
+      - "{{ zabbix_javagateway_version|float in zabbix_valid_javagateway_versions[ansible_distribution_major_version] }}"
+    fail_msg: Zabbix version {{ zabbix_javagateway_version }} is not supported on {{ ansible_distribution }} {{ ansible_distribution_major_version }}
   tags:
     - always
 

--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -15,17 +15,18 @@
 - name: Set More Variables
   ansible.builtin.set_fact:
     zabbix_proxy_db_long: "{{ 'postgresql' if zabbix_proxy_database == 'pgsql' else zabbix_proxy_database }}"
-    zabbix_valid_version: "{{ zabbix_proxy_version|float in zabbix_valid_proxy_versions[ansible_distribution_major_version] }}"
     zabbix_short_version: "{{ zabbix_proxy_version | regex_replace('\\.', '') }}"
     zabbix_proxy_fpinglocation: "{{ zabbix_proxy_fpinglocation if zabbix_proxy_fpinglocation is defined else _zabbix_proxy_fpinglocation}}"
     zabbix_proxy_fping6location: "{{ zabbix_proxy_fping6location if zabbix_proxy_fping6location is defined else _zabbix_proxy_fping6location}}"
   tags:
     - always
 
-- name: Stopping Install of Invalid Version
-  ansible.builtin.fail:
-    msg: Zabbix version {{ zabbix_proxy_version }} is not supported on {{ ansible_distribution }} {{ ansible_distribution_major_version }}
-  when: not zabbix_valid_version
+- name: Check that version is supported
+  when: enable_version_check | default(true) | bool
+  ansible.builtin.assert:
+    that:
+      - "{{ zabbix_proxy_version|float in zabbix_valid_proxy_versions[ ansible_facts['distribution_major_version'] ] }}"
+    fail_msg: Zabbix version {{ zabbix_proxy_version }} is not supported on {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_major_version'] }}
   tags:
     - always
 

--- a/roles/zabbix_server/tasks/main.yml
+++ b/roles/zabbix_server/tasks/main.yml
@@ -14,16 +14,17 @@
 - name: Set More Variables
   ansible.builtin.set_fact:
     zabbix_db_type_long: "{{ 'postgresql' if zabbix_server_database == 'pgsql' else 'mysql' }}"
-    zabbix_valid_version: "{{ zabbix_server_version|float in zabbix_valid_server_versions[ansible_distribution_major_version] }}"
     zabbix_server_fpinglocation: "{{ zabbix_server_fpinglocation if zabbix_server_fpinglocation is defined else _zabbix_server_fpinglocation}}"
     zabbix_server_fping6location: "{{ zabbix_server_fping6location if zabbix_server_fping6location is defined else _zabbix_server_fping6location}}"
   tags:
     - always
 
-- name: Stopping Install of Invalid Version
-  ansible.builtin.fail:
-    msg: Zabbix version {{ zabbix_server_version }} is not supported on {{ ansible_distribution }} {{ ansible_distribution_major_version }}
-  when: not zabbix_valid_version
+- name: Check that version is supported
+  when: enable_version_check | default(true) | bool
+  ansible.builtin.assert:
+    that:
+      - "{{ zabbix_server_version|float in zabbix_valid_server_versions[ ansible_facts['distribution_major_version'] ] }}"
+    fail_msg: Zabbix version {{ zabbix_server_version }} is not supported on {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_major_version'] }}
   tags:
     - always
 

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -13,15 +13,16 @@
 
 - name: Set More Variables
   ansible.builtin.set_fact:
-    zabbix_valid_version: "{{ zabbix_web_version|float in zabbix_valid_web_versions[ansible_distribution_major_version] }}"
     zabbix_db_type_long: "{{ 'postgresql' if zabbix_server_database == 'pgsql' else 'mysql' }}"
   tags:
     - always
 
-- name: Stopping Install of Invalid Version
-  ansible.builtin.fail:
-    msg: Zabbix version {{ zabbix_web_version }} is not supported on {{ ansible_distribution }} {{ ansible_distribution_major_version }}
-  when: not zabbix_valid_version
+- name: Check that version is supported
+  when: enable_version_check | default(true) | bool
+  ansible.builtin.assert:
+    that:
+      - "{{ zabbix_web_version|float in zabbix_valid_web_versions[ ansible_facts['distribution_major_version'] ] }}"
+    fail_msg: Zabbix version {{ zabbix_web_version }} is not supported on {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_major_version'] }}
   tags:
     - always
 


### PR DESCRIPTION
These tables are incomplete, and a hinderance for deployments to valid combinations. Allow the user to bypass this by supplying

  `-e enable_version_check=false`

##### SUMMARY
This should allow for deployments not in the support matrix.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
All the roles
