### PR TITLE
Remove StatusPort default value

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -328,7 +328,7 @@ The following table lists all variables that are exposed to modify the configura
 | ServerActive | zabbix_agent_serveractive |  |  |
 | SourceIP | zabbix_agent_sourceip |  |  |
 | StartAgents | zabbix_agent_startagents | 3 | Agent Only |
-| StatusPort | zabbix_agent_statusport | 9999 | Agent 2 Only |
+| StatusPort | zabbix_agent_statusport |  | Agent 2 Only |
 | Timeout | zabbix_agent_timeout | 3 |  |
 | TLSAccept | zabbix_agent_tlsconnect | unencrypted | Is overridden with `zabbix_agent_tlspsk_auto` == True |
 | TLSCAFile | zabbix_agent_tlscafile | /etc/zabbix/tls_psk_auto.secret |  |

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -33,7 +33,6 @@ zabbix_agent_persistentbufferperiod: 1h
 zabbix_agent_pluginsocket: /tmp/agent.plugin.sock
 zabbix_agent_plugintimeout: 3
 zabbix_agent_refreshactivechecks: 120
-zabbix_agent_statusport: 9999
 zabbix_agent_timeout: 3
 zabbix_agent_tlspsk_auto: false
 zabbix_agent_tlspskfile: /etc/zabbix/tls_psk_auto.secret


### PR DESCRIPTION
Fixes Conflicting defaults in zabbix_agent role #1383

##### SUMMARY
Brings the defaults of the role more in line with the upstream config

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
