### PR TITLE
Fix zabbix_agent role on Windows

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -111,9 +111,8 @@ zabbix_version_long: 5.2.4
 # Windows Related
 zabbix_win_download_url: https://cdn.zabbix.com/zabbix/binaries/stable
 zabbix_win_install_dir: 'C:\Zabbix'
-zabbix_win_install_dir_conf: '{{ zabbix_win_install_dir }}\\conf'
-zabbix_win_install_dir_bin: '{{ zabbix_win_install_dir }}\\bin'
-zabbix_agent_win_include: "{{ zabbix_win_install_dir }}\\zabbix_agent.d\\"
+zabbix_win_install_dir_conf: '{{ zabbix_win_install_dir }}\conf'
+zabbix_win_install_dir_bin: '{{ zabbix_win_install_dir }}\bin'
 zabbix_win_firewall_management: true
 
 # macOS Related

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -4,6 +4,7 @@
     zabbix_agent_win_download_link: "{{ zabbix_agent_win_download_link is defined | ternary(zabbix_agent_win_download_link, zabbix_agent2_win_download_link) | default(_win_download_link) }}"
     zabbix_agent_win_logfile: "{{ zabbix_agent_win_logfile is defined | ternary(zabbix_agent_win_logfile, zabbix_agent2_win_logfile) | default(_win_logfile) }}"
     zabbix_agent_win_package: "{{ zabbix_agent_win_package is defined | ternary(zabbix_agent_win_package, zabbix_agent2_win_package) | default(_win_package) }}"
+    zabbix_agent_win_include: "{{ zabbix_agent_win_include is defined | ternary(zabbix_agent_win_include, zabbix_agent2_win_include) | default(_win_include) }}"
 
 - name: "Windows | Set default architecture"
   ansible.builtin.set_fact:
@@ -191,8 +192,8 @@
 
 - name: "Windows | Set installation settings (agent 2)"
   ansible.builtin.set_fact:
-    zabbix_win_package: "{{ zabbix2_win_package }}"
-    zabbix_win_download_link: "{{ zabbix2_win_download_link }}"
+    zabbix_win_package: "{{ zabbix_win_package | default(_win_package) }}"
+    zabbix_win_download_link: "{{ zabbix_win_download_link | default(_win_download_link) }}"
     zabbix_win_exe_path: "{{ zabbix2_win_exe_path }}"
     zabbix_win_config_name: "{{ zabbix2_win_config_name }}"
     zabbix_win_svc_name: "{{ zabbix2_win_svc_name }}"

--- a/roles/zabbix_agent/tasks/Windows_conf.yml
+++ b/roles/zabbix_agent/tasks/Windows_conf.yml
@@ -2,7 +2,14 @@
 - name: "Set Log File Info"
   ansible.builtin.set_fact:
     zabbix_agent_logfile: "{{ zabbix_agent_win_logfile is defined | ternary(zabbix_agent_win_logfile, zabbix_agent2_win_logfile) | default(_win_logfile) }}"
-  when: zabbix_agent_logfile is undefined
+
+- name: "Set Include Path Info"
+  ansible.builtin.set_fact:
+    zabbix_agent_include: "{{ zabbix_agent_win_include is defined | ternary(zabbix_agent_win_include, zabbix_agent2_win_include) | default(_win_include) }}"
+
+- name: "Set Control Socket"
+  ansible.builtin.set_fact:
+    zabbix_agent_controlsocket: "\\\\.\\pipe\\agent.sock"
 
 - name: "Set default ip address for zabbix_agent_ip"
   ansible.builtin.set_fact:

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -53,7 +53,8 @@
     zabbix_repo_apt_priority: "{{ zabbix_agent_apt_priority | default (omit) }}"
   when:
     - zabbix_manage_repo | default(true)
-    - not (zabbix_agent_docker | bool) or ansible_os_family == "Windows"
+    - not (zabbix_agent_docker | bool)
+    - ansible_os_family != "Windows"
 
 - name: "Install the correct repository"
   ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"

--- a/roles/zabbix_agent/tasks/psk_identity.yml
+++ b/roles/zabbix_agent/tasks/psk_identity.yml
@@ -3,17 +3,21 @@
     - name: AutoPSK | Check for existing TLS PSK identity | Windows
       ansible.windows.win_stat:
         path: "{{ zabbix_agent_tlspskidentity_file }}"
-      register: zabbix_agent_tlspskidentity_check
+      register: zabbix_agent_tlspskidentity_check_windows
       when:
         - ansible_os_family == "Windows"
 
     - name: AutoPSK | Check for existing TLS PSK identity | Linux
       ansible.builtin.stat:
         path: "{{ zabbix_agent_tlspskidentity_file }}"
-      register: zabbix_agent_tlspskidentity_check
+      register: zabbix_agent_tlspskidentity_check_linux
       become: true
       when:
         - ansible_os_family != "Windows"
+
+    - name: Set zabbix_agent_tlspskidentity_check
+      ansible.builtin.set_fact:
+        zabbix_agent_tlspskidentity_check: "{{ zabbix_agent_tlspskidentity_check_windows if ansible_os_family == 'Windows' else zabbix_agent_tlspskidentity_check_linux }}"
   tags:
     - config
 

--- a/roles/zabbix_agent/tasks/psk_secret.yml
+++ b/roles/zabbix_agent/tasks/psk_secret.yml
@@ -12,17 +12,21 @@
     - name: AutoPSK | Check for existing TLS PSK file | Windows
       ansible.windows.win_stat:
         path: "{{ zabbix_agent_tlspskfile }}"
-      register: zabbix_agent_tlspskcheck
+      register: zabbix_agent_tlspskcheck_windows
       when:
         - ansible_os_family == "Windows"
 
     - name: AutoPSK | Check for existing TLS PSK file | Linux
       ansible.builtin.stat:
         path: "{{ zabbix_agent_tlspskfile }}"
-      register: zabbix_agent_tlspskcheck
+      register: zabbix_agent_tlspskcheck_linux
       become: true
       when:
         - ansible_os_family != "Windows"
+
+    - name: Set zabbix_agent_tlspskcheck
+      ansible.builtin.set_fact:
+        zabbix_agent_tlspskcheck: "{{ zabbix_agent_tlspskcheck_windows if ansible_os_family == 'Windows' else zabbix_agent_tlspskcheck_linux }}"
   tags:
     - config
 

--- a/roles/zabbix_agent/vars/agent2_vars.yml
+++ b/roles/zabbix_agent/vars/agent2_vars.yml
@@ -3,7 +3,8 @@ _logfile: /var/log/zabbix/zabbix_agent2.log
 _include: /etc/zabbix/zabbix_agent2.d
 _tls_subject: "{{ zabbix_agent_tlsservercertsubject | default(omit) }}" # FIXME this is not correct and should be removed with 2.0.0, here only to prevent regression
 _win_package: zabbix_agent2-{{ zabbix_version_long }}-windows-amd64-openssl-static.zip
-_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long | regex_search('^\\d+\\.\\d+') }}/{{ zabbix_version_long }}/{{ zabbix2_win_package }}"
-_win_logfile: "{{ zabbix_win_install_dir }}\\zabbix_agent2.log"
+_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long | regex_search('^\\d+\\.\\d+') }}/{{ zabbix_version_long }}/{{ zabbix_win_package | default(_win_package) }}"
+_win_logfile: '{{ zabbix_win_install_dir }}\zabbix_agent2.log'
+_win_include: '{{ zabbix_win_install_dir_conf }}\zabbix_agent2.d'
 _agent_service: zabbix-agent2
 _agent_package: zabbix-agent2

--- a/roles/zabbix_agent/vars/agent_vars.yml
+++ b/roles/zabbix_agent/vars/agent_vars.yml
@@ -3,8 +3,9 @@ _logfile: /var/log/zabbix/zabbix_agentd.log
 _include: /etc/zabbix/zabbix_agentd.d
 _tls_subject: "{{ zabbix_agent_tlsservercertsubject | default(omit) }}" # FIXME this is not correct and should be removed with 2.0.0, here only to prevent regression
 _win_package: zabbix_agent-{{ zabbix_version_long }}-windows-amd64-openssl.zip
-_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long | regex_search('^\\d+\\.\\d+') }}/{{ zabbix_version_long }}/{{ zabbix_win_package }}"
-_win_logfile: "{{ zabbix_win_install_dir }}\\zabbix_agentd.log"
+_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long | regex_search('^\\d+\\.\\d+') }}/{{ zabbix_version_long }}/{{ zabbix_win_package | default(_win_package) }}"
+_win_logfile: '{{ zabbix_win_install_dir }}\zabbix_agentd.log'
+_win_include: '{{ zabbix_win_install_dir_conf }}\zabbix_agent.d'
 _agent_service: zabbix-agent
 _agent_package: zabbix-agent
 _sender_package: zabbix-sender


### PR DESCRIPTION
##### SUMMARY
Role zabbix_agent is not working on Windows.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Role zabbix_agent

##### ADDITIONAL INFORMATION
- Single quotes to avoid double backslashes.
- Remove default variable zabbix_agent_win_include because zabbix-agent2 may be used.
- Fix agent config template name to agent.conf.j2
- Default values for zabbix_win_package and zabbix_win_download_link
- Default value for zabbix_agent_controlsocket
- zabbix_agent_tlspskidentity_check and zabbix_agent_tlspskcheck must be defined in a separately task. There were two tasks that could define these variables. If the second task is skipped, as it has register keyword, the variable is reset.
- Define a value for _win_include

