### PR TITLE
Userparameter fix for #1361

### DIFF
--- a/changelogs/fragments/1361_userparameters_fix.yml
+++ b/changelogs/fragments/1361_userparameters_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_agent Role - Fix for userparameter because include_dir is list #1361

--- a/roles/zabbix_agent/tasks/userparameter.yml
+++ b/roles/zabbix_agent/tasks/userparameter.yml
@@ -29,7 +29,7 @@
         - name: Install user-defined userparameters
           ansible.builtin.template:
             src: "{{ zabbix_agent_userparameters_templates_src }}/{{ item.name }}.j2"
-            dest: "{{ zabbix_agent_include_dir }}/userparameter_{{ item.name }}.conf"
+            dest: "{{ zabbix_agent_include_dir | first }}/userparameter_{{ item.name }}.conf"
             owner: zabbix
             group: zabbix
             mode: "0644"

--- a/roles/zabbix_agent/tasks/userparameter.yml
+++ b/roles/zabbix_agent/tasks/userparameter.yml
@@ -29,7 +29,7 @@
         - name: Install user-defined userparameters
           ansible.builtin.template:
             src: "{{ zabbix_agent_userparameters_templates_src }}/{{ item.name }}.j2"
-            dest: "{{ zabbix_agent_include_dir | first }}/userparameter_{{ item.name }}.conf"
+            dest: "{{ zabbix_agent_include_dir if zabbix_agent_include_dir is string else zabbix_agent_include_dir | first }}/userparameter_{{ item.name }}.conf"
             owner: zabbix
             group: zabbix
             mode: "0644"


### PR DESCRIPTION
##### SUMMARY
Userparameters uses include_dir which is a list since a few patches back. This breaks the placement of userparameter configs.

This fixes #1361

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent

##### ADDITIONAL INFORMATION


<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [community.zabbix.zabbix_agent : Install user-defined userparameters]
failed: [zabbix.example.com] (item={'name': 'nf_conntrack'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "7006c624038e572cf4f6be5ffc02120cccbdf623", "item": {"name": "nf_conntrack"}, "msg": "Destination directory ['/etc/zabbix/zabbix_agent2.d', '/etc/zabbix/zabbix_agent2.d/plugins.d'] does not exist"}
failed: [zabbix.example.com] (item={'name': 'iptables'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "a9e014f8469a37318d75f1dbcff55e0345402da4", "item": {"name": "iptables"}, "msg": "Destination directory ['/etc/zabbix/zabbix_agent2.d', '/etc/zabbix/zabbix_agent2.d/plugins.d'] does not exist"}
```
after

```
TASK [community.zabbix.zabbix_agent : Install user-defined userparameters] 
changed: [zabbix.example.com] => (item={'name': 'nf_conntrack'})
changed: [zabbix.example.com] => (item={'name': 'iptables'})
```
