### PR TITLE
fix: make statusport really optional

### DIFF
--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -33,7 +33,6 @@ zabbix_agent_persistentbufferperiod: 1h
 zabbix_agent_pluginsocket: /tmp/agent.plugin.sock
 zabbix_agent_plugintimeout: 3
 zabbix_agent_refreshactivechecks: 120
-zabbix_agent_statusport: 9999
 zabbix_agent_timeout: 3
 zabbix_agent_tlspsk_auto: false
 zabbix_agent_tlspskfile: /etc/zabbix/tls_psk_auto.secret


### PR DESCRIPTION
Status port is supposed to be configured when zabbix_agent2_statusport is defined. Since its defined in defaults its always defined. Therefore we remove it from default

roles/zabbix_agent/templates/agent.conf.j2
  - {{ (zabbix_agent_statusport is defined and zabbix_agent_statusport is not none) | ternary('', '# ') }}StatusPort={{ zabbix_agent_statusport | default('') }}

- replacement patch for #1376 as it was already deleted
