### PR TITLE
Quality of life improvements for zabbix server role

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -37,8 +37,6 @@ jobs:
           - v64
           - v62
           - v60
-        include:
-          - interpreter: python3
         exclude:
           - container: debian12
             version: v62
@@ -86,6 +84,5 @@ jobs:
           MY_MOLECULE_IMAGE=${{ matrix.container }}
           MY_MOLECULE_VERSION=${{ matrix.version }}
           MY_MOLECULE_DATABASE=${{ matrix.database }}
-          MY_MOLECULE_INTERPRETER=${{ matrix.interpreter }}
           MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
           molecule test -s ${{ matrix.collection_role }}

--- a/molecule/zabbix_server/molecule.yml
+++ b/molecule/zabbix_server/molecule.yml
@@ -39,7 +39,6 @@ provisioner:
         zabbix_server_dbname: zabbix
         zabbix_server_dbuser: zabbix-dbuser
         zabbix_server_database: mysql
-        zabbix_server_dbport: 3306
         zabbix_server_dbhost: "{{ inventory_hostname }}-db"
         zabbix_server_dbhost_run_install: false
         zabbix_server_privileged_host: "%"
@@ -49,7 +48,6 @@ provisioner:
         zabbix_server_mysql_login_port: 3306
       pgsql:
         zabbix_server_database: pgsql
-        zabbix_server_dbport: 5432
         zabbix_server_dbhost: "{{ inventory_hostname }}-db"
         zabbix_server_dbhost_run_install: false
         zabbix_server_pgsql_login_host: "{{ inventory_hostname }}-db"

--- a/molecule/zabbix_server/molecule.yml
+++ b/molecule/zabbix_server/molecule.yml
@@ -14,7 +14,6 @@ platforms:
     groups:
       - ${MY_MOLECULE_DATABASE:-mysql}
       - ${MY_MOLECULE_VERSION:-v64}
-      - ${MY_MOLECULE_INTERPRETER:-python3}
 
 provisioner:
   name: ansible
@@ -23,18 +22,14 @@ provisioner:
     ANSIBLE_ROLES_PATH: $HOME/.ansible/collections/ansible_collections/community/zabbix/roles
   inventory:
     group_vars:
-      python3:
+      all:
         ansible_python_interpreter: /usr/bin/python3
-      python:
-        ansible_python_interpreter: /usr/bin/python
       v64:
         zabbix_server_version: 6.4
       v62:
         zabbix_server_version: 6.2
       v60:
         zabbix_server_version: 6.0
-      v50:
-        zabbix_server_version: 5.0
       mysql:
         zabbix_server_dbname: zabbix
         zabbix_server_dbuser: zabbix-dbuser

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -19,7 +19,10 @@ zabbix_server_dbuser: zabbix-server
 zabbix_server_dbpassword: zabbix-server
 zabbix_server_dbpassword_hash_method: md5
 #zabbix_server_dbsocket:
-zabbix_server_dbport: 5432
+_zabbix_server_database_default_port:
+  mysql: 3306
+  pgsql: 5432
+zabbix_server_dbport: "{{ _zabbix_server_database_default_port[zabbix_server_database] }}"
 zabbix_server_dbhost_run_install: true
 zabbix_server_database: pgsql
 zabbix_server_database_creation: true

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -8,17 +8,17 @@ zabbix_server_manage_service: true
 # Database
 zabbix_server_database_sqlload: true
 zabbix_server_database_timescaledb: false
-zabbix_server_real_dbhost:
+#zabbix_server_real_dbhost:
 zabbix_server_dbhost: localhost
 zabbix_server_dbname: zabbix-server
 zabbix_server_privileged_host: localhost
 zabbix_server_dbencoding: utf8
 zabbix_server_dbcollation: utf8_bin
-zabbix_server_dbschema:
+#zabbix_server_dbschema:
 zabbix_server_dbuser: zabbix-server
 zabbix_server_dbpassword: zabbix-server
 zabbix_server_dbpassword_hash_method: md5
-zabbix_server_dbsocket:
+#zabbix_server_dbsocket:
 zabbix_server_dbport: 5432
 zabbix_server_dbhost_run_install: true
 zabbix_server_database: pgsql

--- a/roles/zabbix_server/tasks/initialize-mysql.yml
+++ b/roles/zabbix_server/tasks/initialize-mysql.yml
@@ -27,6 +27,7 @@
 
 - name: "MySQL Database prep"
   when: zabbix_server_database_creation
+  become: "{{ zabbix_server_dbhost_run_install }}"
   delegate_to: "{{ zabbix_server_real_dbhost | default(zabbix_server_dbhost_run_install | ternary(delegated_dbhost, inventory_hostname)) }}"
   vars:
     delegated_dbhost: "{{ (zabbix_server_dbhost == 'localhost') | ternary(inventory_hostname, zabbix_server_dbhost) }}"

--- a/roles/zabbix_server/tasks/initialize-pgsql.yml
+++ b/roles/zabbix_server/tasks/initialize-pgsql.yml
@@ -32,7 +32,6 @@
         port: "{{ zabbix_server_dbport }}"
         login_unix_socket: "{{ zabbix_server_pgsql_login_unix_socket | default(omit) }}"
         name: "{{ zabbix_server_dbname }}"
-        state: present
 
     - name: "PostgreSQL | Create database user"
       community.postgresql.postgresql_user:
@@ -43,10 +42,19 @@
         login_unix_socket: "{{ zabbix_server_pgsql_login_unix_socket | default(omit) }}"
         name: "{{ zabbix_server_dbuser }}"
         password: "{{ ('md5' + (zabbix_server_dbpassword + zabbix_server_dbuser)|hash('md5')) if zabbix_server_dbpassword_hash_method == 'md5' else zabbix_server_dbpassword }}"
+
+    - name: "PostgreSQL | Set database/user permissions"
+      community.postgresql.postgresql_privs:
+        login_user: "{{ zabbix_server_pgsql_login_user | default(omit) }}"
+        login_password: "{{ zabbix_server_pgsql_login_password | default(omit) }}"
+        login_host: "{{ zabbix_server_pgsql_login_host | default(omit) }}"
+        port: "{{ zabbix_server_dbport }}"
+        login_unix_socket: "{{ zabbix_server_pgsql_login_unix_socket | default(omit) }}"
         db: "{{ zabbix_server_dbname }}"
-        priv: ALL
-        state: present
-        encrypted: true
+        privs: ALL
+        type: schema
+        objs: public
+        role: "{{ zabbix_server_dbuser }}"
 
     - name: "PostgreSQL | Create timescaledb extension"
       when: zabbix_server_database_timescaledb


### PR DESCRIPTION
##### SUMMARY
Quality of life improvements for zabbix server role

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_server role

##### ADDITIONAL INFORMATION
I created a Vagrantfile to just test the most basic, common way I can see this role deployed for mysql and pgsql variants, and these are the remaining fixes I needed to deploy the role.

The most common setup being OS with either postgresql or mysql/mariadb installed, and installing zabbix_server to it with the default localhost connection to the database.