### PR TITLE
Fix agent role when zabbix_agent_listenip is undefined

### DIFF
--- a/changelogs/fragments/pr_1245.yml
+++ b/changelogs/fragments/pr_1245.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_agent - Fix role when zabbix_agent_listenip is undefined

--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -51,7 +51,7 @@
     network_interface: ansible_{{ zabbix_agent_listeninterface }}
   when:
     - (zabbix_agent_listeninterface)
-    - not zabbix_agent_listenip
+    - zabbix_agent_listenip is undefined
   tags:
     - config
 
@@ -60,7 +60,7 @@
     zabbix_agent_listenip: "{{ hostvars[inventory_hostname][network_interface]['ipv4'].address | default('0.0.0.0') }}"
   when:
     - (zabbix_agent_listeninterface)
-    - not zabbix_agent_listenip
+    - zabbix_agent_listenip is undefined
   tags:
     - config
     - api
@@ -69,7 +69,7 @@
   ansible.builtin.set_fact:
     zabbix_agent_listenip: "0.0.0.0"
   when:
-    - not (zabbix_agent_listenip)
+    - zabbix_agent_listenip is undefined
   tags:
     - config
 


### PR DESCRIPTION
##### SUMMARY

zabbix.agent role in 2.5.0 fails when `zabbix_agent_listenip is undefined`

This poull request fixes the role

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

agent

This fixes #1244 