### PR TITLE
Add Support to Item Modules for setting Master Items by Name

### DIFF
--- a/changelogs/fragments/pr_1234.yml
+++ b/changelogs/fragments/pr_1234.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zabbix_item - add support for setting master items by name
+  - zabbix_itemprototype - add support for setting master items by name

--- a/plugins/modules/zabbix_item.py
+++ b/plugins/modules/zabbix_item.py
@@ -283,6 +283,36 @@ EXAMPLES = r'''
             value: application
     state: present
 
+- name: create a dependent item
+  # set task level variables as we change ansible_connection plugin here
+  vars:
+    ansible_network_os: community.zabbix.zabbix
+    ansible_connection: httpapi
+    ansible_httpapi_port: 443
+    ansible_httpapi_use_ssl: true
+    ansible_httpapi_validate_certs: false
+    ansible_zabbix_url_path: "zabbixeu"  # If Zabbix WebUI runs on non-default (zabbix) path ,e.g. http://<FQDN>/zabbixeu
+    ansible_host: zabbix-example-fqdn.org
+  community.zabbix.zabbix_item:
+    name: depend_item
+    host_name: example_host
+    params:
+        type: dependent_item
+        key: vfs.fs.pused
+        value_type: numeric_float
+        units: '%'
+        master_item:
+          item_name: example_item
+          host_name: example_host
+        preprocessing:
+          - type: jsonpath
+            params: '$[?(@.fstype == "ext4")]'
+            error_handler: zabbix_server
+          - type: jsonpath
+            params: "$[*].['bytes', 'inodes'].pused.max()"
+            error_handler: zabbix_server
+    state: present
+
 - name: Delete Zabbix item
   # set task level variables as we change ansible_connection plugin here
   vars:

--- a/plugins/modules/zabbix_item.py
+++ b/plugins/modules/zabbix_item.py
@@ -429,7 +429,10 @@ class Item(ZabbixBase):
               params['master_item']['host_name'] = None
             if 'template_name' not in params['master_item']:
               params['master_item']['template_name'] = None
-            params['master_itemid'] = self.get_items(params['master_item']['item_name'], params['master_item']['host_name'], params['master_item']['template_name'])[0]['itemid']
+            master_items = self.get_items(params['master_item']['item_name'], params['master_item']['host_name'], params['master_item']['template_name'])
+            if len(master_items) == 0:
+              self._module.fail_json(msg="No items with the name %s exist to depend on" % params['master_item']['item_name'])
+            params['master_itemid'] = master_items[0]['itemid']
             params.pop('master_item')
         if 'preprocessing' in params:
             for param in params['preprocessing']:

--- a/plugins/modules/zabbix_item.py
+++ b/plugins/modules/zabbix_item.py
@@ -426,12 +426,12 @@ class Item(ZabbixBase):
                 self._module.fail_json(msg="Status must be 'enabled' or 'disabled', got %s" % status)
         if 'master_item' in params:
             if 'host_name' not in params['master_item']:
-              params['master_item']['host_name'] = None
+                params['master_item']['host_name'] = None
             if 'template_name' not in params['master_item']:
-              params['master_item']['template_name'] = None
+                params['master_item']['template_name'] = None
             master_items = self.get_items(params['master_item']['item_name'], params['master_item']['host_name'], params['master_item']['template_name'])
             if len(master_items) == 0:
-              self._module.fail_json(msg="No items with the name %s exist to depend on" % params['master_item']['item_name'])
+                self._module.fail_json(msg="No items with the name %s exist to depend on" % params['master_item']['item_name'])
             params['master_itemid'] = master_items[0]['itemid']
             params.pop('master_item')
         if 'preprocessing' in params:

--- a/plugins/modules/zabbix_item.py
+++ b/plugins/modules/zabbix_item.py
@@ -116,6 +116,29 @@ options:
                     - log
                     - numeric_unsigned
                     - text
+            master_item:
+                description:
+                    - item that is the master of the current one
+                    - Overrides "master_itemid" in API docs
+                required: false
+                type: dict
+                suboptions:
+                    item_name:
+                        description:
+                          - name of the master item
+                        required: true
+                        type: str
+                    host_name:
+                        description:
+                          - name of the host the master item belongs to
+                          - Required when I(template_name) is not used.
+                          - Mutually exclusive with I(template_name).
+                        required: false
+                    template_name:
+                        description:
+                          - name of the template the master item belongs to
+                          - Required when I(host_name) is not used.
+                          - Mutually exclusive with I(host_name).
             preprocessing:
                 description:
                     - Item preprocessing options.
@@ -401,6 +424,13 @@ class Item(ZabbixBase):
                 params['status'] = 1
             else:
                 self._module.fail_json(msg="Status must be 'enabled' or 'disabled', got %s" % status)
+        if 'master_item' in params:
+            if 'host_name' not in params['master_item']:
+              params['master_item']['host_name'] = None
+            if 'template_name' not in params['master_item']:
+              params['master_item']['template_name'] = None
+            params['master_itemid'] = self.get_items(params['master_item']['item_name'], params['master_item']['host_name'], params['master_item']['template_name'])[0]['itemid']
+            params.pop('master_item')
         if 'preprocessing' in params:
             for param in params['preprocessing']:
                 preprocess_type_int = self.PREPROCESSING_TYPES[param['type']]

--- a/plugins/modules/zabbix_itemprototype.py
+++ b/plugins/modules/zabbix_itemprototype.py
@@ -121,6 +121,34 @@ options:
                     - log
                     - numeric_unsigned
                     - text
+            master_item:
+                description:
+                    - item that is the master of the current one
+                    - Overrides "master_itemid" in API docs
+                required: false
+                type: dict
+                suboptions:
+                    item_name:
+                        description:
+                          - name of the master item
+                        required: true
+                        type: str
+                    discovery_rule:
+                        description:
+                          - name of the discovery rule the master item belongs to
+                        required: true
+                        type: str
+                    host_name:
+                        description:
+                          - name of the host the master item belongs to
+                          - Required when I(template_name) is not used.
+                          - Mutually exclusive with I(template_name).
+                        required: false
+                    template_name:
+                        description:
+                          - name of the template the master item belongs to
+                          - Required when I(host_name) is not used.
+                          - Mutually exclusive with I(host_name).
             preprocessing:
                 description:
                     - Item preprocessing options.
@@ -423,6 +451,13 @@ class Itemprototype(ZabbixBase):
         if 'enabled' in params:
             params['status'] = params['enabled']
             params.pop('enabled')
+        if 'master_item' in params:
+            if 'host_name' not in params['master_item']:
+              params['master_item']['host_name'] = None
+            if 'template_name' not in params['master_item']:
+              params['master_item']['template_name'] = None
+            params['master_itemid'] = self.get_itemprototypes(params['master_item']['item_name'], params['master_item']['discoveryrule_name'], params['master_item']['host_name'], params['master_item']['template_name'])[0]['itemid']
+            params.pop('master_item')
         if 'preprocessing' in params:
             for param in params['preprocessing']:
                 preprocess_type_int = self.PREPROCESSING_TYPES[param['type']]

--- a/plugins/modules/zabbix_itemprototype.py
+++ b/plugins/modules/zabbix_itemprototype.py
@@ -453,12 +453,13 @@ class Itemprototype(ZabbixBase):
             params.pop('enabled')
         if 'master_item' in params:
             if 'host_name' not in params['master_item']:
-              params['master_item']['host_name'] = None
+                params['master_item']['host_name'] = None
             if 'template_name' not in params['master_item']:
-              params['master_item']['template_name'] = None
-            master_items = self.get_itemprototypes(params['master_item']['item_name'], params['master_item']['discoveryrule_name'], params['master_item']['host_name'], params['master_item']['template_name'])
+                params['master_item']['template_name'] = None
+            master_items = self.get_itemprototypes(params['master_item']['item_name'], params['master_item']['discoveryrule_name'],
+                                                   params['master_item']['host_name'], params['master_item']['template_name'])
             if len(master_items) == 0:
-              self._module.fail_json(msg="No items with the name %s exist to depend on" % params['master_item']['item_name'])
+                self._module.fail_json(msg="No items with the name %s exist to depend on" % params['master_item']['item_name'])
             params['master_itemid'] = master_items[0]['itemid']
             params.pop('master_item')
         if 'preprocessing' in params:

--- a/plugins/modules/zabbix_itemprototype.py
+++ b/plugins/modules/zabbix_itemprototype.py
@@ -456,7 +456,10 @@ class Itemprototype(ZabbixBase):
               params['master_item']['host_name'] = None
             if 'template_name' not in params['master_item']:
               params['master_item']['template_name'] = None
-            params['master_itemid'] = self.get_itemprototypes(params['master_item']['item_name'], params['master_item']['discoveryrule_name'], params['master_item']['host_name'], params['master_item']['template_name'])[0]['itemid']
+            master_items = self.get_itemprototypes(params['master_item']['item_name'], params['master_item']['discoveryrule_name'], params['master_item']['host_name'], params['master_item']['template_name'])
+            if len(master_items) == 0:
+              self._module.fail_json(msg="No items with the name %s exist to depend on" % params['master_item']['item_name'])
+            params['master_itemid'] = master_items[0]['itemid']
             params.pop('master_item')
         if 'preprocessing' in params:
             for param in params['preprocessing']:

--- a/plugins/modules/zabbix_itemprototype.py
+++ b/plugins/modules/zabbix_itemprototype.py
@@ -300,6 +300,35 @@ EXAMPLES = r'''
             value: application
     state: present
 
+- name: create dependent item
+  # set task level variables as we change ansible_connection plugin here
+  vars:
+    ansible_network_os: community.zabbix.zabbix
+    ansible_connection: httpapi
+    ansible_httpapi_port: 443
+    ansible_httpapi_use_ssl: true
+    ansible_httpapi_validate_certs: false
+    ansible_zabbix_url_path: 'zabbixeu'  # If Zabbix WebUI runs on non-default (zabbix) path ,e.g. http://<FQDN>/zabbixeu
+    ansible_host: zabbix-example-fqdn.org
+  community.zabbix.zabbix_itemprototype:
+    name: '{% raw %}{#FSNAME}:example_depend_item_prototype{% endraw %}'
+    discoveryrule_name: example_rule
+    host_name: example_host
+    params:
+        type: dependent_item
+        key: '{% raw %}vfs.fs.size.half[{#FSNAME}]{% endraw %}'
+        value_type: numeric_float
+        units: B
+        master_item:
+          item_name: '{% raw %}{#FSNAME}:example_item_prototype{% endraw %}'
+          discoveryrule_name: example_rule
+          host_name: example_host
+        preprocessing:
+          - type: javascript
+            params: 'return value / 2;'
+            error_handler: zabbix_server
+    state: present
+
 - name: Delete Zabbix item prototype
   # set task level variables as we change ansible_connection plugin here
   vars:

--- a/tests/integration/targets/test_zabbix_item/tasks/zabbix_tests.yml
+++ b/tests/integration/targets/test_zabbix_item/tasks/zabbix_tests.yml
@@ -7,8 +7,16 @@
     params:
         type: zabbix_agent_active
         key: vfs.fs.get
-        value_type: text
+        value_type: numeric_float
+        units: '%'
         interval: 1m
+        preprocessing:
+          - type: jsonpath
+            params: '$[?(@.fstype == "ext4")]'
+            error_handler: zabbix_server
+          - type: jsonpath
+            params: "$[*].['bytes', 'inodes'].pused.max()"
+            error_handler: zabbix_server
         tags:
           - tag: tag
             value: value
@@ -19,15 +27,23 @@
   ansible.builtin.assert:
     that: zbxhostitem_new is changed
 
-- name: test - create same Zabbix item once again
+- name: test - create same Zabbix item group once again
   community.zabbix.zabbix_item:
     name: TestItem
     host_name: ExampleHost
     params:
         type: zabbix_agent_active
         key: vfs.fs.get
-        value_type: text
+        value_type: numeric_float
+        units: '%'
         interval: 1m
+        preprocessing:
+          - type: jsonpath
+            params: '$[?(@.fstype == "ext4")]'
+            error_handler: zabbix_server
+          - type: jsonpath
+            params: "$[*].['bytes', 'inodes'].pused.max()"
+            error_handler: zabbix_server
         tags:
           - tag: tag
             value: value
@@ -50,6 +66,47 @@
 - name: expect to succeed and that things changed
   ansible.builtin.assert:
     that: zbxhostitem_changed is changed
+
+- name: test - attempt to delete previously created zabbix item
+  community.zabbix.zabbix_item:
+    name: TestItem
+    host_name: ExampleHost
+    state: absent
+  register: zbxhostitem_existing_delete
+
+- name: assert that item was deleted
+  ansible.builtin.assert:
+    that: zbxhostitem_existing_delete is changed
+
+- name: test - attempt to delete non-existing zabbix item
+  community.zabbix.zabbix_item:
+    name: TestItem
+    host_name: ExampleHost
+    state: absent
+  register: zbxhostitem_missing_delete
+
+- name: assert that nothing has been changed
+  ansible.builtin.assert:
+    that: not zbxhostitem_missing_delete is changed
+
+- name: test - create new Zabbix master item on host
+  community.zabbix.zabbix_item:
+    name: TestItem
+    host_name: ExampleHost
+    params:
+        type: zabbix_agent_active
+        key: vfs.fs.get
+        value_type: text
+        interval: 1m
+        tags:
+          - tag: tag
+            value: value
+    state: present
+  register: zbxhostmstitem_new
+
+- name: assert that item was created
+  ansible.builtin.assert:
+    that: zbxhostmstitem_new is changed
 
 - name: create dependent item
   community.zabbix.zabbix_item:
@@ -77,16 +134,16 @@
   ansible.builtin.assert:
     that: zbxhostdependitem_new is changed
 
-- name: test - attempt to delete previously created zabbix item
+- name: test - attempt to delete previously created zabbix master item
   community.zabbix.zabbix_item:
     name: TestItem
     host_name: ExampleHost
     state: absent
-  register: zbxhostitem_existing_delete
+  register: zbxhostmstitem_existing_delete
 
 - name: assert that item was deleted
   ansible.builtin.assert:
-    that: zbxhostitem_existing_delete is changed
+    that: zbxhostmstitem_existing_delete is changed
 
 - name: test - attempt to delete dependent item
   community.zabbix.zabbix_item:
@@ -98,17 +155,6 @@
 - name: assert that the item had been removed with its master
   ansible.builtin.assert:
     that: not zbxhostdependitem_delete is changed
-
-- name: test - attempt to delete non-existing zabbix item
-  community.zabbix.zabbix_item:
-    name: TestItem
-    host_name: ExampleHost
-    state: absent
-  register: zbxhostitem_missing_delete
-
-- name: assert that nothing has been changed
-  ansible.builtin.assert:
-    that: not zbxhostitem_missing_delete is changed
 
 - name: test - create new Zabbix item on template with many options set
   community.zabbix.zabbix_item:

--- a/tests/integration/targets/test_zabbix_item/tasks/zabbix_tests.yml
+++ b/tests/integration/targets/test_zabbix_item/tasks/zabbix_tests.yml
@@ -7,16 +7,8 @@
     params:
         type: zabbix_agent_active
         key: vfs.fs.get
-        value_type: numeric_float
-        units: '%'
+        value_type: text
         interval: 1m
-        preprocessing:
-          - type: jsonpath
-            params: '$[?(@.fstype == "ext4")]'
-            error_handler: zabbix_server
-          - type: jsonpath
-            params: "$[*].['bytes', 'inodes'].pused.max()"
-            error_handler: zabbix_server
         tags:
           - tag: tag
             value: value
@@ -27,23 +19,15 @@
   ansible.builtin.assert:
     that: zbxhostitem_new is changed
 
-- name: test - create same Zabbix item group once again
+- name: test - create same Zabbix item once again
   community.zabbix.zabbix_item:
     name: TestItem
     host_name: ExampleHost
     params:
         type: zabbix_agent_active
         key: vfs.fs.get
-        value_type: numeric_float
-        units: '%'
+        value_type: text
         interval: 1m
-        preprocessing:
-          - type: jsonpath
-            params: '$[?(@.fstype == "ext4")]'
-            error_handler: zabbix_server
-          - type: jsonpath
-            params: "$[*].['bytes', 'inodes'].pused.max()"
-            error_handler: zabbix_server
         tags:
           - tag: tag
             value: value
@@ -67,6 +51,32 @@
   ansible.builtin.assert:
     that: zbxhostitem_changed is changed
 
+- name: create dependent item
+  community.zabbix.zabbix_item:
+    name: TestDependItem
+    host_name: ExampleHost
+    params:
+        type: dependent_item
+        key: vfs.fs.pused
+        value_type: numeric_float
+        units: '%'
+        master_item:
+          item_name: TestItem
+          host_name: ExampleHost
+        preprocessing:
+          - type: jsonpath
+            params: '$[?(@.fstype == "ext4")]'
+            error_handler: zabbix_server
+          - type: jsonpath
+            params: "$[*].['bytes', 'inodes'].pused.max()"
+            error_handler: zabbix_server
+    state: present
+  register: zbxhostdependitem_new
+
+- name: assert that item was created
+  ansible.builtin.assert:
+    that: zbxhostdependitem_new is changed
+
 - name: test - attempt to delete previously created zabbix item
   community.zabbix.zabbix_item:
     name: TestItem
@@ -77,6 +87,17 @@
 - name: assert that item was deleted
   ansible.builtin.assert:
     that: zbxhostitem_existing_delete is changed
+
+- name: test - attempt to delete dependent item
+  community.zabbix.zabbix_item:
+    name: TestDependItem
+    host_name: ExampleHost
+    state: absent
+  register: zbxhostdependitem_delete
+
+- name: assert that the item had been removed with its master
+  ansible.builtin.assert:
+    that: not zbxhostdependitem_delete is changed
 
 - name: test - attempt to delete non-existing zabbix item
   community.zabbix.zabbix_item:
@@ -116,7 +137,7 @@
   ansible.builtin.assert:
     that: zbxtempitem_new is changed
 
-- name: test - create same Zabbix item group once again
+- name: test - create same Zabbix item once again
   community.zabbix.zabbix_item:
     name: TestItem
     template_name: ExampleTemplate

--- a/tests/integration/targets/test_zabbix_itemprototype/tasks/zabbix_tests.yml
+++ b/tests/integration/targets/test_zabbix_itemprototype/tasks/zabbix_tests.yml
@@ -9,7 +9,7 @@
         type: zabbix_agent_active
         key: '{% raw %}vfs.fs.size[{#FSNAME},used]{% endraw %}'
         value_type: numeric_unsigned
-        units: B
+        units: GB
         interval: 1m
         tags:
           - tag: tag
@@ -30,7 +30,7 @@
         type: zabbix_agent_active
         key: '{% raw %}vfs.fs.size[{#FSNAME},used]{% endraw %}'
         value_type: numeric_unsigned
-        units: B
+        units: GB
         interval: 1m
         tags:
           - tag: tag
@@ -55,6 +55,51 @@
 - name: expect to succeed and that things changed
   ansible.builtin.assert:
     that: zbxhostitem_changed is changed
+
+- name: test - attempt to delete previously created zabbix item
+  community.zabbix.zabbix_itemprototype:
+    name: '{% raw %}{#FSNAME}:TestItemPrototype{% endraw %}'
+    discoveryrule_name: ExampleHostRule
+    host_name: ExampleHost
+    state: absent
+  register: zbxhostitem_existing_delete
+
+- name: assert that item was deleted
+  ansible.builtin.assert:
+    that: zbxhostitem_existing_delete is changed
+
+- name: test - attempt to delete non-existing zabbix item
+  community.zabbix.zabbix_itemprototype:
+    name: '{% raw %}{#FSNAME}:TestItemPrototype{% endraw %}'
+    discoveryrule_name: ExampleHostRule
+    host_name: ExampleHost
+    state: absent
+  register: zbxhostitem_missing_delete
+
+- name: assert that nothing has been changed
+  ansible.builtin.assert:
+    that: not zbxhostitem_missing_delete is changed
+
+- name: test - create new Zabbix master item on host
+  community.zabbix.zabbix_itemprototype:
+    name: '{% raw %}{#FSNAME}:TestItemPrototype{% endraw %}'
+    discoveryrule_name: ExampleHostRule
+    host_name: ExampleHost
+    params:
+        type: zabbix_agent_active
+        key: '{% raw %}vfs.fs.size[{#FSNAME},used]{% endraw %}'
+        value_type: numeric_unsigned
+        units: B
+        interval: 1m
+        tags:
+          - tag: tag
+            value: value
+    state: present
+  register: zbxhostmstitem_new
+
+- name: assert that item was created
+  ansible.builtin.assert:
+    that: zbxhostmstitem_new is changed
 
 - name: create dependent item
   community.zabbix.zabbix_itemprototype:
@@ -87,11 +132,11 @@
     discoveryrule_name: ExampleHostRule
     host_name: ExampleHost
     state: absent
-  register: zbxhostitem_existing_delete
+  register: zbxhostmstitem_existing_delete
 
 - name: assert that item was deleted
   ansible.builtin.assert:
-    that: zbxhostitem_existing_delete is changed
+    that: zbxhostmstitem_existing_delete is changed
 
 - name: test - attempt to delete dependent item
   community.zabbix.zabbix_itemprototype:
@@ -104,18 +149,6 @@
 - name: assert that the item had been removed with its master
   ansible.builtin.assert:
     that: not zbxhostdependitem_delete is changed
-
-- name: test - attempt to delete non-existing zabbix item
-  community.zabbix.zabbix_itemprototype:
-    name: '{% raw %}{#FSNAME}:TestItemPrototype{% endraw %}'
-    discoveryrule_name: ExampleHostRule
-    host_name: ExampleHost
-    state: absent
-  register: zbxhostitem_missing_delete
-
-- name: assert that nothing has been changed
-  ansible.builtin.assert:
-    that: not zbxhostitem_missing_delete is changed
 
 - name: remove host rule
   community.zabbix.zabbix_discoveryrule:

--- a/tests/integration/targets/test_zabbix_itemprototype/tasks/zabbix_tests.yml
+++ b/tests/integration/targets/test_zabbix_itemprototype/tasks/zabbix_tests.yml
@@ -9,7 +9,7 @@
         type: zabbix_agent_active
         key: '{% raw %}vfs.fs.size[{#FSNAME},used]{% endraw %}'
         value_type: numeric_unsigned
-        units: GB
+        units: B
         interval: 1m
         tags:
           - tag: tag
@@ -30,7 +30,7 @@
         type: zabbix_agent_active
         key: '{% raw %}vfs.fs.size[{#FSNAME},used]{% endraw %}'
         value_type: numeric_unsigned
-        units: GB
+        units: B
         interval: 1m
         tags:
           - tag: tag
@@ -56,6 +56,31 @@
   ansible.builtin.assert:
     that: zbxhostitem_changed is changed
 
+- name: create dependent item
+  community.zabbix.zabbix_itemprototype:
+    name: '{% raw %}{#FSNAME}:TestDependItemPrototype{% endraw %}'
+    discoveryrule_name: ExampleHostRule
+    host_name: ExampleHost
+    params:
+        type: dependent_item
+        key: '{% raw %}vfs.fs.size.half[{#FSNAME}]{% endraw %}'
+        value_type: numeric_float
+        units: B
+        master_item:
+          item_name: '{% raw %}{#FSNAME}:TestItemPrototype{% endraw %}'
+          discoveryrule_name: ExampleHostRule
+          host_name: ExampleHost
+        preprocessing:
+          - type: javascript
+            params: 'return value / 2;'
+            error_handler: zabbix_server
+    state: present
+  register: zbxhostdependitem_new
+
+- name: assert that item was created
+  ansible.builtin.assert:
+    that: zbxhostdependitem_new is changed
+
 - name: test - attempt to delete previously created zabbix item
   community.zabbix.zabbix_itemprototype:
     name: '{% raw %}{#FSNAME}:TestItemPrototype{% endraw %}'
@@ -67,6 +92,18 @@
 - name: assert that item was deleted
   ansible.builtin.assert:
     that: zbxhostitem_existing_delete is changed
+
+- name: test - attempt to delete dependent item
+  community.zabbix.zabbix_itemprototype:
+    name: '{% raw %}{#FSNAME}:TestDependItemPrototype{% endraw %}'
+    discoveryrule_name: ExampleHostRule
+    host_name: ExampleHost
+    state: absent
+  register: zbxhostdependitem_delete
+
+- name: assert that the item had been removed with its master
+  ansible.builtin.assert:
+    that: not zbxhostdependitem_delete is changed
 
 - name: test - attempt to delete non-existing zabbix item
   community.zabbix.zabbix_itemprototype:
@@ -106,7 +143,7 @@
         type: zabbix_agent_active
         key: '{% raw %}vfs.fs.size[{#FSNAME},used]{% endraw %}'
         value_type: numeric_unsigned
-        units: GB
+        units: B
         interval: 1m
         tags:
           - tag: tag
@@ -127,7 +164,7 @@
         type: zabbix_agent_active
         key: '{% raw %}vfs.fs.size[{#FSNAME},used]{% endraw %}'
         value_type: numeric_unsigned
-        units: GB
+        units: B
         interval: 1m
         tags:
           - tag: tag


### PR DESCRIPTION
##### SUMMARY

This change adds support to the zabbix_item and zabbix_itemprototype modules for setting the master item by name rather by ID

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
zabbix_item
zabbix_itemprototype

##### ADDITIONAL INFORMATION
Currently, if you want to create a dependent item using either the zabbix_item and zabbix_itemprototype module you can do so using the master item's ID, but you can't do it by name:

```
community.zabbix.zabbix_item:
    name: ExampleItem
    host_name: ExampleHost
    params:
        type: dependent_item
        key: ExampleKey
        value_type: numeric_unsigned
        master_itemid: 12345
```

This PR adds a new parameter, `master_item` that you can use to set the master item by name rather than by ID:

```
community.zabbix.zabbix_item:
    name: ExampleItem
    host_name: ExampleHost
    params:
        type: dependent_item
        key: ExampleKey
        value_type: numeric_unsigned
        master_item:
          item_name: ExampleMasterItem
          host_name: ExampleHost
```

Note that this PR preserves the previous functionality, if anyone was setting the master item by ID, that will continue to work