### PR TITLE
Make database client installation optional for mysql on Debian/Ubuntu

### DIFF
--- a/roles/zabbix_proxy/vars/Debian.yml
+++ b/roles/zabbix_proxy/vars/Debian.yml
@@ -28,20 +28,20 @@ _zabbix_proxy_pgsql_dependencies:
 _zabbix_proxy_mysql_dependencies:
   # Debian
   "12":
-    - default-mysql-client
+    - "{{ zabbix_proxy_install_database_client | ternary('default-mysql-client', '') }}"
     - python3-pymysql
   "11":
-    - default-mysql-client
+    - "{{ zabbix_proxy_install_database_client | ternary('default-mysql-client', '') }}"
     - python3-pymysql
   # Ubuntu
   "24":
-    - default-mysql-client
+    - "{{ zabbix_proxy_install_database_client | ternary('default-mysql-client', '') }}"
     - python3-mysqldb
   "22":
-    - default-mysql-client
+    - "{{ zabbix_proxy_install_database_client | ternary('default-mysql-client', '') }}"
     - python3-pymysql
   "20":
-    - default-mysql-client
+    - "{{ zabbix_proxy_install_database_client | ternary('default-mysql-client', '') }}"
     - python3-pymysql
 
 _zabbix_proxy_sqlite3_dependencies:


### PR DESCRIPTION
##### SUMMARY
`zabbix_proxy_install_database_client` is not honored for mysql on Debian/Ubuntu like it is for RedHat and Suse.

Installing `default-mysql-client` removes MariaDB packages.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_proxy role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# apt-get install default-mysql-client
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  galera-4 libcgi-fast-perl libcgi-pm-perl libclone-perl libconfig-inifiles-perl libdbd-mysql-perl libdbi-perl libencode-locale-perl
  libfcgi-bin libfcgi-perl libfcgi0ldbl libhtml-parser-perl libhtml-tagset-perl libhtml-template-perl libhttp-date-perl libhttp-message-perl
  libio-html-perl liblwp-mediatypes-perl libmariadb3 libsnappy1v5 libtimedate-perl liburi-perl liburing2 mariadb-common
  mariadb-server-core-10.6 socat
Use 'apt autoremove' to remove them.
The following additional packages will be installed:
  mysql-client-8.0 mysql-client-core-8.0
The following packages will be REMOVED:
  mariadb-client mariadb-client-10.6 mariadb-client-core-10.6 mariadb-server mariadb-server-10.6
The following NEW packages will be installed:
  default-mysql-client mysql-client-8.0 mysql-client-core-8.0
0 upgraded, 3 newly installed, 5 to remove and 5 not upgraded.
Need to get 2741 kB of archives.
After this operation, 45.6 MB disk space will be freed.
Do you want to continue? [Y/n]
```
