### PR TITLE
Fix login and session issues connecting to zabbix

### DIFF
--- a/changelogs/fragments/relogin_after_changing-api-users-password.yml
+++ b/changelogs/fragments/relogin_after_changing-api-users-password.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - zabbix httpapi plugin - if login failed, it would not be attempted again by later tasks. fix now marks the connection as disconnected on failed login so that later tasks can try 
+  - zabbix_user - if the api user's password was changed, session errors would occur in later tasks. fix will relogin to zabbix after changing password of the api user

--- a/plugins/httpapi/zabbix.py
+++ b/plugins/httpapi/zabbix.py
@@ -108,7 +108,6 @@ class HttpApi(HttpApiBase):
                 self.connection._connected = False
                 raise
 
-
         if code == 200 and response != '':
             # Replace auth with real api_key we got from Zabbix after successful login
             self.connection._auth = {'auth': response}

--- a/plugins/module_utils/api_request.py
+++ b/plugins/module_utils/api_request.py
@@ -52,6 +52,19 @@ class ZabbixApiRequest(object):
     def api_version(self):
         return self.connection.api_version()
 
+    def password_changed_for_user(self, username: str, password: str):
+        '''
+        Call to the Zabbix HTTPAPI handler for when a Zabbix user's password has been changed.
+
+        This info is used to determine if the API user's password was changed and re-login
+        if so.
+
+        :param str username: Username of the user whose password was changed
+        :param str password: The new password
+        '''
+        # module_utils.connection.Connection will use JSONRPC to call back to Zabbix HTTPAPI
+        return self.connection.password_changed_for_user(username, password)
+
     @staticmethod
     def payload_builder(method_, params, jsonrpc_version='2.0', reqid=str(uuid4()), **kwargs):
         req = {'jsonrpc': jsonrpc_version, 'method': method_, 'id': reqid}

--- a/plugins/modules/zabbix_user.py
+++ b/plugins/modules/zabbix_user.py
@@ -663,6 +663,10 @@ class User(ZabbixBase):
                     msg="Failed to update user %s: %s" % (username, e)
                 )
 
+        successfully_changed_password = user_ids and override_passwd
+        if successfully_changed_password:
+            self._zapi.password_changed_for_user(username=username, password=passwd)
+
         return user_ids
 
     def delete_user(self, zbx_user, username):

--- a/tests/integration/targets/test_zabbix_user/tasks/change_api_user_pass.yml
+++ b/tests/integration/targets/test_zabbix_user/tasks/change_api_user_pass.yml
@@ -42,10 +42,15 @@
       override_passwd: "true"
       user_medias:
       usrgrps:
-        - Internal
         - Zabbix administrators
     when: "user_info.exception is not defined "
 
+  # Originally I setup an "Always:" block to reset the password back to default but
+  # because the password must be at least 8 char's long and the default pass 'zabbix' is not,
+  # this causes issues!
+  - name: Update the zabbix password var
+    set_fact:
+      zabbix_api_login_pass: "{{ new_pass }}"
 
   # Thanks to the modifications we no longer receive the following error on this task:
   # '{'code': -32602, 'message': 'Invalid params.', 'data': 'Session terminated, re-login, please.'}'
@@ -54,19 +59,3 @@
       ansible_httpapi_pass: "{{ new_pass }}" 
     community.zabbix.zabbix_user_info:
       username: "{{ zabbix_api_login_user }}"
-  
-  always:
-    - name: Reset Zabbix API user password back to default
-      vars:
-        ansible_httpapi_pass: "{{ new_pass }}" 
-      community.zabbix.zabbix_user:
-        username: "{{ zabbix_api_login_user }}"
-        current_passwd: "{{ new_pass }}"
-        passwd: "{{ old_pass }}"
-        override_passwd: "true"
-        user_medias:
-        usrgrps:
-          - Internal
-          - Zabbix administrators
-      when: "user_info.exception is not defined"
-

--- a/tests/integration/targets/test_zabbix_user/tasks/change_api_user_pass.yml
+++ b/tests/integration/targets/test_zabbix_user/tasks/change_api_user_pass.yml
@@ -1,0 +1,72 @@
+- name: set new pass
+  set_fact:
+    old_pass: "{{ zabbix_api_login_pass }}"
+    new_pass: "MyNewPassw0rd1"
+
+
+- name: Zabbix password modification block
+  block:
+  # The Zabbix docker images do not allow you to change Zabbix admin user/pass and 
+  # suggest doing so in configuration management, i.e. Ansible.
+  #
+  # To make our playbook idempotent, we want to check to see if we have changed the
+  # admin password yet by doing a test connect with the zabbix_user_info module.
+  #
+  # We set failed_when to false because we expect the call to fail if we are using
+  # the old password after it already being changed
+  # 
+  # Register user_info so we can check if we are logged in or not in later tasks
+  #
+  # This pattern is why the changes to community.zabbix/plugins/httpapi/zabbix.py:login()
+  # are required to force the connection to be disconnected on a failed login.
+  - name: Has the admin password been changed check
+    vars:
+      ansible_httpapi_pass: "{{ new_pass }}" 
+    community.zabbix.zabbix_user_info:
+      username: "{{ zabbix_api_login_user }}"
+    register: user_info
+    failed_when: false
+
+  # Here is where we update the password of the user that is connecting to the API.
+  # With the modifications:
+  # * Module tells connection a password changed for a user. 
+  # * Connection check if the user is our api user 
+  #   * If api user's password is changed, re-login
+  - name: Update the admin's email and password
+    vars:
+      ansible_httpapi_pass: "{{ old_pass }}" 
+    community.zabbix.zabbix_user:
+      username: "{{ zabbix_api_login_user }}"
+      current_passwd: "{{ old_pass }}"
+      passwd: "{{ new_pass }}"
+      override_passwd: "true"
+      user_medias:
+      usrgrps:
+        - Internal
+        - Zabbix administrators
+    when: "user_info.exception is not defined "
+
+
+  # Thanks to the modifications we no longer receive the following error on this task:
+  # '{'code': -32602, 'message': 'Invalid params.', 'data': 'Session terminated, re-login, please.'}'
+  - name: Get zabbix user info
+    vars:
+      ansible_httpapi_pass: "{{ new_pass }}" 
+    community.zabbix.zabbix_user_info:
+      username: "{{ zabbix_api_login_user }}"
+  
+  always:
+    - name: Reset Zabbix API user password back to default
+      vars:
+        ansible_httpapi_pass: "{{ new_pass }}" 
+      community.zabbix.zabbix_user:
+        username: "{{ zabbix_api_login_user }}"
+        current_passwd: "{{ new_pass }}"
+        passwd: "{{ old_pass }}"
+        override_passwd: "true"
+        user_medias:
+        usrgrps:
+          - Internal
+          - Zabbix administrators
+      when: "user_info.exception is not defined"
+

--- a/tests/integration/targets/test_zabbix_user/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_user/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- import_tasks: change_api_user_pass.yml
+
 # New user create test from here
 - name: test - Create a new Zabbix user with check_mode and diff
   community.zabbix.zabbix_user:

--- a/tests/unit/plugins/httpapi/test_zabbix.py
+++ b/tests/unit/plugins/httpapi/test_zabbix.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock
+from plugins.httpapi.zabbix import HttpApi
+
+def test_password_changed_for_user_should_login_for_api_user():
+    # Given a Zabbix httpapi
+    connection = MagicMock()
+    httpapi = HttpApi(connection=connection)
+    # And the API user is "remote"
+    api_username = "remote"
+    connection.get_option.side_effect = {'remote_user': api_username}.get
+    # And the new password is "mynewpassword"
+    new_pass = "mynewpassword"
+    httpapi.login = MagicMock()
+
+    # When calling password_changed_for_user() with the API user
+    httpapi.password_changed_for_user(api_username, new_pass)
+
+    # Then the login method should be called
+    httpapi.login.assert_called_once_with(api_username, new_pass)
+
+def test_password_changed_for_user_should_not_login_for_non_api_user():
+    # Given a Zabbix httpapi
+    connection = MagicMock()
+    httpapi = HttpApi(connection=connection)
+    # And the API user is "remote"
+    api_username = "remote"
+    connection.get_option.side_effect = {'remote_user': api_username}.get
+    httpapi.login = MagicMock()
+
+    # When calling password_changed_for_user() with a user
+    # other than the API user
+    httpapi.password_changed_for_user("not_the_mamaaaa", "mynewpassword")
+
+    # Then the login method should not be called
+    httpapi.login.assert_not_called()

--- a/tests/unit/plugins/httpapi/test_zabbix.py
+++ b/tests/unit/plugins/httpapi/test_zabbix.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 from plugins.httpapi.zabbix import HttpApi
 
+
 def test_password_changed_for_user_should_login_for_api_user():
     # Given a Zabbix httpapi
     connection = MagicMock()
@@ -17,6 +18,7 @@ def test_password_changed_for_user_should_login_for_api_user():
 
     # Then the login method should be called
     httpapi.login.assert_called_once_with(api_username, new_pass)
+
 
 def test_password_changed_for_user_should_not_login_for_non_api_user():
     # Given a Zabbix httpapi


### PR DESCRIPTION
* zabbix httpapi plugin - if login failed, it would not be attempted again by later tasks. fix now marks the connection as disconnected on failed login so that later tasks can try
* zabbix_user - if the api user's password was changed, session errors would occur in later tasks. fix will relogin to zabbix after changing password of the api user

## SUMMARY
Fixes #1209 because reset_connection will no longer be necessary in that context

### Disconnect when a failed login happens
#### Why do we need this ?
- The [zabbix docker images](https://github.com/zabbix/zabbix-docker) do not allow you to change zabbix admin user/pass:  https://github.com/zabbix/zabbix-docker/issues/820
    - This is a security decision and the Zabbix docker maintainer said you can use the API via something like Ansible to do it.

In the case of writing an Ansible role to:

* install Zabbix from these images
*  then update the Zabbix admin password in a idempotent way,

We may need to use a test login call to see if our new password works or if its still the default

- We use `failed_when: false` on the task so our play doesn't fail if we get a failed login
- If the the call fails, we can assume we have not yet setup the admin password and the default zabbix password is still in place

#### Where this fails
Currently the codebase doesn't mark the connection as disconnected when a login fails so subsequent attempts will assume we are logged in and provide a bad auth token

#### The fix
In `community/zabbix/plugins/httpapi/zabbix.py` we update the `login()` method so that when the login is failed, the connection is marked as disconnected.
```python
try:
	# Zabbix <= 6.2
	payload = self.payload_builder("user.login", user=username, password=password)
	code, response = self.send_request(data=payload)
except ConnectionError:
	# Zabbix >= 6.4
	try:
		payload = self.payload_builder("user.login", username=username, password=password)
		code, response = self.send_request(data=payload)
	 except ConnectionError:
		# If this task fails to login, we mark the connection as disconnected so that
		# future tasks can try to reauth
		self.connection._connected = False
		raise
```

### Update zabbix_user module to notify on successful password changes
#### Why do we have to do this?
It would be nice if we could detect changing the current Zabbix API user's password and re-login the user instead of seeing session terminated errors on subsequent calls

The original intent was to do this all from inside the Zabbix HTTPAPI class but it turns out the update user request is actually two separate requests made by the zabbix_user module:

* Get the user id by searching for the user by the given username using the [user.get method](https://www.zabbix.com/documentation/current/en/manual/api/reference/user/get)
* Call [user.update method](https://www.zabbix.com/documentation/current/en/manual/api/reference/user/update) to change the password by passing in the user id
	* By the time the zabbix httpapi receives the send_request for the user.update:
		* We only have the user id of the request so its hard to determine if the connection user is the user we are changing the password of!
			

#### Zabbix_user module User::update_user() method
- From within the zabbix_user module we still have access to the username of the user we are changing the password for but we don't have access to the Ansible HTTPAPI options such as the ansible_user which is our API user!
	- So we have to notify the Zabbix Ansible HTTPAPI that a user's password has changed.
	- The Ansible HTTPAPI can then determine if we changed our current user's password and re-login with the new credentials
		- We call the `password_changed_for_user()` method of the `ZabbixApiRequest` class
		- ` community/zabbix/plugins/modules/zabbix_user.py`:
		-
		  ```python
		  successfully_changed_password = user_ids and override_passwd
		  if successfully_changed_password:
		      self._zapi.password_changed_for_user(username=username, password=passwd)
		  
		  return user_ids
		  ```
#### Add the password_changed_for_user method to ZabbixApiRequest
* We need to communicate with the connection so it makes sense to encapsulate these calls inside the ZabbixApiRequest class that already has the handle.
* `community/zabbix/plugins/module_utils/api_request.py`:

```python
def password_changed_for_user(self, username: str, password: str):
    return self.connection.password_changed_for_user(username, password)
 ```

- Theres some voodoo that occurs here that involves JSON-RPC calls to get to the actual Zabbix Ansible HTTPAPI because the connection object we have here is just a [dummy from module-utils](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/connection.py)
		
#### Add password_changed_for_user method to Zabbix Ansible/HTTPAPI
- `community/zabbix/plugins/httpapi/zabbix.py`
- This is the method that ends up being called by the module through the ZabbixApiRequest class and the JSON-RPC calls.
- Here we detect if the user whose password was changed is the same user we are using for the Zabbix API requests.
	- If so, we login with the new credentials
	
	  ```python
	  def password_changed_for_user(self, username: str, password: str):
	     '''
	     An event handler for when a zabbix user's password has been changed.
	     We can then check to see if the API user's password has been changed.
	     If so, we re-login so that the next modules are authenticated with the new password.
	  
	     :param str username: Username of the user whose password was changed
	     :param str password: The new password
	     '''
	     changed_current_user_pass = self.connection.get_option('remote_user') == username
	     if changed_current_user_pass:
	        self.login(username, password)
	     return 
	  ```
#### JSON-RPC communication between module and connection
- JSON-RPC requests are handled by the [JsonRpcServer class](https://github.com/ansible/ansible/blob/devel/lib/ansible/utils/jsonrpc.py)
- Modules and their connection usually reside on different machines so their communication goes over RPC
- JSON-RPC request and responses must have the same ID
- By returning nothing from the `password_changed_for_user()`method, the marshaller for the json-rpc requests automatically [adds the header data](https://github.com/ansible/ansible/blob/devel/lib/ansible/utils/jsonrpc.py#L80)  including the correct request id

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
* Zabbix HTTPAPI
* zabbix_user module

##### ADDITIONAL INFORMATION
See the integration test for a playbook on how to reproduce the issue: tests/integration/targets/test_zabbix_user/tasks/change_api_user_pass.yml
