### PR TITLE
Added Apache into Web Testing

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -35,6 +35,7 @@ jobs:
           - pgsql
         web_server:
           - nginx
+          - apache
         version:
           - v64
           - v62


### PR DESCRIPTION
As was pointed out in an earlier PR, somehow Apache fell off the test matrix for the web role.