### PR TITLE
Add append option to zabbix_maintenance module

### DIFF
--- a/changelogs/fragments/pr_1438.yml
+++ b/changelogs/fragments/pr_1438.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_maintenance - Added ability to append host or host groups to existing maintenance.

--- a/tests/integration/targets/test_zabbix_maintenance/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_maintenance/tasks/main.yml
@@ -323,6 +323,40 @@
     that:
       - create_maintenance_active_till_again_result.changed is sameas false
 
+- name: "test - Create maintenance with an append param"
+  community.zabbix.zabbix_maintenance:
+    name: maintenance
+    host_names:
+      - Zabbix server
+    host_groups:
+      - Linux servers
+    append: true
+    active_since: "1979-09-19 00:00"
+    active_till: "1979-09-19 23:59"
+    state: present
+  register: create_maintenance_append_result
+
+- ansible.builtin.assert:
+    that:
+      - create_maintenance_append_result.changed is sameas true
+
+- name: "test - Create maintenance with an append param(again - expectations: no change will occur)"
+  community.zabbix.zabbix_maintenance:
+    name: maintenance
+    host_names:
+      - Zabbix server
+    host_groups:
+      - Linux servers
+    append: true
+    active_since: "1979-09-19 00:00"
+    active_till: "1979-09-19 23:59"
+    state: present
+  register: create_maintenance_append_again_result
+
+- ansible.builtin.assert:
+    that:
+      - create_maintenance_append_again_result.changed is sameas false
+
 - name: "test - Delete maintenance"
   community.zabbix.zabbix_maintenance:
     name: maintenance


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add append option to zabbix_maintenance module to append hosts or host groups to existing maintenance.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

community.zabbix.zabbix_maintenance

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
