### PR TITLE
Change version of docker compose action

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -68,7 +68,7 @@ jobs:
       # the Zabbix server. To do this we spin up a Docker container using the `matrix`
       # of version and ports specified earlier.
       - name: Zabbix container server provisioning
-        uses: isbang/compose-action@v1.5.0
+        uses: hoverkraft-tech/compose-action@v2.0.1
         with:
           compose-file: "./ansible_collections/community/zabbix/docker-compose.yml"
         env:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change version of docker compose action in integration-test GitHub Actions workflow 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
.github/workflows/plugins-integration.yml
##### ADDITIONAL INFORMATION

- Post job of the action always finish with error. it might be caused by using deprecated nodejs version. 
- `isbang/compose-action` is probably renamed to `hoverkraft-tech/compose-action`.
![Screenshot 2024-08-03 17 02 43](https://github.com/user-attachments/assets/218f4de6-bf47-4c69-8905-281f89ae8989)
