### PR TITLE
Fix zabbix_agent include_dir creation logic

### DIFF
--- a/roles/zabbix_agent/tasks/Linux.yml
+++ b/roles/zabbix_agent/tasks/Linux.yml
@@ -128,18 +128,6 @@
   tags:
     - config
 
-- name: "Create include dir zabbix-agent"
-  ansible.builtin.file:
-    path: "{{ zabbix_agent_include_dir }}"
-    owner: root
-    group: zabbix
-    mode: "{{ zabbix_agent_include_mode }}"
-    state: directory
-  become: true
-  tags:
-    - config
-  when: zabbix_agent_include_dir is string
-
 - name: "Create include dirs zabbix-agent"
   ansible.builtin.file:
     path: "{{ include_dir }}"
@@ -147,10 +135,9 @@
     group: zabbix
     mode: "{{ zabbix_agent_include_mode }}"
     state: directory
-  loop: "{{ zabbix_agent_include_dir | list }}"  # To prevent errors, filter a string value as a list
+  loop: "{{ [zabbix_agent_include_dir] if zabbix_agent_include_dir is string else zabbix_agent_include_dir }}"
   loop_control:
     loop_var: 'include_dir'
-  when: zabbix_agent_include_dir is iterable
   become: true
   tags:
     - config


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

As a string is iterable of chars, the previous logic changed the permissions for all single-character dirs: '/', 'e', 't', 'c', '/', etc.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- zabbix_agent role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- **IMPORTANT**: open terminal session as `root` because the current version of the role resets the `/` ownership for all users except `root` and `zabbix` group
- run the `zabbix_agent` role
- check that the ownership of the `/` is set to `root:zabbix` and the permissions are smth like `drwxr-x---`
