### PR TITLE
Simplify repo key handling

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -120,7 +120,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_agent_disable_repo`: A list of repos to disable during install.  Default `epel`.
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
-* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key` (or `https://repo.zabbix.com/zabbix-official-repo-apr2024.gpg` for Ubuntu 24.04 repo).
+* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key.
 * `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default `true`.
 
 ### SElinux

--- a/docs/ZABBIX_JAVAGATEWAY_ROLE.md
+++ b/docs/ZABBIX_JAVAGATEWAY_ROLE.md
@@ -65,7 +65,7 @@ The `zabbix_javagateway_version` is optional. The latest available major.minor v
 * `zabbix_javagateway_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_agent_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
-* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key` (or `https://repo.zabbix.com/zabbix-official-repo-apr2024.gpg` for Ubuntu 24.04 repo).
+* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
 * `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default `true`.
 
 ### Java Gatewaty

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -136,7 +136,7 @@ The following is an overview of all available configuration default for this rol
 * `*zabbix_proxy_package_state`: Default: `present`. Can be overridden to `latest` to update packages
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_proxy_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
-* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key` (or `https://repo.zabbix.com/zabbix-official-repo-apr2024.gpg` for Ubuntu 24.04 repo).
+* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
 * `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default `true`.
 
 ### SElinux

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -112,7 +112,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_service_enabled`: Default: `True` Can be overridden to `False` if needed
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_server_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
-* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key` (or `https://repo.zabbix.com/zabbix-official-repo-apr2024.gpg` for Ubuntu 24.04 repo).
+* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
 * `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default `true`.
 
 ### SElinux

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -98,7 +98,7 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_web_conf_mode`: Default: `0644`. The "mode" for the Zabbix configuration file.
 * `zabbix_repo_deb_url`: The URL to the Zabbix repository.  Default `http://repo.zabbix.com/zabbix/{{ zabbix_web_version }}/{{ ansible_distribution.lower() }}`
 * `zabbix_repo_deb_component`: The repository component for Debian installs. Default `main`.
-* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key` (or `https://repo.zabbix.com/zabbix-official-repo-apr2024.gpg` for Ubuntu 24.04 repo).
+* `zabbix_repo_deb_gpg_key_url`: The URL to download the Zabbix GPG key from. Default `http://repo.zabbix.com/zabbix-official-repo.key`.
 * `zabbix_repo_deb_include_deb_src`: True, if deb-src should be included in the zabbix.sources entry. Default `true`.
 
 ### Zabbix Web specific

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -18,6 +18,7 @@ zabbix_agent_tlspskidentity_file: "/etc/zabbix/tls_psk_auto.identity"
 # Selinux related vars
 selinux_allow_zabbix_run_sudo: false
 
+zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
 zabbix_repo_deb_include_deb_src: true
 
 zabbix_agent_install_agent_only: false

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -40,8 +40,8 @@
 - name: "Debian | Download gpg key"
   when: not ansible_check_mode # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
-    url: "{{ zabbix_repo_deb_gpg_key_url | default(_zabbix_repo_default_deb_gpg_key_url_by_distrib[ansible_distribution_major_version]) }}"
-    dest: "{{ zabbix_gpg_key | default(_zabbix_gpg_key_default_by_distrib[ansible_distribution_major_version]) }}"
+    url: "{{ zabbix_repo_deb_gpg_key_url }}"
+    dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
   environment:
@@ -64,7 +64,7 @@
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
       Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
-      Signed-By: {{ zabbix_gpg_key | default(_zabbix_gpg_key_default_by_distrib[ansible_distribution_major_version]) }}
+      Signed-By: {{ zabbix_gpg_key }}
   become: true
   tags:
     - install

--- a/roles/zabbix_agent/vars/Debian.yml
+++ b/roles/zabbix_agent/vars/Debian.yml
@@ -45,21 +45,4 @@ zabbix_valid_agent_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-_zabbix_gpg_key_default_by_distrib:
-  "12": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "11": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "10": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "9": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "24": "{{ debian_keyring_path }}zabbix-repo.gpg"
-  "22": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "20": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "18": "{{ debian_keyring_path }}zabbix-repo.asc"
-_zabbix_repo_default_deb_gpg_key_url_by_distrib:
-  "12": https://repo.zabbix.com/zabbix-official-repo.key
-  "11": https://repo.zabbix.com/zabbix-official-repo.key
-  "10": https://repo.zabbix.com/zabbix-official-repo.key
-  "9": https://repo.zabbix.com/zabbix-official-repo.key
-  "24": https://repo.zabbix.com/zabbix-official-repo-apr2024.gpg
-  "22": https://repo.zabbix.com/zabbix-official-repo.key
-  "20": https://repo.zabbix.com/zabbix-official-repo.key
-  "18": https://repo.zabbix.com/zabbix-official-repo.key
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"

--- a/roles/zabbix_javagateway/defaults/main.yml
+++ b/roles/zabbix_javagateway/defaults/main.yml
@@ -33,4 +33,5 @@ zabbix_javagateway_listenip: 0.0.0.0
 zabbix_javagateway_listenport: 10052
 zabbix_javagateway_startpollers: 5
 
+zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
 zabbix_repo_deb_include_deb_src: true

--- a/roles/zabbix_javagateway/tasks/Debian.yml
+++ b/roles/zabbix_javagateway/tasks/Debian.yml
@@ -21,8 +21,8 @@
 - name: "Debian | Download gpg key"
   when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
-    url: "{{ zabbix_repo_deb_gpg_key_url | default(_zabbix_repo_default_deb_gpg_key_url_by_distrib[ansible_distribution_major_version]) }}"
-    dest: "{{ zabbix_gpg_key | default(_zabbix_gpg_key_default_by_distrib[ansible_distribution_major_version]) }}"
+    url: "{{ zabbix_repo_deb_gpg_key_url }}"
+    dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
   environment:
@@ -45,7 +45,7 @@
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
       Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
-      Signed-By: {{ zabbix_gpg_key | default(_zabbix_gpg_key_default_by_distrib[ansible_distribution_major_version]) }}
+      Signed-By: {{ zabbix_gpg_key }}
   register: zabbix_repo
   become: true
   tags:

--- a/roles/zabbix_javagateway/vars/Debian.yml
+++ b/roles/zabbix_javagateway/vars/Debian.yml
@@ -29,19 +29,4 @@ zabbix_valid_javagateway_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-_zabbix_gpg_key_default_by_distrib:
-  "12": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "11": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "10": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "24": "{{ debian_keyring_path }}zabbix-repo.gpg"
-  "22": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "20": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "18": "{{ debian_keyring_path }}zabbix-repo.asc"
-_zabbix_repo_default_deb_gpg_key_url_by_distrib:
-  "12": https://repo.zabbix.com/zabbix-official-repo.key
-  "11": https://repo.zabbix.com/zabbix-official-repo.key
-  "10": https://repo.zabbix.com/zabbix-official-repo.key
-  "24": https://repo.zabbix.com/zabbix-official-repo-apr2024.gpg
-  "22": https://repo.zabbix.com/zabbix-official-repo.key
-  "20": https://repo.zabbix.com/zabbix-official-repo.key
-  "18": https://repo.zabbix.com/zabbix-official-repo.key
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -60,6 +60,7 @@ zabbix_repo_yum:
     state: present
 zabbix_proxy_apt_priority:
 zabbix_proxy_package_state: present
+zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
 zabbix_repo_deb_include_deb_src: true
 
 # Proxy Configuration Variables (Only ones with role provided defaults)

--- a/roles/zabbix_proxy/tasks/Debian.yml
+++ b/roles/zabbix_proxy/tasks/Debian.yml
@@ -45,8 +45,8 @@
 - name: "Debian | Download gpg key"
   when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
-    url: "{{ zabbix_repo_deb_gpg_key_url | default(_zabbix_repo_default_deb_gpg_key_url_by_distrib[ansible_distribution_major_version]) }}"
-    dest: "{{ zabbix_gpg_key | default(_zabbix_gpg_key_default_by_distrib[ansible_distribution_major_version]) }}"
+    url: "{{ zabbix_repo_deb_gpg_key_url }}"
+    dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
   environment:
@@ -71,7 +71,7 @@
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
       Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
-      Signed-By: {{ zabbix_gpg_key | default(_zabbix_gpg_key_default_by_distrib[ansible_distribution_major_version]) }}
+      Signed-By: {{ zabbix_gpg_key }}
   become: true
   tags:
     - install

--- a/roles/zabbix_proxy/vars/Debian.yml
+++ b/roles/zabbix_proxy/vars/Debian.yml
@@ -64,22 +64,7 @@ mysql_plugin:
   "10": mysql_native_password
 
 debian_keyring_path: /etc/apt/keyrings/
-_zabbix_gpg_key_default_by_distrib:
-  "12": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "11": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "10": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "24": "{{ debian_keyring_path }}zabbix-repo.gpg"
-  "22": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "20": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "18": "{{ debian_keyring_path }}zabbix-repo.asc"
-_zabbix_repo_default_deb_gpg_key_url_by_distrib:
-  "12": https://repo.zabbix.com/zabbix-official-repo.key
-  "11": https://repo.zabbix.com/zabbix-official-repo.key
-  "10": https://repo.zabbix.com/zabbix-official-repo.key
-  "24": https://repo.zabbix.com/zabbix-official-repo-apr2024.gpg
-  "22": https://repo.zabbix.com/zabbix-official-repo.key
-  "20": https://repo.zabbix.com/zabbix-official-repo.key
-  "18": https://repo.zabbix.com/zabbix-official-repo.key
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
 _zabbix_proxy_fping6location: /usr/bin/fping6
 _zabbix_proxy_fpinglocation: /usr/bin/fping
 

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -61,6 +61,7 @@ zabbix_repo_yum:
     state: present
 zabbix_server_apt_priority:
 zabbix_server_conf_mode: 0640
+zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
 zabbix_repo_deb_include_deb_src: true
 
 # Server Configuration Variables (Only ones with role provided defaults)

--- a/roles/zabbix_server/tasks/Debian.yml
+++ b/roles/zabbix_server/tasks/Debian.yml
@@ -38,8 +38,8 @@
 - name: "Debian | Download gpg key"
   when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
-    url: "{{ zabbix_repo_deb_gpg_key_url | default(_zabbix_repo_default_deb_gpg_key_url_by_distrib[ansible_distribution_major_version]) }}"
-    dest: "{{ zabbix_gpg_key | default(_zabbix_gpg_key_default_by_distrib[ansible_distribution_major_version]) }}"
+    url: "{{ zabbix_repo_deb_gpg_key_url }}"
+    dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
   environment:
@@ -64,7 +64,7 @@
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
       Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
-      Signed-By: {{ zabbix_gpg_key | default(_zabbix_gpg_key_default_by_distrib[ansible_distribution_major_version]) }}
+      Signed-By: {{ zabbix_gpg_key }}
   become: true
   tags:
     - install

--- a/roles/zabbix_server/vars/Debian.yml
+++ b/roles/zabbix_server/vars/Debian.yml
@@ -32,22 +32,7 @@ zabbix_valid_server_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-_zabbix_gpg_key_default_by_distrib:
-  "12": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "11": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "10": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "24": "{{ debian_keyring_path }}zabbix-repo.gpg"
-  "22": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "20": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "18": "{{ debian_keyring_path }}zabbix-repo.asc"
-_zabbix_repo_default_deb_gpg_key_url_by_distrib:
-  "12": https://repo.zabbix.com/zabbix-official-repo.key
-  "11": https://repo.zabbix.com/zabbix-official-repo.key
-  "10": https://repo.zabbix.com/zabbix-official-repo.key
-  "24": https://repo.zabbix.com/zabbix-official-repo-apr2024.gpg
-  "22": https://repo.zabbix.com/zabbix-official-repo.key
-  "20": https://repo.zabbix.com/zabbix-official-repo.key
-  "18": https://repo.zabbix.com/zabbix-official-repo.key
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"
 
 _zabbix_server_pgsql_dependencies:
   - "{{ zabbix_server_install_database_client | ternary('postgresql-client', '') }}"

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -93,6 +93,7 @@ selinux_allow_httpd_can_connect_ldap: false
 selinux_allow_httpd_can_network_connect_db: false
 selinux_allow_httpd_can_connect_zabbix: false
 
+zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
 zabbix_repo_deb_include_deb_src: true
 
 # SAML certificates

--- a/roles/zabbix_web/tasks/Debian.yml
+++ b/roles/zabbix_web/tasks/Debian.yml
@@ -63,8 +63,8 @@
 - name: "Debian | Download gpg key"
   when: not ansible_check_mode  # Because get_url always has changed status in check_mode.
   ansible.builtin.get_url:
-    url: "{{ zabbix_repo_deb_gpg_key_url | default(_zabbix_repo_default_deb_gpg_key_url_by_distrib[ansible_distribution_major_version]) }}"
-    dest: "{{ zabbix_gpg_key | default(_zabbix_gpg_key_default_by_distrib[ansible_distribution_major_version]) }}"
+    url: "{{ zabbix_repo_deb_gpg_key_url }}"
+    dest: "{{ zabbix_gpg_key }}"
     mode: "0644"
     force: true
   environment:
@@ -87,7 +87,7 @@
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
       Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
-      Signed-By: {{ zabbix_gpg_key | default(_zabbix_gpg_key_default_by_distrib[ansible_distribution_major_version]) }}
+      Signed-By: {{ zabbix_gpg_key }}
   become: true
   tags:
     - install

--- a/roles/zabbix_web/vars/Debian.yml
+++ b/roles/zabbix_web/vars/Debian.yml
@@ -50,19 +50,4 @@ zabbix_valid_web_versions:
     - 6.0
 
 debian_keyring_path: /etc/apt/keyrings/
-_zabbix_gpg_key_default_by_distrib:
-  "12": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "11": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "10": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "24": "{{ debian_keyring_path }}zabbix-repo.gpg"
-  "22": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "20": "{{ debian_keyring_path }}zabbix-repo.asc"
-  "18": "{{ debian_keyring_path }}zabbix-repo.asc"
-_zabbix_repo_default_deb_gpg_key_url_by_distrib:
-  "12": https://repo.zabbix.com/zabbix-official-repo.key
-  "11": https://repo.zabbix.com/zabbix-official-repo.key
-  "10": https://repo.zabbix.com/zabbix-official-repo.key
-  "24": https://repo.zabbix.com/zabbix-official-repo-apr2024.gpg
-  "22": https://repo.zabbix.com/zabbix-official-repo.key
-  "20": https://repo.zabbix.com/zabbix-official-repo.key
-  "18": https://repo.zabbix.com/zabbix-official-repo.key
+zabbix_gpg_key: "{{ debian_keyring_path }}zabbix-repo.asc"


### PR DESCRIPTION
##### SUMMARY

Zabbix LLC finally published their new repo signing key in the same file than previous keys.

It is now time to revert extra complexity in repo key management added to accommodate new Ubuntu 24.04 repo being signed with a different key stored at a different location.

##### ISSUE TYPE

- Chore Pull Request

##### ADDITIONAL INFORMATION

Zabbix debian repository for Ubuntu 24.04 is signed with a brand new GPG key named `Zabbix LLC (Apr 2024)`

First they have forgotten to publish the key, they they have published it in a separate file than other previous keys.

This new key finally landed into the usual key file published alongside other older keys.

for more information, see https://support.zabbix.com/browse/ZBX-24443