### PR TITLE
zabbix_authentication - fix inability to update passwd_check_rules

### DIFF
--- a/changelogs/fragments/fix-zabbix-authentication-passwd-check-rules.yml
+++ b/changelogs/fragments/fix-zabbix-authentication-passwd-check-rules.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - zabbix_authentication - fix inability to update passwd_check_rules
+  - zabbix_authentication - fix inability to set passwd_check_rules to empty list

--- a/changelogs/fragments/fix-zabbix-authentication-passwd-check-rules.yml
+++ b/changelogs/fragments/fix-zabbix-authentication-passwd-check-rules.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_authentication - fix inability to update passwd_check_rules

--- a/plugins/modules/zabbix_authentication.py
+++ b/plugins/modules/zabbix_authentication.py
@@ -615,7 +615,7 @@ class Authentication(ZabbixBase):
                 else:
                     params["passwd_min_length"] = str(passwd_min_length)
 
-            if passwd_check_rules:
+            if passwd_check_rules is not None:
                 passwd_check_rules_values = [
                     "contain_uppercase_and_lowercase_letters",
                     "contain_digits",
@@ -644,11 +644,11 @@ class Authentication(ZabbixBase):
                                 msg="%s is invalid value for passwd_check_rules."
                                 % _passwd_check_rules_value
                             )
-                            params[
-                                "passwd_check_rules"
-                            ] += 2 ** zabbix_utils.helper_to_numeric_value(
-                                passwd_check_rules_values, _passwd_check_rules_value
-                            )
+                        params[
+                            "passwd_check_rules"
+                        ] += 2 ** zabbix_utils.helper_to_numeric_value(
+                            passwd_check_rules_values, _passwd_check_rules_value
+                        )
 
                 params["passwd_check_rules"] = str(params["passwd_check_rules"])
 

--- a/tests/integration/targets/setup_zabbix/tasks/main.yml
+++ b/tests/integration/targets/setup_zabbix/tasks/main.yml
@@ -50,8 +50,8 @@
     status_code: 200
   retries: 60
   delay: 5
-  until: check_login_result is defined and 'json' in check_login_result and 'result' in check_login_result.json
-  register: check_login_result
+  until: check_login_under64_result is defined and 'json' in check_login_under64_result and 'result' in check_login_under64_result.json
+  register: check_login_under64_result
   when: zabbix_version is version('6.4', '<')
 
 - name: check login to zabbix for Zabbix >= 6.4

--- a/tests/integration/targets/test_zabbix_authentication/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_authentication/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - block:
     - include_tasks: zabbix_authentication_tests.yml
+    - include_tasks: zabbix_authentication_test_passwd_check_rules.yml
 
   always:
     - name: Cleanup

--- a/tests/integration/targets/test_zabbix_authentication/tasks/zabbix_authentication_test_passwd_check_rules.yml
+++ b/tests/integration/targets/test_zabbix_authentication/tasks/zabbix_authentication_test_passwd_check_rules.yml
@@ -1,0 +1,50 @@
+---
+- name: Start with a known state with one rule enabled
+  community.zabbix.zabbix_authentication:
+    passwd_check_rules: "avoid_easy_to_guess"
+
+- name: Get the authentication rules
+  ansible.builtin.uri:
+    url: "{{ zabbix_api_server_url }}/api_jsonrpc.php"
+    method: POST
+    body:
+      jsonrpc: "2.0"
+      method: "authentication.get"
+      params:  {}
+      id: "1"
+      auth: "{{ check_login_result.json.result }}"
+    body_format: json
+    status_code: 200
+  register: get_auth_result
+
+
+# Internally the value of 8 represents an "avoid_easy_to_guess" rule
+- name: Assert that the passwd_check_rules is 8 (avoid_easy_to_guess)
+  ansible.builtin.assert:
+    that:
+      - get_auth_result.json.result.passwd_check_rules == "8"
+
+- name: Disable all password check rules
+  community.zabbix.zabbix_authentication:
+    passwd_check_rules: []
+
+- name: Get the authentication rules
+  ansible.builtin.uri:
+    url: "{{ zabbix_api_server_url }}/api_jsonrpc.php"
+    method: POST
+    body:
+      jsonrpc: "2.0"
+      method: "authentication.get"
+      params:  {}
+      id: "1"
+      auth: "{{ check_login_result.json.result }}"
+    body_format: json
+    status_code: 200
+  register: get_auth_result
+
+
+# Internally the value of 0 represents an empty password check rule set
+- name: Assert that the passwd_check_rules is empty
+  ansible.builtin.assert:
+    that:
+      - get_auth_result.json.result.passwd_check_rules == "0"

--- a/tests/integration/targets/test_zabbix_authentication/tasks/zabbix_authentication_test_passwd_check_rules.yml
+++ b/tests/integration/targets/test_zabbix_authentication/tasks/zabbix_authentication_test_passwd_check_rules.yml
@@ -3,6 +3,10 @@
   community.zabbix.zabbix_authentication:
     passwd_check_rules: "avoid_easy_to_guess"
 
+- name: Set the login result based on current zabbix version
+  set_fact:
+    login_result: "{{ check_login_under64_result if zabbix_version is version('6.4', '<') else check_login_result }}"
+
 - name: Get the authentication rules
   ansible.builtin.uri:
     url: "{{ zabbix_api_server_url }}/api_jsonrpc.php"
@@ -12,11 +16,10 @@
       method: "authentication.get"
       params:  {}
       id: "1"
-      auth: "{{ check_login_result.json.result }}"
+      auth: "{{ login_result.json.result }}"
     body_format: json
     status_code: 200
   register: get_auth_result
-
 
 # Internally the value of 8 represents an "avoid_easy_to_guess" rule
 - name: Assert that the passwd_check_rules is 8 (avoid_easy_to_guess)
@@ -37,11 +40,10 @@
       method: "authentication.get"
       params:  {}
       id: "1"
-      auth: "{{ check_login_result.json.result }}"
+      auth: "{{ login_result.json.result }}"
     body_format: json
     status_code: 200
   register: get_auth_result
-
 
 # Internally the value of 0 represents an empty password check rule set
 - name: Assert that the passwd_check_rules is empty


### PR DESCRIPTION
##### SUMMARY
zabbix_authentication - fix inability to update passwd_check_rules

* It seems there is a indentation-level python bug where the passwd_check_rules are updated in the zabbix_authentication module.
* There also was an issue with being able to pass in an empty list to the passwd_check_rules which has been resolved


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_authentication

##### ADDITIONAL INFORMATION
See the added integration tests for steps on how to reproduce
