### PR TITLE
Use SSL for database connection when zabbix_server_dbtlsconnect is set

### DIFF
--- a/roles/zabbix_server/tasks/initialize-mysql.yml
+++ b/roles/zabbix_server/tasks/initialize-mysql.yml
@@ -45,6 +45,7 @@
         login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
         login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
         login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
+        check_hostname: "{{ zabbix_server_dbtlsconnect is defined and zabbix_server_dbtlsconnect != '' }}"
         name: "{{ zabbix_server_dbname }}"
         encoding: "{{ zabbix_server_dbencoding }}"
         collation: "{{ zabbix_server_dbcollation }}"
@@ -58,6 +59,7 @@
         login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
         login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
         login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
+        check_hostname: "{{ zabbix_server_dbtlsconnect is defined and zabbix_server_dbtlsconnect != '' }}"
         name: "{{ zabbix_server_dbuser }}"
         password: "{{ zabbix_server_dbpassword }}"
         host: "{{ zabbix_server_privileged_host }}"
@@ -82,6 +84,7 @@
         login_host: "{{ zabbix_server_dbhost }}"
         login_port: "{{ zabbix_server_dbport }}"
         login_db: "{{ zabbix_server_dbname }}"
+        check_hostname: "{{ zabbix_server_dbtlsconnect is defined and zabbix_server_dbtlsconnect != '' }}"
         query: "SELECT mandatory FROM dbversion"
   rescue:
     - name: "MySQL | Get and set schema import overrides"
@@ -95,6 +98,7 @@
             login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
             login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
             login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
+            check_hostname: "{{ zabbix_server_dbtlsconnect is defined and zabbix_server_dbtlsconnect != '' }}"
           loop:
             - innodb_default_row_format
             - log_bin_trust_function_creators
@@ -111,6 +115,7 @@
             login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
             login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
             login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
+            check_hostname: "{{ zabbix_server_dbtlsconnect is defined and zabbix_server_dbtlsconnect != '' }}"
           when: item.msg != _mysql_schema_import_overrides[item.name]
           loop: "{{ _mysql_variable_defaults.results }}"
           loop_control:
@@ -130,6 +135,7 @@
             login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
             login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
             login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
+            check_hostname: "{{ zabbix_server_dbtlsconnect is defined and zabbix_server_dbtlsconnect != '' }}"
 
     - name: "MySQL | Import schema"
       community.mysql.mysql_db:
@@ -137,6 +143,7 @@
         login_password: "{{ zabbix_server_dbpassword }}"
         login_host: "{{ zabbix_server_dbhost }}"
         login_port: "{{ zabbix_server_dbport }}"
+        check_hostname: "{{ zabbix_server_dbtlsconnect is defined and zabbix_server_dbtlsconnect != '' }}"
         name: "{{ zabbix_server_dbname }}"
         encoding: "{{ zabbix_server_dbencoding }}"
         collation: "{{ zabbix_server_dbcollation }}"
@@ -154,6 +161,7 @@
         login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
         login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
         login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
+        check_hostname: "{{ zabbix_server_dbtlsconnect is defined and zabbix_server_dbtlsconnect != '' }}"
       loop: "{{ _mysql_variable_defaults.results | default([]) }}"
       loop_control:
         label: "{{ item.name }}: {{ item.msg }}"


### PR DESCRIPTION
##### SUMMARY
A reworking of https://github.com/ansible-collections/community.zabbix/pull/951

I am setting up Zabbix with a database where SSL is enforced. Zabbix itself works fine with this, thanks to the `zabbix_server_dbtlsconnect` parameter, but a few of the playbook's setup tasks try to connect without TLS, which fails. This adds a parameter to enable TLS if the server would also be set to use it.

This isn't a perfect solution, but the `community.mysql` collection doesn't provide a way to use a TLS connection without setting one of `check_hostname`, `ca_cert`, `client_key`, or `client_hostname`, and we don't (can't, in our case) specify a cert/key. This _will_ potentially fail when the host presents a cert with the wrong hostname (which can happen if `zabbix_server_dbtlsconnect` is set to `required` rather than `verify_ca` or `verify_full`). However, there's not a way to enable TLS without setting one of these options without _also_ changing the MySQL collection.

There's some more background on this issue in the `community.mysql` collection: https://github.com/ansible-collections/community.mysql/issues/90

(I'm not convinced this is the right approach, though it does fix our particular use case! If there's another way to fix this that would be better, I'd appreciate the feedback and can try to update the PR if desired.)

I've tested this to work in my configuration, and believe the only configuration it should break is cases where the server has a valid TLS certificate but assigned to the wrong hostname, as mentioned above.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_server role