### PR TITLE
DRAFT:  Fixed PSK Logic

### DIFF
--- a/changelogs/fragments/1297.yml
+++ b/changelogs/fragments/1297.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Agent Role - Fixed logic problem that would break if anything other than PSK was used.

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -330,7 +330,7 @@ The following table lists all variables that are exposed to modify the configura
 | StartAgents | zabbix_agent_startagents | 3 | Agent Only |
 | StatusPort | zabbix_agent_statusport | 9999 | Agent 2 Only |
 | Timeout | zabbix_agent_timeout | 3 |  |
-| TLSAccept | zabbix_agent_tlsconnect |  |  |
+| TLSAccept | zabbix_agent_tlsconnect | unencrypted | Is overridden with `zabbix_agent_tlspsk_auto` == True |
 | TLSCAFile | zabbix_agent_tlscafile | /etc/zabbix/tls_psk_auto.secret |  |
 | TLSCertFile | zabbix_agent_tlscertfile |  |  |
 | TLSCipherAll | zabbix_agent_tlscipherall |  | Agent on Linux Only |
@@ -339,7 +339,7 @@ The following table lists all variables that are exposed to modify the configura
 | TLSCipherCert13 | zabbix_agent_tlsciphercert13 |  | Agent on Linux Only |
 | TLSCipherPSK | zabbix_agent_tlscipherpsk |  | Agent on Linux Only |
 | TLSCipherPSK13 | zabbix_agent_tlscipherpsk13 |  | Agent on Linux Only |
-| TLSConnect | zabbix_agent_tlsconnect |  |  |
+| TLSConnect | zabbix_agent_tlsconnect | unencrypted | Is overridden with `zabbix_agent_tlspsk_auto` == True |
 | TLSCRLFile | zabbix_agent_tlscrlfile |  |  |
 | TLSKeyFile | zabbix_agent_tlskeyfile |  |  |
 | TLSPSKFile | zabbix_agent_tlspskfile |  |  |

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -32,6 +32,8 @@
     zabbix_agent_pidfile: "{{ zabbix_agent_pidfile is defined | ternary(zabbix_agent_pidfile, _pidfile) }}"
     zabbix_agent_service: "{{ zabbix_agent_service is defined | ternary(zabbix_agent_service, _agent_service) }}"
     zabbix_agent_tls_subject: "{{ zabbix_agent_tls_subject is defined | ternary(zabbix_agent_tls_subject, _tls_subject) }}"
+    zabbix_agent_tlsaccept: "{{ zabbix_agent_tlsaccept is defined | ternary(zabbix_agent_tlsaccept, 'unencrypted')}}"
+    zabbix_agent_tlsconnect: "{{ zabbix_agent_tlsconnect is defined | ternary(zabbix_agent_tlsconnect, 'unencrypted')}}"
 
 - name: Setting Zabbix API Server Port
   ansible.builtin.set_fact:
@@ -61,7 +63,7 @@
     - config
 
 - name: Configure PSK
-  when: "zabbix_agent_tlsaccept == 'psk' or zabbix_agent_tlsconnect == 'psk'"
+  when: "( zabbix_agent_tlsaccept == 'psk' ) or (zabbix_agent_tlsconnect  == 'psk')"
   block:
     - name: Gather PSK Secret Info
       ansible.builtin.include_tasks: psk_secret.yml

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -52,17 +52,27 @@
   when:
     - not (zabbix_agent_docker | bool)
 
-- name: Gather PSK Secret Info
-  ansible.builtin.include_tasks: psk_secret.yml
-
-- name: Gather PSK Identity Info
-  ansible.builtin.include_tasks: psk_identity.yml
-
 - name: AutoPSK | Default tlsaccept and tlsconnect to enforce PSK
   ansible.builtin.set_fact:
     zabbix_agent_tlsaccept: psk
     zabbix_agent_tlsconnect: psk
   when: zabbix_agent_tlspsk_auto | bool
+  tags:
+    - config
+
+- name: Configure PSK
+  when: "zabbix_agent_tlsaccept == 'psk' or zabbix_agent_tlsconnect == 'psk'"
+  block:
+    - name: Gather PSK Secret Info
+      ansible.builtin.include_tasks: psk_secret.yml
+
+    - name: Gather PSK Identity Info
+      ansible.builtin.include_tasks: psk_identity.yml
+
+    - name: "Configure Agent"
+      ansible.builtin.include_tasks: Windows_conf.yml
+      when:
+        - ansible_os_family == "Windows"
   tags:
     - config
 

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -68,13 +68,13 @@
 
     - name: Gather PSK Identity Info
       ansible.builtin.include_tasks: psk_identity.yml
-
-    - name: "Configure Agent"
-      ansible.builtin.include_tasks: Windows_conf.yml
-      when:
-        - ansible_os_family == "Windows"
   tags:
     - config
+
+- name: "Configure Agent"
+  ansible.builtin.include_tasks: Windows_conf.yml
+  when:
+    - ansible_os_family == "Windows"
 
 - name: "Configure Agent"
   ansible.builtin.include_tasks: Windows_conf.yml

--- a/roles/zabbix_agent/templates/agent.conf.j2
+++ b/roles/zabbix_agent/templates/agent.conf.j2
@@ -135,8 +135,10 @@ Plugins.{{ my_name }}.{{ param }}={{ value }}
 {{ (zabbix_agent_tlsconnect is defined and zabbix_agent_tlsconnect is not none) | ternary('', '# ') }}TLSConnect={{ zabbix_agent_tlsconnect | default('') }}
 {{ (zabbix_agent_tlscrlfile is defined and zabbix_agent_tlscrlfile is not none) | ternary('', '# ') }}TLSCRLFile={{ zabbix_agent_tlscrlfile | default('') }}
 {{ (zabbix_agent_tlskeyfile is defined and zabbix_agent_tlskeyfile is not none) | ternary('', '# ') }}TLSKeyFile={{ zabbix_agent_tlskeyfile | default('') }}
+{% if zabbix_agent_tlsaccept == 'psk' or zabbix_agent_tlsconnect == 'psk' %}
 {{ (zabbix_agent_tlspskfile is defined and zabbix_agent_tlspskfile is not none) | ternary('', '# ') }}TLSPSKFile={{ zabbix_agent_tlspskfile | default('') }}
 {{ (zabbix_agent_tlspskidentity is defined and zabbix_agent_tlspskidentity is not none) | ternary('', '# ') }}TLSPSKIdentity={{ zabbix_agent_tlspskidentity | default('') }}
+{% endif %}
 {{ (zabbix_agent_tlsservercertissuer is defined and zabbix_agent_tlsservercertissuer is not none) | ternary('', '# ') }}TLSServerCertIssuer={{ zabbix_agent_tlsservercertissuer | default('') }}
 {{ (zabbix_agent_tlsservercertsubject is defined and zabbix_agent_tlsservercertsubject is not none) | ternary('', '# ') }}TLSServerCertSubject={{ zabbix_agent_tlsservercertsubject | default('') }}
 {{ (zabbix_agent_unsafeuserparameters is defined and zabbix_agent_unsafeuserparameters is not none) | ternary('', '# ') }}UnsafeUserParameters={{ zabbix_agent_unsafeuserparameters | default (false) | ternary('1', '0') }}


### PR DESCRIPTION
##### SUMMARY
This change adds logic that that the PSK identify and secret files are touched unless encryption is set to PSK and solves #1297.

##### ISSUE TYPE
- Bugfix Pull Request

