### PR TITLE
fixes a bug when run crushes, because zabbix_repo tries register as v…

### DIFF
--- a/roles/zabbix_repo/tasks/Debian.yml
+++ b/roles/zabbix_repo/tasks/Debian.yml
@@ -58,7 +58,7 @@
       Components: {{ zabbix_repo_deb_component }}
       Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
       Signed-By: {{ zabbix_repo_gpg_key }}
-  register: zabbix_repo
+  register: zabbix_repo_apt_file
   become: true
   tags:
     - install
@@ -94,6 +94,7 @@
     - install
 
 - name: "Debian | Update apt cache if repo was added"
-  ansible.builtin.apt: update_cache=yes
-  when: zabbix_repo is changed
+  ansible.builtin.apt:
+    update_cache: true
+  when: zabbix_repo_apt_file.changed
   become: true


### PR DESCRIPTION
**fixes a bug when run crushes, because zabbix_repo tries register as variable, but at the same time it is a role name**

```
TASK [community.zabbix.zabbix_repo : Debian | Update apt cache if repo was added] *************************************************************************************************
fatal: [test]: FAILED! => {"msg": "The conditional check 'zabbix_repo is changed' failed. The error was: The 'changed' test expects a dictionary\n\nThe error appears to be in '~/test/ansible/collections/ansible_collections/community/zabbix/roles/zabbix_repo/tasks/Debian.yml': line 96, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Debian | Update apt cache if repo was added\"\n  ^ here\n"}
```