### PR TITLE
fix: add default value to zabbix_proxy_tlsaccept and zabbix_proxy_tlsconnect in create api call argument

### DIFF
--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -127,3 +127,7 @@ zabbix_api_timeout: 30
 zabbix_api_create_proxy: false
 zabbix_proxy_state: present
 zabbix_proxy_status: active # or passive
+
+# TLS setttings
+zabbix_proxy_tlsaccept:
+zabbix_proxy_tlsconnect:

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -127,7 +127,3 @@ zabbix_api_timeout: 30
 zabbix_api_create_proxy: false
 zabbix_proxy_state: present
 zabbix_proxy_status: active # or passive
-
-# TLS setttings
-zabbix_proxy_tlsaccept:
-zabbix_proxy_tlsconnect:

--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -143,8 +143,8 @@
     tls_psk: "{{ zabbix_proxy_tlspsk_secret | default(omit) }}"
     tls_psk_identity: "{{ zabbix_proxy_tlspskidentity | default(omit) }}"
     tls_subject: "{{ zabbix_proxy_tls_subject | default(omit) }}"
-    tls_connect: "{{ zabbix_proxy_tls_config[zabbix_proxy_tlsaccept if zabbix_proxy_tlsaccept else 'no_encryption'] }}"
-    tls_accept: "{{ zabbix_proxy_tls_config[zabbix_proxy_tlsconnect if zabbix_proxy_tlsconnect else 'no_encryption'] }}"
+    tls_connect: "{{ zabbix_proxy_tls_config[zabbix_proxy_tlsaccept | default('no_encryption')] }}"
+    tls_accept: "{{ zabbix_proxy_tls_config[zabbix_proxy_tlsconnect | default('no_encryption')] }}"
   when:
     - zabbix_api_create_proxy | bool
   delegate_to: "{{ zabbix_api_server_host }}"


### PR DESCRIPTION
null default for these variables was introduced in #1019. But #1291 dropped this. So currently zabbix_proxy role is not working. This PR restore past behavior.

first commit is just adding null default value in `defaults/main.yml`, but I changed to adding API call argument `tasks/main.yml` based on review comment in second commit.

see also
 - https://github.com/ansible-collections/community.zabbix/pull/1019
 - https://github.com/ansible-collections/community.zabbix/pull/1291

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

zabbix_proxy role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
