### PR TITLE
Change codedev action version

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -87,6 +87,6 @@ jobs:
         working-directory: ./ansible_collections/community/zabbix
 
       # See the repots at https://codecov.io/gh/ansible-collections/community.zabbix
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change codedev action version from v3 to v4
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- workflows/plugins-integration.yml
##### ADDITIONAL INFORMATION
- codedev action v3 uses deprecated nodejs, then the action output warning.
We can use v4 now, let's use it!

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue --> 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
