### PR TITLE
Hide Logging on hostmacro API call

### DIFF
--- a/changelogs/fragments/1341.yml
+++ b/changelogs/fragments/1341.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_agent Role - Set `no_log` parameter to hostmacro API call.

--- a/roles/zabbix_agent/tasks/api.yml
+++ b/roles/zabbix_agent/tasks/api.yml
@@ -57,6 +57,7 @@
   register: zabbix_api_hostmarcro_created
   until: zabbix_api_hostmarcro_created is succeeded
   retries: 10
+  no_log: "{{ ansible_verbosity < 3 }}"
   delegate_to: "{{ zabbix_api_server_host }}"
   tags:
     - api


### PR DESCRIPTION
##### SUMMARY
This change hides logging (verbosity < 3) on the hostmacro API call within the zabbix_agent role as called out in #1341 1341

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_agent role
