### PR TITLE
Add jinja2 template option to inventory plugin for auth_token

### DIFF
--- a/changelogs/fragments/1342.yml
+++ b/changelogs/fragments/1342.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_inventory Plugin - Add support for jinja2 templating for auth_token in zabbix_inventory.yml

--- a/plugins/inventory/zabbix_inventory.py
+++ b/plugins/inventory/zabbix_inventory.py
@@ -298,6 +298,11 @@ server_url: https://zabbix.com
 auth_token: 3bc3dc85e13e2431812e7a32fa8341cbcf378e5101356c015fdf2e35fd511b06
 validate_certs: false
 
+#Using ansible-vault for auth token instead of username/password
+plugin: community.zabbix.zabbix_inventory
+server_url: https://zabbix.com
+auth_token: "{{ (lookup('ansible.builtin.vault','vault.yml') | ansible.builtin.from_yaml).zabbix_api_key }}"
+validate_certs: false
 """
 
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable, to_safe_group_name
@@ -378,7 +383,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         )
 
     def login_zabbix(self):
-        auth_token = self.get_option('auth_token')
+        auth_token = self._template_option('auth_token')
         if auth_token:
             self.auth = auth_token
             return
@@ -463,3 +468,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                         group_name = to_safe_group_name(group['name'])
                         self.inventory.add_group(group_name)
                         self.inventory.add_child(group_name, host_name)
+
+    def _template_option(self, option):
+        value = self.get_option(option)
+        self.templar.available_variables = {}
+        return self.templar.template(value)

--- a/plugins/inventory/zabbix_inventory.py
+++ b/plugins/inventory/zabbix_inventory.py
@@ -298,10 +298,10 @@ server_url: https://zabbix.com
 auth_token: 3bc3dc85e13e2431812e7a32fa8341cbcf378e5101356c015fdf2e35fd511b06
 validate_certs: false
 
-#Using ansible-vault for auth token instead of username/password
+#Using jinga2 template for auth token instead of username/password.
 plugin: community.zabbix.zabbix_inventory
 server_url: https://zabbix.com
-auth_token: "{{ (lookup('ansible.builtin.vault','vault.yml') | ansible.builtin.from_yaml).zabbix_api_key }}"
+auth_token: "{{ lookup('ansible.builtin.env', 'ZABBIX_API_KEY') }}"
 validate_certs: false
 """
 


### PR DESCRIPTION
##### SUMMARY
This allows for jinja2 templating to be used in the zabbix_inventory plugin so that the auth_token value can be protected with an environment variable or ansible-vault file.  Without this you are forced to add your API token in clear text in the configuration file which is not ideal for security.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.zabbix.zabbix_inventory

##### ADDITIONAL INFORMATION
Credit for the code goes to contributers to the digitalocean inventory plugin where they have this feature implemented.


I have not been successful in getting my development environment / integration tests working at the moment but this has been manually tested and it works as intended.
