### PR TITLE
Switch username/password during playbook execution

### DIFF
--- a/changelogs/fragments/relogin-when-username-changes.yml
+++ b/changelogs/fragments/relogin-when-username-changes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - httpapi - added ability to switch username/password during playbook execution.

--- a/plugins/httpapi/zabbix.py
+++ b/plugins/httpapi/zabbix.py
@@ -75,6 +75,10 @@ class HttpApi(HttpApiBase):
         return None
 
     def login(self, username, password):
+        # Store username/password in class variables (to be used in "username switch" scenario
+        self.username = username
+        self.password = password
+
         self.auth_key = self.get_option('zabbix_auth_key')
         if self.auth_key:
             self.connection._auth = {'auth': self.auth_key}
@@ -171,6 +175,47 @@ class HttpApi(HttpApiBase):
                 raise ConnectionError("Invalid JSON response: %s" % value)
 
             if "error" in json_data:
+                if "re-login" in json_data["error"]["data"]:
+                    # Get this response from Zabbix when we switch username to execute REST API
+                    if not self.auth_key:
+                        # Provide "fake" auth so netcommon.connection does not replace our headers
+                        self.connection._auth = {'auth': 'fake'}
+                    # Need to login with new username/password
+                    self.login(self.username, self.password)
+                    # Replace 'auth' field in payload with new one (we got from login process)
+                    data = json.loads(data)
+                    data['auth'] = self.connection._auth['auth']
+                    data = json.dumps(data)
+                    # Re-send the request we initially were trying to execute
+                    response, response_data = self.connection.send(
+                        path,
+                        data,
+                        method=request_method,
+                        headers=hdrs
+                    )
+                    value = to_text(response_data.getvalue())
+
+                    try:
+                        json_data = json.loads(value) if value else {}
+                    # JSONDecodeError only available on Python 3.5+
+                    except ValueError:
+                        raise ConnectionError("Invalid JSON response: %s" % value)
+
+                    if "error" in json_data:
+                        raise ConnectionError("REST API returned %s when sending %s" % (json_data["error"], data))
+
+                    if "result" in json_data:
+                        json_data = json_data["result"]
+
+                    try:
+                        # Some methods return bool not a dict in "result"
+                        iter(json_data)
+                    except TypeError:
+                        # Do not try to find "error" if it is not a dict
+                        return response.getcode(), json_data
+
+                    return response.getcode(), json_data
+
                 raise ConnectionError("REST API returned %s when sending %s" % (json_data["error"], data))
 
             if "result" in json_data:

--- a/plugins/httpapi/zabbix.py
+++ b/plugins/httpapi/zabbix.py
@@ -75,10 +75,6 @@ class HttpApi(HttpApiBase):
         return None
 
     def login(self, username, password):
-        # Store username/password in class variables (to be used in "username switch" scenario
-        self.username = username
-        self.password = password
-
         self.auth_key = self.get_option('zabbix_auth_key')
         if self.auth_key:
             self.connection._auth = {'auth': self.auth_key}
@@ -181,7 +177,7 @@ class HttpApi(HttpApiBase):
                         # Provide "fake" auth so netcommon.connection does not replace our headers
                         self.connection._auth = {'auth': 'fake'}
                     # Need to login with new username/password
-                    self.login(self.username, self.password)
+                    self.login(self.connection.get_option('remote_user'), self.connection.get_option('password'))
                     # Replace 'auth' field in payload with new one (we got from login process)
                     data = json.loads(data)
                     data['auth'] = self.connection._auth['auth']


### PR DESCRIPTION
##### SUMMARY
Fixes #1209 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
httpapi connection plugin

##### ADDITIONAL INFORMATION
Here is how you can disable default Admin account and add new admin user
```
---
- name: Ensure telemetry server is set up and running
  hosts: all
  gather_facts: false
  tasks:

    - name: Configure zabbix server
      vars:
        ansible_network_os: community.zabbix.zabbix
        ansible_connection: httpapi
        ansible_httpapi_port: 8080
        ansible_httpapi_use_ssl: no
        ansible_zabbix_url_path: ""
        ansible_user: "super"
        ansible_httpapi_pass: "verysecretpass"
      block:
        - name: Try to login with new (non-existent user)
          block:
            - name: Check status of default admin
              community.zabbix.zabbix_user_info:
                username: Admin 

          # If new admin user does not exist
          rescue:
            - name: Configure new primary admin user
              vars:
                # Connect with existing user
                ansible_user: "Admin"
                ansible_httpapi_pass: "zabbix"
              community.zabbix.zabbix_user:
                username: "super"
                state: present   
                name: "New Super"
                surname: "User"   
                passwd: "verysecretpass"
                role_name: Super admin role
                usrgrps:
                  - Zabbix administrators
                  - Internal 
                autologin: no  
                autologout: "0"

            - name: Disable default admin user
              vars:
                # Connect with new admin user
                ansible_user: "super"
                ansible_httpapi_pass: "verysecretpass"
              community.zabbix.zabbix_user:
                username: "Admin"
                passwd: "zabbix"
                usrgrps:
                  - "Disabled"
```
