### PR TITLE
zabbix_agent - Use zabbix_agent_distribution_release to backport packages

### DIFF
--- a/changelogs/fragments/zabbix_agent_distribution_release.yml
+++ b/changelogs/fragments/zabbix_agent_distribution_release.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - zabbix_agent_distribution_release - Overload ansible_distribution_release on Debian when choosing packages to install

--- a/roles/zabbix_agent/tasks/Debian.yml
+++ b/roles/zabbix_agent/tasks/Debian.yml
@@ -61,7 +61,7 @@
       Types: deb{{ ' deb-src' if zabbix_repo_deb_include_deb_src }}
       Enabled: yes
       URIs: {{ zabbix_repo_deb_url }}
-      Suites: {{ ansible_distribution_release }}
+      Suites: {{ zabbix_agent_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
       Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
       Signed-By: {{ zabbix_gpg_key }}


### PR DESCRIPTION
##### SUMMARY
Configuration 'zabbix_agent_distribution_release' is already defined in the role. Actually make it usable to overload the system's ansible_distribution_release. This is useful to for example install Zabbix Agent2 on Raspbian 12 Bookworm using the older packages, as there is not release for the specific target distribution and version.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Zabbix Agent

##### ADDITIONAL INFORMATION
