### PR TITLE
Delete denied parameters from host interfaces

### DIFF
--- a/changelogs/fragments/1356-zabbix_host-delete-denied-parameters.yml
+++ b/changelogs/fragments/1356-zabbix_host-delete-denied-parameters.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_host - delete denied parameter from interfaces

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -944,7 +944,7 @@ class Host(ZabbixBase):
 
 
 # Add all default values to all missing parameters for existing interfaces
-def update_exist_interfaces_with_defaults(exist_interfaces, zabbix_version):
+def update_exist_interfaces_with_defaults(exist_interfaces):
 
     new_exist_interfaces = []
     default_interface = {
@@ -981,11 +981,10 @@ def update_exist_interfaces_with_defaults(exist_interfaces, zabbix_version):
     ]
     for interface in exist_interfaces:
         normalized_interface = interface
-        if LooseVersion("7.0") <= LooseVersion(zabbix_version):
-            denied_fields = list(set(interface.keys()) - set(allowed_fields))
-            normalized_interface = zabbix_utils.helper_normalize_data(
-                interface, del_keys=denied_fields
-            )[0]
+        denied_fields = list(set(interface.keys()) - set(allowed_fields))
+        normalized_interface = zabbix_utils.helper_normalize_data(
+            interface, del_keys=denied_fields
+        )[0]
 
         new_interface = default_interface.copy()
         new_interface.update(normalized_interface)
@@ -1215,7 +1214,7 @@ def main():
             # get existing host's interfaces
             exist_interfaces = host._zapi.hostinterface.get({"output": "extend", "hostids": host_id})
             exist_interfaces.sort(key=lambda x: int(x["interfaceid"]))
-            exist_interfaces = update_exist_interfaces_with_defaults(exist_interfaces, host._zbx_api_version)
+            exist_interfaces = update_exist_interfaces_with_defaults(exist_interfaces)
 
             # Convert integer parameters from strings to ints
             for idx, interface in enumerate(copy.deepcopy(exist_interfaces)):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Fix zabbix_host module to run on 7.0.1 and higher.
- This commit resolve the #1355 issue.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
In my change, I copied allowed_fields from [this commit](https://git.zabbix.com/projects/ZBX/repos/zabbix/commits/3d5a48d327ec01a4c8e58460873297f9b56f576e#ui/include/classes/api/services/CHostInterface.php) which is Vanav mentioned. Therefore, it will course errorif the allowed_fields chenges.
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
