### PR TITLE
Fix reading existing psk

### DIFF
--- a/changelogs/fragments/pr_1246.yml
+++ b/changelogs/fragments/pr_1246.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_agent - Fix reading existing psk

--- a/roles/zabbix_agent/tasks/psk_secret.yml
+++ b/roles/zabbix_agent/tasks/psk_secret.yml
@@ -30,6 +30,7 @@
   ansible.builtin.slurp:
     src: "{{ zabbix_agent_tlspskfile }}"
   register: zabbix_agent_tlspsk_base64
+  become: true
   when:
     - zabbix_agent_tlspskcheck.stat.exists
   no_log: "{{ ansible_verbosity < 3 }}"


### PR DESCRIPTION
##### SUMMARY

in 2.5.0 reading existing PSK is missing a become parameter so it can't read the existing PSK

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

agent

