### PR TITLE
Put zabbix_repo_deb_url in defaults

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -69,6 +69,7 @@ zabbix_repo_yum:
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
 
+zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
 zabbix_repo_deb_component: main
 
 # Zabbix API stuff

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -8,33 +8,6 @@
   tags:
     - always
 
-- name: "Debian | Installing lsb-release"
-  ansible.builtin.apt:
-    pkg: lsb-release
-    update_cache: true
-    cache_valid_time: 3600
-    force: true
-    state: present
-  environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
-  become: true
-  tags:
-    - install
-
-- name: "Debian | Update ansible_lsb fact"
-  ansible.builtin.setup:
-    gather_subset:
-      - lsb
-
-- name: "Debian | Repo URL"
-  ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"
-  when:
-    - zabbix_repo_deb_url is undefined
-  tags:
-    - always
-
 - name: "Debian | Installing gnupg"
   ansible.builtin.apt:
     pkg: gnupg

--- a/roles/zabbix_agent/vars/Debian.yml
+++ b/roles/zabbix_agent/vars/Debian.yml
@@ -45,4 +45,3 @@ zabbix_valid_agent_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
-_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}"

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -25,6 +25,7 @@ zabbix_repo_yum:
     gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX
     state: present
 
+zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
 zabbix_repo_deb_component: main
 
 zabbix_javagateway_pidfile: /run/zabbix/zabbix_java_gateway.pid

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -5,33 +5,6 @@
   tags:
     - always
 
-- name: "Debian | Installing lsb-release"
-  ansible.builtin.apt:
-    pkg: lsb-release
-    update_cache: true
-    cache_valid_time: 3600
-    force: true
-    state: present
-  environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
-  become: true
-  tags:
-    - install
-
-- name: "Debian | Update ansible_lsb fact"
-  ansible.builtin.setup:
-    gather_subset:
-      - lsb
-
-- name: "Debian | Repo URL"
-  ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"
-  when:
-    - zabbix_repo_deb_url is undefined
-  tags:
-    - always
-
 # In releases older than Debian 12 and Ubuntu 22.04, /etc/apt/keyrings does not exist by default.
 # It SHOULD be created with permissions 0755 if it is needed and does not already exist.
 # See: https://wiki.debian.org/DebianRepository/UseThirdParty

--- a/roles/zabbix_javagateway/vars/Debian.yml
+++ b/roles/zabbix_javagateway/vars/Debian.yml
@@ -27,4 +27,3 @@ zabbix_valid_javagateway_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
-_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_javagateway_version }}"

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -41,6 +41,7 @@ zabbix_proxy_version_minor: "*"
 # Yum/APT Variables
 zabbix_repo_yum_schema: https
 zabbix_repo_yum_gpgcheck: 0
+zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
 zabbix_repo_deb_component: main
 zabbix_proxy_disable_repo:
   - epel

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -7,33 +7,6 @@
   tags:
     - always
 
-- name: "Debian | Installing lsb-release"
-  ansible.builtin.apt:
-    pkg: lsb-release
-    update_cache: true
-    cache_valid_time: 3600
-    force: true
-    state: present
-  environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
-  become: true
-  tags:
-    - install
-
-- name: "Debian | Update ansible_lsb fact"
-  ansible.builtin.setup:
-    gather_subset:
-      - lsb
-
-- name: "Debian | Repo URL"
-  ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"
-  when:
-    - zabbix_repo_deb_url is undefined
-  tags:
-    - always
-
 - name: "Debian | Set some facts for Zabbix"
   ansible.builtin.set_fact:
     datafiles_path: /usr/share/doc/zabbix-sql-scripts/{{ zabbix_proxy_db_long }}

--- a/roles/zabbix_proxy/vars/Debian.yml
+++ b/roles/zabbix_proxy/vars/Debian.yml
@@ -52,6 +52,5 @@ mysql_plugin:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
-_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}"
 _zabbix_proxy_fping6location: /usr/bin/fping6
 _zabbix_proxy_fpinglocation: /usr/bin/fping

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -40,6 +40,7 @@ zabbix_server_version_minor: "*"
 zabbix_server_package_state: present
 zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https
+zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
 zabbix_repo_deb_component: main
 zabbix_server_disable_repo:
   - epel

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -7,33 +7,6 @@
   tags:
     - always
 
-- name: "Debian | Installing lsb-release"
-  ansible.builtin.apt:
-    pkg: lsb-release
-    update_cache: true
-    cache_valid_time: 3600
-    force: true
-    state: present
-  environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
-  become: true
-  tags:
-    - install
-
-- name: "Debian | Update ansible_lsb fact"
-  ansible.builtin.setup:
-    gather_subset:
-      - lsb
-
-- name: "Debian | Repo URL"
-  ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"
-  when:
-    - zabbix_repo_deb_url is undefined
-  tags:
-    - always
-
 - name: "Debian | Set some facts for Zabbix"
   ansible.builtin.set_fact:
     datafiles_path: /usr/share/zabbix-sql-scripts/{{ 'postgresql' if zabbix_server_database == 'pgsql' else 'mysql' }}

--- a/roles/zabbix_server/vars/Debian.yml
+++ b/roles/zabbix_server/vars/Debian.yml
@@ -30,6 +30,5 @@ zabbix_valid_server_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
-_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}"
 _zabbix_server_fping6location: /usr/bin/fping6
 _zabbix_server_fpinglocation: /usr/bin/fping

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -53,6 +53,7 @@ zabbix_web_apt_priority:
 zabbix_web_version_minor: "*"
 zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https
+zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
 zabbix_repo_deb_component: main
 zabbix_web_disable_repo:
   - epel

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -13,33 +13,6 @@
   tags:
     - always
 
-- name: "Debian | Update ansible_lsb fact"
-  ansible.builtin.setup:
-    gather_subset:
-      - lsb
-
-- name: "Debian | Installing lsb-release"
-  ansible.builtin.apt:
-    pkg: lsb-release
-    update_cache: true
-    cache_valid_time: 3600
-    force: true
-    state: present
-  environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
-  become: true
-  tags:
-    - install
-
-- name: "Debian | Repo URL"
-  ansible.builtin.set_fact:
-    zabbix_repo_deb_url: "{{ _zabbix_repo_deb_url }}/{{ ansible_lsb.id.lower() }}{{ '-arm64' if ansible_machine == 'aarch64' and ansible_lsb.id == 'debian' else ''}}"
-  when:
-    - zabbix_repo_deb_url is undefined
-  tags:
-    - always
-
 - name: "Debian | Install PHP Dependencies"
   ansible.builtin.apt:
     pkg: "{{ zabbix_web_php_dependencies }}"

--- a/roles/zabbix_web/vars/Debian.yml
+++ b/roles/zabbix_web/vars/Debian.yml
@@ -48,4 +48,3 @@ zabbix_valid_web_versions:
 
 debian_keyring_path: /etc/apt/keyrings/
 zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
-_zabbix_repo_deb_url: "http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}"


### PR DESCRIPTION
##### SUMMARY

Instead of having a partial url in vars/Debian.yml, and appending to it with additional info via set_fact, if zabbix_repo_deb_url is not defined. Just supply it as a default, which could be overriden by user.

Zabbix also supplies an ubuntu-arm64 repo, so now we check for that aswell.

Notes on Raspbian
There are very few ways do differentiate Raspbian from Debian with ansible_facts. The only candidate seems to be ansible_facts.lsb.id.

The lsb section does not get filled in unless some packages are installed. But luckily those packages come installed on Raspbian systems. And we just default it back to ansible_facts.distribution if lsb.id is not present. So we're gonna simplify and drop some tasks.

Tested with ansible-core 2.13.13 on;

  2024-03-12-raspios-bullseye-armhf-lite
  2024-03-15-raspios-bookworm-armhf-lite

If this for some unforseen reason wouldn't work on older or newer versions of raspbian, there's always the option of just overriding the zabbix_repo_deb_url.

##### ISSUE TYPE
- Refactor pull request
- Feature Pull Request

##### COMPONENT NAME
All the roles.

##### ADDITIONAL INFORMATION
Discussed at great length in https://github.com/ansible-collections/community.zabbix/pull/1196#discussion_r1594417835

Addresses the concerns of #1219