### PR TITLE
Removed python 3.10 from testing against devel.

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -43,6 +43,8 @@ jobs:
             python: '3.9'
           - ansible: devel
             python: '3.9'
+          - ansible: devel
+            python: '3.10'
 
     steps:
       - name: Check out code


### PR DESCRIPTION
##### SUMMARY
This removes testing of Python 3.10 against the devel branch of Ansible because it no longer supports that version.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Integration tests
