### PR TITLE
Install GPG key for Red Hat

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -21,6 +21,8 @@ selinux_allow_zabbix_run_sudo: false
 zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
 zabbix_repo_deb_include_deb_src: true
 
+zabbix_repo_rpm_gpg_key_url: http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD
+
 zabbix_agent_install_agent_only: false
 
 # Zabbix role related vars

--- a/roles/zabbix_agent/tasks/RedHat.yml
+++ b/roles/zabbix_agent/tasks/RedHat.yml
@@ -20,6 +20,14 @@
   tags:
     - install
 
+- name: "RedHat | Install GPG key"
+  ansible.builtin.rpm_key:
+    state: present
+    key: "{{ zabbix_repo_rpm_gpg_key_url }}"
+  become: true
+  tags:
+    - install
+
 - name: Check if warn parameter can be used for shell module
   ansible.builtin.set_fact:
     produce_warn: False


### PR DESCRIPTION
##### SUMMARY
Install Zabbix repo GPG key for rpm distros.

Presently if you try to perform a fresh agent install with `zabbix_repo_yum_gpgcheck` set to `true` it will fail as nothing installed the necessary GPG key.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix-agent