### PR TITLE
allow nginx/apache group to write to FPM socket

### DIFF
--- a/changelogs/fragments/1227-fpm-socket-permissions.yml
+++ b/changelogs/fragments/1227-fpm-socket-permissions.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - zabbix_web - make the FPM socket group-writable so the web server can properly forward requests to the FPM process (https://github.com/ansible-collections/community.zabbix/pull/1227)
+  - zabbix_web - make the FPM socket group-writable so the web server can properly forward requests to the FPM process

--- a/changelogs/fragments/1227-fpm-socket-permissions.yml
+++ b/changelogs/fragments/1227-fpm-socket-permissions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_web - make the FPM socket group-writable so the web server can properly forward requests to the FPM process (https://github.com/ansible-collections/community.zabbix/pull/1227)

--- a/roles/zabbix_web/templates/php-fpm.conf.j2
+++ b/roles/zabbix_web/templates/php-fpm.conf.j2
@@ -8,7 +8,7 @@ listen.acl_users = {{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is de
 {% endif %}
 listen.owner = {{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is defined else zabbix_web_user }}
 listen.group = {{ _nginx_group if zabbix_web_http_server=='nginx' else _apache_group }}
-listen.mode = 0644
+listen.mode = 0660
 listen.allowed_clients = 127.0.0.1
 
 pm = dynamic


### PR DESCRIPTION
##### SUMMARY
In the current configuration, the web server is not allowed to write to the FPM socket, causing a "bad gateway" error, as the web server cannot forward requests over the socket.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix-web

##### ADDITIONAL INFORMATION
Before this change, the FPM socket has these permissions:
```
srw-r--r-- 1 zabbix-fpm www-data 0 May 13 13:13 /run/php/zabbix.sock
```
The web server, which runs as user/group `www-data` needs write access to this socket in order to forward requests.

With this PR applied, the socket permissions become:
```
srw-rw---- 1 zabbix-fpm www-data 0 May 13 13:15 /run/php/zabbix.sock
```

