### PR TITLE
Fix windows include dir in configuration

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -304,7 +304,7 @@ The following table lists all variables that are exposed to modify the configura
 | HostMetadataItem | zabbix_agent_hostmetadataitem |  |  |
 | Hostname | zabbix_agent_hostname |  | `{{ inventory_hostname }}` |
 | HostnameItem | zabbix_agent_hostnameitem |  |  |
-| Include | zabbix_agent_include | /etc/zabbix/`{{ agent version specific }}`.d/*.conf |  |
+| Include | zabbix_agent_include_dir | /etc/zabbix/`{{ agent version specific }}`.d/*.conf |  |
 | ListenBacklog | zabbix_agent_listenbacklog |  | Agent Only |
 | ListenIP | zabbix_agent_listenip | 0.0.0.0  |  |
 | ListenPort | zabbix_agent_listenport | 10050 |  |

--- a/roles/zabbix_agent/tasks/Windows_conf.yml
+++ b/roles/zabbix_agent/tasks/Windows_conf.yml
@@ -5,7 +5,7 @@
 
 - name: "Set Include Path Info"
   ansible.builtin.set_fact:
-    zabbix_agent_include: "{{ zabbix_agent_win_include is defined | ternary(zabbix_agent_win_include, zabbix_agent2_win_include) | default(_win_include) }}"
+    zabbix_agent_include_dir: "{{ zabbix_agent_win_include is defined | ternary(zabbix_agent_win_include, zabbix_agent2_win_include) | default(_win_include) }}"
 
 - name: "Set Control Socket"
   ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY
Fixes #1378 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent

##### ADDITIONAL INFORMATION
Fix the variable name in Windows_conf from zabbix_agent_include to zabbix_agent_include_dir
