### PR TITLE
Fix conditional warning caused by jinja in assert

### DIFF
--- a/changelogs/fragments/jinja_conditional.yml
+++ b/changelogs/fragments/jinja_conditional.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_agent Role - Fixes assert warning 'conditional statements should not include jinja2 templating delimiters such as..'

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -16,7 +16,7 @@
   when: enable_version_check | default(true) | bool
   ansible.builtin.assert:
     that:
-      - "{{ zabbix_agent_version|float in zabbix_valid_agent_versions[ansible_distribution_major_version] }}"
+      - zabbix_agent_version | float in zabbix_valid_agent_versions[ansible_distribution_major_version]
     fail_msg: Zabbix version {{ zabbix_agent_version }} is not supported on {{ ansible_distribution }} {{ ansible_distribution_major_version }}
   tags:
     - always


### PR DESCRIPTION
##### SUMMARY
Fixes the warning seen during a play on zabbix_agent.
The assert task uses jinja which is not needed for the functionality.

##### ISSUE TYPE
- Minor Change Pull Request

##### COMPONENT NAME
community.zabbix.zabbix_agent / main.yml / Check that version is supported

##### ADDITIONAL INFORMATION
Just a minor change to fix the warning

before:
```
TASK [community.zabbix.zabbix_agent : Check that version is supported] 
[WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ zabbix_agent_version|float in zabbix_valid_agent_versions[ansible_distribution_major_version] }}
ok: [zabbix.example.com] => {
    "changed": false,
    "msg": "All assertions passed"
}
```
after:
```
TASK [community.zabbix.zabbix_agent : Check that version is supported] 
ok: [zabbix.example.com] => {
    "changed": false,
    "msg": "All assertions passed"
}
```
