### PR TITLE
Cleanup of Windows tasks in zabbix_agent

### DIFF
--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -222,6 +222,8 @@ Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
 
 * `zabbix_agent_win_include`: The directory in which the Zabbix Agent specific configuration files are stored.
 * `zabbix_agent_win_logfile`: The full path to the logfile for the Zabbix Agent.
+* `zabbix_agent_win_controlsocket`: Windows specific value for `zabbix_agent_controlsocket`. Default: `\\.\pipe\agent.sock`
+* `zabbix_agent_win_pluginsocket`: Windows specific value for `zabbix_agent_pluginsocket`. Default: `\\.\pipe\agent.plugin.sock`
 * `zabbix_version_long`: The long (major.minor.patch) version of the Zabbix Agent. This will be used to generate the `zabbix_win_package` and `zabbix_win_download_link` variables. This takes precedence over `zabbix_agent_version`.
 * `zabbix_win_download_link`: The download url to the `win.zip` file.
 * `zabbix_win_firewall_management`: Enable Windows firewall management (add service and port to allow rules). Default: `True`

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -229,6 +229,7 @@ Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
 * `zabbix_win_install_dir_conf`: The directory where Zabbix configuration file needs to be installed.
 * `zabbix_win_install_dir_bin`: The directory where Zabbix binary file needs to be installed.
 * `zabbix_win_package`: file name pattern (zip only). This will be used to generate the `zabbix_win_download_link` variable.
+* `zabbix_win_config_remove`: Remove all existing configuration on update. Default `True`
 
 ## macOS Variables
 

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -115,6 +115,7 @@ zabbix_win_install_dir: 'C:\Zabbix'
 zabbix_win_install_dir_conf: '{{ zabbix_win_install_dir }}\conf'
 zabbix_win_install_dir_bin: '{{ zabbix_win_install_dir }}\bin'
 zabbix_win_firewall_management: true
+zabbix_win_config_remove: true
 
 # macOS Related
 zabbix_mac_package: zabbix_agent-{{ zabbix_version_long }}-macos-amd64-openssl.pkg

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -116,6 +116,8 @@ zabbix_win_install_dir_conf: '{{ zabbix_win_install_dir }}\conf'
 zabbix_win_install_dir_bin: '{{ zabbix_win_install_dir }}\bin'
 zabbix_win_firewall_management: true
 zabbix_win_config_remove: true
+zabbix_agent_win_controlsocket: '\\.\pipe\agent.sock'
+zabbix_agent_win_pluginsocket: '\\.\pipe\agent.plugin.sock'
 
 # macOS Related
 zabbix_mac_package: zabbix_agent-{{ zabbix_version_long }}-macos-amd64-openssl.pkg

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -110,6 +110,7 @@ zabbix_version_long: 5.2.4
 
 # Windows Related
 zabbix_win_download_url: https://cdn.zabbix.com/zabbix/binaries/stable
+zabbix_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long | regex_search('^\\d+\\.\\d+') }}/{{ zabbix_version_long }}/{{ zabbix_win_package | default(_win_package) }}"
 zabbix_win_install_dir: 'C:\Zabbix'
 zabbix_win_install_dir_conf: '{{ zabbix_win_install_dir }}\conf'
 zabbix_win_install_dir_bin: '{{ zabbix_win_install_dir }}\bin'

--- a/roles/zabbix_agent/handlers/main.yml
+++ b/roles/zabbix_agent/handlers/main.yml
@@ -22,6 +22,8 @@
   win_service:
     name: "{{ zabbix_win_svc_name }}"
     state: restarted
+  register: zabbix_win_restart_result
+  until: zabbix_win_restart_result is succeeded
   when:
     - ansible_os_family == "Windows"
 

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -5,34 +5,11 @@
     zabbix_agent_win_logfile: "{{ zabbix_agent_win_logfile is defined | ternary(zabbix_agent_win_logfile, zabbix_agent2_win_logfile) | default(_win_logfile) }}"
     zabbix_agent_win_package: "{{ zabbix_agent_win_package is defined | ternary(zabbix_agent_win_package, zabbix_agent2_win_package) | default(_win_package) }}"
     zabbix_agent_win_include: "{{ zabbix_agent_win_include is defined | ternary(zabbix_agent_win_include, zabbix_agent2_win_include) | default(_win_include) }}"
-
-- name: "Windows | Set default architecture"
-  ansible.builtin.set_fact:
-    windows_arch: 32
-  tags:
-    - always
-
-- name: "Windows | Override architecture if 64-bit"
-  ansible.builtin.set_fact:
-    windows_arch: 64
-  when:
-    - '"64" in ansible_architecture'
-  tags:
-    - always
-
-- name: "Windows | Set path to zabbix.exe"
-  ansible.builtin.set_fact:
-    zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\win{{ windows_arch }}\zabbix_agentd.exe'
-  tags:
-    - always
-
-- name: "Windows | Set variables specific to Zabbix"
-  ansible.builtin.set_fact:
     zabbix_win_svc_name: Zabbix Agent
-    zabbix_win_exe_path: '{{ zabbix_win_install_dir }}\bin\zabbix_agentd.exe'
+    zabbix_win_exe_path: '{{ zabbix_win_install_dir_bin }}\zabbix_agentd.exe'
     zabbix_win_config_name: "zabbix_agentd.conf"
     zabbix2_win_svc_name: Zabbix Agent 2
-    zabbix2_win_exe_path: '{{ zabbix_win_install_dir }}\bin\zabbix_agent2.exe'
+    zabbix2_win_exe_path: '{{ zabbix_win_install_dir_bin }}\zabbix_agent2.exe'
     zabbix2_win_config_name: "zabbix_agent2.conf"
   tags:
     - always
@@ -60,7 +37,7 @@
 - name: "Windows | Set facts current zabbix agent installation"
   ansible.builtin.set_fact:
     zabbix_agent_1_binary_exist: true
-    zabbix_agent_1_version: zabbix_win_exe_info.results[0].win_file_version.product_version
+    zabbix_agent_1_version: "{{ zabbix_win_exe_info.results[0].win_file_version.product_version }}"
   when:
     - zabbix_win_exe_info.results[0] is defined
     - zabbix_win_exe_info.results[0].item.stat.exists
@@ -72,7 +49,7 @@
 - name: "Windows | Set facts current zabbix agent installation (agent 2)"
   ansible.builtin.set_fact:
     zabbix_agent_2_binary_exist: true
-    zabbix_agent_2_version: zabbix_win_exe_info.results[1].win_file_version.product_version
+    zabbix_agent_2_version: "{{ zabbix_win_exe_info.results[1].win_file_version.product_version }}"
   when:
     - zabbix_win_exe_info.results[1] is defined
     - zabbix_win_exe_info.results[1].item.stat.exists
@@ -83,7 +60,7 @@
 
 - name: "Windows | Check Zabbix service"
   ansible.windows.win_service:
-    name: "{{ (item.item.stat.path == zabbix_win_exe_path ) | ternary(zabbix_win_svc_name,zabbix2_win_svc_name) }}"
+    name: "{{ (item.item.stat.path == zabbix_win_exe_path) | ternary(zabbix_win_svc_name, zabbix2_win_svc_name) }}"
   register: zabbix_service_info
   when: item.item.stat.exists
   with_items: "{{ zabbix_win_exe_info.results }}"
@@ -176,6 +153,8 @@
     state: directory
   with_items:
     - "{{ zabbix_win_install_dir }}"
+    - "{{ zabbix_win_install_dir_conf }}"
+    - "{{ zabbix_win_install_dir_bin }}"
   tags:
     - install
 

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -1,16 +1,20 @@
 ---
-- name: "Windows | Set some variables"
+- name: "Windows | Set base variables"
   ansible.builtin.set_fact:
-    zabbix_agent_win_download_link: "{{ zabbix_agent_win_download_link is defined | ternary(zabbix_agent_win_download_link, zabbix_agent2_win_download_link) | default(_win_download_link) }}"
     zabbix_agent_win_logfile: "{{ zabbix_agent_win_logfile is defined | ternary(zabbix_agent_win_logfile, zabbix_agent2_win_logfile) | default(_win_logfile) }}"
     zabbix_agent_win_package: "{{ zabbix_agent_win_package is defined | ternary(zabbix_agent_win_package, zabbix_agent2_win_package) | default(_win_package) }}"
     zabbix_agent_win_include: "{{ zabbix_agent_win_include is defined | ternary(zabbix_agent_win_include, zabbix_agent2_win_include) | default(_win_include) }}"
+    zabbix_win_install_dir_setup: '{{ zabbix_win_install_dir }}\setup'
+    zabbix_win_package: "{{ zabbix_win_package | default(_win_package) }}"
     zabbix_win_svc_name: Zabbix Agent
+    zabbix_win_exe_name: 'zabbix_agentd.exe'
     zabbix_win_exe_path: '{{ zabbix_win_install_dir_bin }}\zabbix_agentd.exe'
     zabbix_win_config_name: "zabbix_agentd.conf"
     zabbix2_win_svc_name: Zabbix Agent 2
+    zabbix2_win_exe_name: 'zabbix_agent2.exe'
     zabbix2_win_exe_path: '{{ zabbix_win_install_dir_bin }}\zabbix_agent2.exe'
     zabbix2_win_config_name: "zabbix_agent2.conf"
+
   tags:
     - always
 
@@ -108,7 +112,6 @@
 - name: "Windows | Stop Zabbix agent v1"
   ansible.windows.win_service:
     name: "{{ zabbix_win_svc_name }}"
-    start_mode: auto
     state: stopped
   when:
     - zabbix_agent_version_change | default(false) or zabbix_agent2
@@ -117,7 +120,6 @@
 - name: "Windows | Stop Zabbix agent v2"
   ansible.windows.win_service:
     name: "{{ zabbix2_win_svc_name }}"
-    start_mode: auto
     state: stopped
   when:
     - zabbix_agent_version_change | default(false) or not zabbix_agent2
@@ -139,6 +141,10 @@
   ansible.windows.win_file:
     path: "{{ zabbix_win_install_dir }}"
     state: absent
+  register: zabbix_agent_dir_remove_result
+  until: zabbix_agent_dir_remove_result is succeeded
+  retries: 5
+  delay: 15
   when:
     ((zabbix_agent_version_change | default(false) or zabbix_agent2) and zabbix_agent_1_binary_exist | default(false)) or
     ((zabbix_agent_version_change | default(false) or not zabbix_agent2) and zabbix_agent_2_binary_exist | default(false))
@@ -146,6 +152,23 @@
 ###################
 # install section #
 ###################
+
+- name: "Windows | Set installation settings (agent 2)"
+  ansible.builtin.set_fact:
+    zabbix_win_exe_path: "{{ zabbix2_win_exe_path }}"
+    zabbix_win_exe_name: "{{ zabbix2_win_exe_name }}"
+    zabbix_win_config_name: "{{ zabbix2_win_config_name }}"
+    zabbix_win_svc_name: "{{ zabbix2_win_svc_name }}"
+  when: zabbix_agent2 | bool
+  tags:
+    - install
+
+- name: "Windows | Check if agent binaries in place"
+  ansible.windows.win_stat:
+    path: "{{ zabbix_win_exe_path }}"
+  register: zabbix_windows_binaries
+  tags:
+    - install
 
 - name: "Windows | Create directory structure"
   ansible.windows.win_file:
@@ -155,6 +178,8 @@
     - "{{ zabbix_win_install_dir }}"
     - "{{ zabbix_win_install_dir_conf }}"
     - "{{ zabbix_win_install_dir_bin }}"
+    - "{{ zabbix_win_install_dir_setup }}"
+  when: zabbix_agent_version_change | default(false) or not zabbix_windows_binaries.stat.exists
   tags:
     - install
 
@@ -169,35 +194,19 @@
   tags:
     - install
 
-- name: "Windows | Set installation settings (agent 2)"
-  ansible.builtin.set_fact:
-    zabbix_win_package: "{{ zabbix_win_package | default(_win_package) }}"
-    zabbix_win_download_link: "{{ zabbix_win_download_link | default(_win_download_link) }}"
-    zabbix_win_exe_path: "{{ zabbix2_win_exe_path }}"
-    zabbix_win_config_name: "{{ zabbix2_win_config_name }}"
-    zabbix_win_svc_name: "{{ zabbix2_win_svc_name }}"
-  when: zabbix_agent2 | bool
-  tags:
-    - install
-
 - name: "Windows | Check if agent file is already downloaded"
   ansible.windows.win_stat:
-    path: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
+    path: '{{ zabbix_win_install_dir_setup }}\{{ zabbix_win_package }}'
+  when:
+    - zabbix_agent_version_change | default(false) or not zabbix_windows_binaries.stat.exists
   register: file_info
-  tags:
-    - install
-
-- name: "Windows | Check if agent binaries in place"
-  ansible.windows.win_stat:
-    path: "{{ zabbix_win_exe_path }}"
-  register: zabbix_windows_binaries
   tags:
     - install
 
 - name: "Windows | Download Zabbix Agent Zip file"
   ansible.windows.win_get_url:
     url: "{{ zabbix_win_download_link }}"
-    dest: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
+    dest: '{{ zabbix_win_install_dir_setup }}\{{ zabbix_win_package }}'
     url_username: "{{ zabbix_download_user | default(omit) }}"
     url_password: "{{ zabbix_download_pass | default(omit) }}"
     force: false
@@ -206,8 +215,8 @@
     validate_certs: "{{ zabbix_download_validate_certs | default(False) | bool }}"
     timeout: "{{ zabbix_download_timeout | default(120) | int }}"
   when:
+    - zabbix_agent_version_change | default(false) or not zabbix_windows_binaries.stat.exists
     - not file_info.stat.exists
-    - not zabbix_windows_binaries.stat.exists
   register: zabbix_agent_win_download_zip
   until: zabbix_agent_win_download_zip is succeeded
   throttle: "{{ zabbix_download_throttle | default(5) | int }}"
@@ -216,61 +225,56 @@
 
 - name: "Windows | Unzip file"
   community.windows.win_unzip:
-    src: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
-    dest: "{{ zabbix_win_install_dir }}"
-    creates: "{{ zabbix_win_exe_path }}"
-  tags:
-    - install
-
-- name: "Windows | Cleanup downloaded Zabbix Agent Zip file"
-  ansible.windows.win_file:
-    path: '{{ zabbix_win_install_dir }}\{{ zabbix_win_package }}'
-    state: absent
+    src: '{{ zabbix_win_install_dir_setup }}\{{ zabbix_win_package }}'
+    dest: "{{ zabbix_win_install_dir_setup }}"
   when:
-    - zabbix_agent_win_download_zip.changed
+    - zabbix_agent_version_change | default(false) or not zabbix_windows_binaries.stat.exists
+    - zabbix_agent_win_download_zip is changed or file_info.stat.exists
   tags:
     - install
 
 - name: "Windows | Copy binary files to expected location"
   ansible.windows.win_copy:
-    src: "{{ zabbix_win_install_dir }}\\bin\\{{ item }}"
+    src: "{{ zabbix_win_install_dir_setup }}\\bin\\{{ item }}"
     dest: "{{ zabbix_win_install_dir_bin }}\\{{ item }}"
-    remote_src: yes
+    remote_src: true
   loop:
-    - zabbix_agentd.exe
+    - "{{ zabbix_win_exe_name }}"
     - zabbix_sender.exe
+    - zabbix_get.exe
   when:
-    - zabbix_win_install_dir_bin is defined
-    - not (zabbix_agent2 | bool)
+    - zabbix_agent_version_change | default(false) or not zabbix_windows_binaries.stat.exists
+    - zabbix_agent_win_download_zip is changed or file_info.stat.exists
   tags:
     - install
 
-- name: "Windows | Copy binary files to expected location (zabbix-agent2)"
+- name: "Windows | Copy initial configuration to expected location"
   ansible.windows.win_copy:
-    src: "{{ zabbix_win_install_dir }}\\bin\\{{ item }}"
-    dest: "{{ zabbix_win_install_dir_bin }}\\{{ item }}"
-    remote_src: yes
-  loop:
-    - zabbix_agent2.exe
+    src: "{{ zabbix_win_install_dir_setup }}\\conf\\{{ zabbix_win_config_name }}"
+    dest: "{{ zabbix_win_install_dir_conf }}\\{{ zabbix_win_config_name }}"
+    force: false
+    remote_src: true
   when:
-    - zabbix_win_install_dir_bin is defined
-    - zabbix_agent2 | bool
+    - zabbix_agent_win_download_zip is changed or file_info.stat.exists | default(false)
   tags:
     - install
 
-- set_fact:
-    zabbix_win_exe_path: "{{ zabbix_win_install_dir_bin }}\\zabbix_agentd.exe"
+- name: "Windows | Copy plugin configuration to expected location on Agent 2"
+  ansible.windows.win_copy:
+    src: "{{ zabbix_win_install_dir_setup }}\\conf\\zabbix_agent2.d\\plugins.d"
+    dest: "{{ zabbix_win_install_dir_conf }}\\zabbix_agent2.d\\plugins.d"
+    force: false
+    remote_src: true
   when:
-    - zabbix_win_install_dir_bin is defined
-    - not (zabbix_agent2 | bool)
+    - zabbix_agent2
+    - zabbix_agent_win_download_zip is changed or file_info.stat.exists | default(false)
   tags:
     - install
 
-- set_fact:
-    zabbix_win_exe_path: "{{ zabbix_win_install_dir_bin }}\\zabbix_agent2.exe"
-  when:
-    - zabbix_win_install_dir_bin is defined
-    - zabbix_agent2 | bool
+- name: "Windows | Cleanup temporary setup directory"
+  ansible.windows.win_file:
+    path: '{{ zabbix_win_install_dir_setup }}'
+    state: absent
   tags:
     - install
 

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -14,7 +14,6 @@
     zabbix2_win_exe_name: 'zabbix_agent2.exe'
     zabbix2_win_exe_path: '{{ zabbix_win_install_dir_bin }}\zabbix_agent2.exe'
     zabbix2_win_config_name: "zabbix_agent2.conf"
-
   tags:
     - always
 
@@ -137,9 +136,9 @@
     - zabbix_agent_version_change | default(false) or not zabbix_agent2
     - zabbix_agent_2_service_exist | default(false)
 
-- name: "Windows | Removing Zabbix Directory"
+- name: "Windows | Removing Zabbix bin Directory"
   ansible.windows.win_file:
-    path: "{{ zabbix_win_install_dir }}"
+    path: "{{ zabbix_win_install_dir_bin }}"
     state: absent
   register: zabbix_agent_dir_remove_result
   until: zabbix_agent_dir_remove_result is succeeded
@@ -148,6 +147,20 @@
   when:
     ((zabbix_agent_version_change | default(false) or zabbix_agent2) and zabbix_agent_1_binary_exist | default(false)) or
     ((zabbix_agent_version_change | default(false) or not zabbix_agent2) and zabbix_agent_2_binary_exist | default(false))
+
+- name: "Windows | Removing Zabbix conf Directory"
+  ansible.windows.win_file:
+    path: "{{ zabbix_win_install_dir_conf }}"
+    state: absent
+  register: zabbix_agent_dir_remove_result
+  until: zabbix_agent_dir_remove_result is succeeded
+  retries: 5
+  delay: 15
+  when:
+    - zabbix_win_config_remove
+    - >
+      ((zabbix_agent_version_change | default(false) or zabbix_agent2) and zabbix_agent_1_binary_exist | default(false)) or
+      ((zabbix_agent_version_change | default(false) or not zabbix_agent2) and zabbix_agent_2_binary_exist | default(false))
 
 ###################
 # install section #

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -20,7 +20,7 @@
 - name: "Windows | Check if Zabbix agent is present"
   ansible.windows.win_stat:
     path: "{{ item }}"
-  with_items:
+  loop:
     - "{{ zabbix_win_exe_path }}"
     - "{{ zabbix2_win_exe_path }}"
   register: agent_file_info
@@ -33,7 +33,9 @@
   register: zabbix_win_exe_info
   when:
     - item.stat.exists | bool
-  with_items: "{{ agent_file_info.results }}"
+  loop: "{{ agent_file_info.results }}"
+  loop_control:
+    label: "{{ item.item }}"
   tags:
     - always
 
@@ -66,7 +68,9 @@
     name: "{{ (item.item.stat.path == zabbix_win_exe_path) | ternary(zabbix_win_svc_name, zabbix2_win_svc_name) }}"
   register: zabbix_service_info
   when: item.item.stat.exists
-  with_items: "{{ zabbix_win_exe_info.results }}"
+  loop: "{{ zabbix_win_exe_info.results }}"
+  loop_control:
+    label: "{{ item.item.item }}"
   tags:
     - always
 
@@ -187,7 +191,7 @@
   ansible.windows.win_file:
     path: "{{ item }}"
     state: directory
-  with_items:
+  loop:
     - "{{ zabbix_win_install_dir }}"
     - "{{ zabbix_win_install_dir_conf }}"
     - "{{ zabbix_win_install_dir_bin }}"
@@ -198,10 +202,8 @@
 
 - name: "Windows | Create directory structure, includes"
   ansible.windows.win_file:
-    path: "{{ item }}"
+    path: "{{ zabbix_agent_win_include }}"
     state: directory
-  with_items:
-    - "{{ zabbix_agent_win_include }}"
   when:
     - ('.conf' not in zabbix_agent_win_include)
   tags:

--- a/roles/zabbix_agent/tasks/Windows.yml
+++ b/roles/zabbix_agent/tasks/Windows.yml
@@ -250,13 +250,9 @@
 
 - name: "Windows | Copy binary files to expected location"
   ansible.windows.win_copy:
-    src: "{{ zabbix_win_install_dir_setup }}\\bin\\{{ item }}"
-    dest: "{{ zabbix_win_install_dir_bin }}\\{{ item }}"
+    src: "{{ zabbix_win_install_dir_setup }}\\bin\\"
+    dest: "{{ zabbix_win_install_dir_bin }}\\"
     remote_src: true
-  loop:
-    - "{{ zabbix_win_exe_name }}"
-    - zabbix_sender.exe
-    - zabbix_get.exe
   when:
     - zabbix_agent_version_change | default(false) or not zabbix_windows_binaries.stat.exists
     - zabbix_agent_win_download_zip is changed or file_info.stat.exists
@@ -265,8 +261,8 @@
 
 - name: "Windows | Copy initial configuration to expected location"
   ansible.windows.win_copy:
-    src: "{{ zabbix_win_install_dir_setup }}\\conf\\{{ zabbix_win_config_name }}"
-    dest: "{{ zabbix_win_install_dir_conf }}\\{{ zabbix_win_config_name }}"
+    src: "{{ zabbix_win_install_dir_setup }}\\conf\\"
+    dest: "{{ zabbix_win_install_dir_conf }}\\"
     force: false
     remote_src: true
   when:

--- a/roles/zabbix_agent/tasks/Windows_conf.yml
+++ b/roles/zabbix_agent/tasks/Windows_conf.yml
@@ -1,15 +1,10 @@
 ---
-- name: "Set Log File Info"
+- name: "Set Windows specific configuration facts"
   ansible.builtin.set_fact:
     zabbix_agent_logfile: "{{ zabbix_agent_win_logfile is defined | ternary(zabbix_agent_win_logfile, zabbix_agent2_win_logfile) | default(_win_logfile) }}"
-
-- name: "Set Include Path Info"
-  ansible.builtin.set_fact:
     zabbix_agent_include_dir: "{{ zabbix_agent_win_include is defined | ternary(zabbix_agent_win_include, zabbix_agent2_win_include) | default(_win_include) }}"
-
-- name: "Set Control Socket"
-  ansible.builtin.set_fact:
-    zabbix_agent_controlsocket: "\\\\.\\pipe\\agent.sock"
+    zabbix_agent_controlsocket: "{{ zabbix_agent_win_controlsocket | default('\\\\.\\pipe\\agent.sock') }}"
+    zabbix_agent_pluginsocket: "{{ zabbix_agent_win_pluginsocket | default('\\\\.\\pipe\\agent.plugin.sock') }}"
 
 - name: "Set default ip address for zabbix_agent_ip"
   ansible.builtin.set_fact:

--- a/roles/zabbix_agent/tasks/Windows_conf.yml
+++ b/roles/zabbix_agent/tasks/Windows_conf.yml
@@ -32,7 +32,6 @@
   ansible.windows.win_service:
     name: "{{ zabbix_win_svc_name }}"
     start_mode: auto
-    state: started
     failure_actions:
       - type: restart
         delay_ms: 5000
@@ -41,6 +40,7 @@
       - type: restart
         delay_ms: 20000
     failure_reset_period_sec: 86400
+  notify: restart win zabbix agent
   tags:
     - config
 

--- a/roles/zabbix_agent/tasks/Windows_conf.yml
+++ b/roles/zabbix_agent/tasks/Windows_conf.yml
@@ -3,8 +3,8 @@
   ansible.builtin.set_fact:
     zabbix_agent_logfile: "{{ zabbix_agent_win_logfile is defined | ternary(zabbix_agent_win_logfile, zabbix_agent2_win_logfile) | default(_win_logfile) }}"
     zabbix_agent_include_dir: "{{ zabbix_agent_win_include is defined | ternary(zabbix_agent_win_include, zabbix_agent2_win_include) | default(_win_include) }}"
-    zabbix_agent_controlsocket: "{{ zabbix_agent_win_controlsocket | default('\\\\.\\pipe\\agent.sock') }}"
-    zabbix_agent_pluginsocket: "{{ zabbix_agent_win_pluginsocket | default('\\\\.\\pipe\\agent.plugin.sock') }}"
+    zabbix_agent_controlsocket: "{{ zabbix_agent_win_controlsocket }}"
+    zabbix_agent_pluginsocket: "{{ zabbix_agent_win_pluginsocket }}"
 
 - name: "Set default ip address for zabbix_agent_ip"
   ansible.builtin.set_fact:

--- a/roles/zabbix_agent/vars/agent2_vars.yml
+++ b/roles/zabbix_agent/vars/agent2_vars.yml
@@ -5,7 +5,6 @@ _include:
   - /etc/zabbix/zabbix_agent2.d/plugins.d
 _tls_subject: "{{ zabbix_agent_tlsservercertsubject | default(omit) }}" # FIXME this is not correct and should be removed with 2.0.0, here only to prevent regression
 _win_package: zabbix_agent2-{{ zabbix_version_long }}-windows-amd64-openssl-static.zip
-_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long | regex_search('^\\d+\\.\\d+') }}/{{ zabbix_version_long }}/{{ zabbix_win_package | default(_win_package) }}"
 _win_logfile: '{{ zabbix_win_install_dir }}\zabbix_agent2.log'
 _win_include: '{{ zabbix_win_install_dir_conf }}\zabbix_agent2.d'
 _agent_service: zabbix-agent2

--- a/roles/zabbix_agent/vars/agent_vars.yml
+++ b/roles/zabbix_agent/vars/agent_vars.yml
@@ -3,7 +3,6 @@ _logfile: /var/log/zabbix/zabbix_agentd.log
 _include: /etc/zabbix/zabbix_agentd.d
 _tls_subject: "{{ zabbix_agent_tlsservercertsubject | default(omit) }}" # FIXME this is not correct and should be removed with 2.0.0, here only to prevent regression
 _win_package: zabbix_agent-{{ zabbix_version_long }}-windows-amd64-openssl.zip
-_win_download_link: "{{ zabbix_win_download_url }}/{{ zabbix_version_long | regex_search('^\\d+\\.\\d+') }}/{{ zabbix_version_long }}/{{ zabbix_win_package | default(_win_package) }}"
 _win_logfile: '{{ zabbix_win_install_dir }}\zabbix_agentd.log'
 _win_include: '{{ zabbix_win_install_dir_conf }}\zabbix_agent.d'
 _agent_service: zabbix-agent


### PR DESCRIPTION
##### SUMMARY
This change cleans up the Windows tasks of the zabbix_agent role and fixes several issues.
No existing functionality is changed or removed (hopefully).

- Add windows specific version of `zabbix_agent_win_controlsocket` and `zabbix_agent_win_pluginsocket` to avoid setting unix default values
- Add `zabbix_win_config_remove` variable to optionally prevent deletion of extra configuration inside of zabbix_agent2.d on updates
- Add loop labels to reduce output clutter
- Fix detection of currently installed version (solves the same issue as #1139 but only noticed the PR while already submitting)
- Fix usage of `zabbix_win_install_dir_` variables throughout all tasks and add temporary "setup" direcory to avoid issues when using different paths
- Clean up some never used variables and combine some redundant set_facts tasks
- Avoid unneeded agent restarts which caused errors on some hosts

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_agent (Windows)

##### ADDITIONAL INFORMATION
I've verified the changes on Windows Server versions 2016, 2019 and 2022 with Zabbix Agent 1 and 2 on versions 6.0 and 7.0.