### PR TITLE
Fix #1236 - removal of wrong include directory

### DIFF
--- a/changelogs/fragments/pr_1302_wrong_include_dir_removal.yml
+++ b/changelogs/fragments/pr_1302_wrong_include_dir_removal.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix for removal of wrong agent include directory (https://github.com/ansible-collections/community.zabbix/issues/1236)

--- a/roles/zabbix_agent/tasks/remove.yml
+++ b/roles/zabbix_agent/tasks/remove.yml
@@ -2,9 +2,12 @@
 - name: Pull service facts
   ansible.builtin.service_facts:
 
+- name: Load Agent Defaults
+  ansible.builtin.include_vars: "agent_vars.yml"
+
 - name: 'Remove | Make sure the "old" zabbix-agent service stopped'
   ansible.builtin.service:
-    name: "zabbix-agent"
+    name: "{{ _agent_service }}"
     state: stopped
     enabled: false
   become: true
@@ -14,12 +17,12 @@
 
 - name: "Remove | Package removal"
   ansible.builtin.package:
-    name: "zabbix-agent"
+    name: "{{ _agent_package }}"
     state: absent
   become: true
 
 - name: "Remove | Remove the agent-include-dir"
   ansible.builtin.file:
-    path: "{{ zabbix_agent_include }}"
+    path: "{{ _include }}"
     state: absent
   become: true

--- a/roles/zabbix_agent/tasks/remove.yml
+++ b/roles/zabbix_agent/tasks/remove.yml
@@ -2,12 +2,9 @@
 - name: Pull service facts
   ansible.builtin.service_facts:
 
-- name: Load Agent Defaults
-  ansible.builtin.include_vars: "agent_vars.yml"
-
 - name: 'Remove | Make sure the "old" zabbix-agent service stopped'
   ansible.builtin.service:
-    name: "{{ _agent_service }}"
+    name: "{{ zabbix_agent_service | replace('agent2', 'agent') }}"
     state: stopped
     enabled: false
   become: true
@@ -17,12 +14,12 @@
 
 - name: "Remove | Package removal"
   ansible.builtin.package:
-    name: "{{ _agent_package }}"
+    name: "{{ zabbix_agent_package | replace('agent2', 'agent') }}"
     state: absent
   become: true
 
 - name: "Remove | Remove the agent-include-dir"
   ansible.builtin.file:
-    path: "{{ _include }}"
+    path: "{{ zabbix_agent_include | replace('agent2', 'agent') }}"
     state: absent
   become: true


### PR DESCRIPTION
##### SUMMARY
When both `zabbix_agent2` and `zabbix_agent_package_remove` are true this removes the wrong include directory breaking the run.

Fixes #1236 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tasks/remove.yml

##### ADDITIONAL INFORMATION
Since agent and agent2 both use the same variable names to determine which path to use for the include Directory the choice which one to use is based on the `zabbix_agent2` variable.

loading var from `agent_vars.yml` and using the internal vars to stop the service, remove the package and include-dir prevent this issue.

Before:
```
TASK [community.zabbix.zabbix_agent : Remove | Remove the agent-include-dir]
changed: [zabbix.example.com]

<snip for readability>

TASK [community.zabbix.zabbix_agent : Install user-defined userparameters]
failed: [zabbix.example.com] (item={'name': 'custom_parameter'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "a9e014f8469a37318d75f1dbcff55e0345402da4", "item": {"name": "custom_parameter"}, "msg": "Destination directory /etc/zabbix/zabbix_agent2.d does not exist"}
```

After:
```
TASK [community.zabbix.zabbix_agent : Remove | Remove the agent-include-dir]
ok: [zabbix.example.com]

<snip for readability>

TASK [community.zabbix.zabbix_agent : Install user-defined userparameters]
ok: [zabbix.example.com] => (item={'name': 'custom_parameter'})
```