### PR TITLE
Remove References to Tags in LLD Rules

### DIFF
--- a/changelogs/fragments/pr_1269.yml
+++ b/changelogs/fragments/pr_1269.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - remove references to tags in LLD rules

--- a/plugins/modules/zabbix_discoveryrule.py
+++ b/plugins/modules/zabbix_discoveryrule.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: zabbix_discoveryrule
-short_description: Create/delete Zabbix discovery rules
+short_description: Create/delete Zabbix low-level discovery (LLD) rules
 description:
    - Create discoveryrules if they do not exist.
    - Delete existing discoveryrules if they exist.
@@ -206,7 +206,7 @@ EXAMPLES = r'''
         enabled: True
     state: present
 
-# Add tags to the existing Zabbix LLD rule
+# Change interval for existing Zabbix LLD rule
 - name: update rule
   # set task level variables as we change ansible_connection plugin here
   vars:
@@ -221,13 +221,7 @@ EXAMPLES = r'''
     name: mounted_filesystem_discovery
     template_name: example_template
     params:
-        type: zabbix_agent
-        key: 'vfs.fs.discovery'
-        interval: 1h
-        enabled: True
-        tags:
-          - tag: class
-            value: application
+        interval: 2h
     state: present
 
 # Delete LLD rule

--- a/tests/integration/targets/test_zabbix_discoveryrule/tasks/zabbix_tests.yml
+++ b/tests/integration/targets/test_zabbix_discoveryrule/tasks/zabbix_tests.yml
@@ -9,9 +9,6 @@
         key: 'vfs.fs.discovery'
         interval: 1m
         enabled: True
-        tags:
-          - tag: tag
-            value: value
     state: present
   register: zbxhostrule_new
 
@@ -28,9 +25,6 @@
         key: 'vfs.fs.discovery'
         interval: 1m
         enabled: True
-        tags:
-          - tag: tag
-            value: value
     state: present
   register: zbxhostrule_existing
 
@@ -82,9 +76,6 @@
         key: 'vfs.fs.discovery'
         interval: 1m
         enabled: True
-        tags:
-          - tag: tag
-            value: value
     state: present
   register: zbxtemprule_new
 
@@ -101,9 +92,6 @@
         key: 'vfs.fs.discovery'
         interval: 1m
         enabled: True
-        tags:
-          - tag: tag
-            value: value
     state: present
   register: zbxtemprule_existing
 


### PR DESCRIPTION
##### SUMMARY
Tags were accidentally added to LLD rules examples and tests, even though LLD rules don't actually support them. This removes all references to the tags

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- zabbix_discoveryrule

##### ADDITIONAL INFORMATION
Fixes https://github.com/ansible-collections/community.zabbix/issues/1269
