### PR TITLE
The api task os role zabbix_agent should be executed with explicit become false

### DIFF
--- a/changelogs/fragments/1393-fix-api-tasks-in-zabbix-agent-role-to-run-without-sudo.yml
+++ b/changelogs/fragments/1393-fix-api-tasks-in-zabbix-agent-role-to-run-without-sudo.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_agent Role - Set become parameter explicitly to false for API tasks to run without sudo on the local computer.

--- a/roles/zabbix_agent/tasks/api.yml
+++ b/roles/zabbix_agent/tasks/api.yml
@@ -9,6 +9,7 @@
   until: zabbix_api_hostgroup_created is succeeded
   retries: 10
   delegate_to: "{{ zabbix_api_server_host }}"
+  become: false
   tags:
     - api
 
@@ -43,6 +44,7 @@
   until: zabbix_api_host_created is succeeded
   retries: 10
   delegate_to: "{{ zabbix_api_server_host }}"
+  become: false
   changed_when: false
   tags:
     - api
@@ -61,5 +63,6 @@
   retries: 10
   no_log: "{{ ansible_verbosity < 3 }}"
   delegate_to: "{{ zabbix_api_server_host }}"
+  become: false
   tags:
     - api


### PR DESCRIPTION
##### SUMMARY

Undo some changes of commit 5480ff750bc9dd9133cce7156e229853923761e9 

The community.zabbix.zabbix_host module with the delegate_to parameter should not be executed with "become true" if the role zabbix_agent is applied with "become true".

It is possible that the user executing the ansible script has sudo permission on the remote computer that the zabbix_agent role will be executed on, but does not have sudo permission on the local computer from which the ansible script is initially executed.

The same applies to the other modules of this task.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
role zabbix_agent
