### PR TITLE
fix Configure zabbix-agent

### DIFF
--- a/changelogs/fragments/pr_1311.yml
+++ b/changelogs/fragments/pr_1311.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- zabbix-agent Fix Configure zabbix-agent #1310
+  - zabbix-agent Fix Configure zabbix-agent #1310

--- a/changelogs/fragments/pr_1311.yml
+++ b/changelogs/fragments/pr_1311.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- zabbix-agent Fix Configure zabbix-agent #1310

--- a/roles/zabbix_agent/tasks/Windows_conf.yml
+++ b/roles/zabbix_agent/tasks/Windows_conf.yml
@@ -15,7 +15,7 @@
 
 - name: "Windows | Configure zabbix-agent"
   ansible.windows.win_template:
-    src: "{{ zabbix_win_config_name }}.j2"
+    src: agent.conf.j2
     dest: "{{ zabbix_win_install_dir_conf }}\\{{ zabbix_win_config_name }}"
   notify: restart win zabbix agent
   tags:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Sets template src to 'agent.conf.j2' which is also used by Linux tasks.

[linux task](https://github.com/ansible-collections/community.zabbix/blob/911304a7c9ee167523efb457406a2c059cd96678/roles/zabbix_agent/tasks/Linux.yml#L116)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

ansible.windows.win_template

[template task](https://github.com/ansible-collections/community.zabbix/blob/911304a7c9ee167523efb457406a2c059cd96678/roles/zabbix_agent/tasks/Windows_conf.yml#L16)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

- name: "Windows | Configure zabbix-agent"
  ansible.windows.win_template:
    src: "{{ zabbix_win_config_name }}.j2"
    dest: "{{ zabbix_win_install_dir_conf }}\\{{ zabbix_win_config_name }}"
  notify: restart win zabbix agent
  tags:
    - config
    
- name: "Windows | Configure zabbix-agent"
  ansible.windows.win_template:
    src: agent.conf.j2
    dest: "{{ zabbix_win_install_dir_conf }}\\{{ zabbix_win_config_name }}"
  notify: restart win zabbix agent
  tags:
    - config

```
