### PR TITLE
zabbix_inventory - do not require login credentials when auth_token is provided

### DIFF
--- a/changelogs/fragments/1439-inventory-required-fix.yml
+++ b/changelogs/fragments/1439-inventory-required-fix.yml
@@ -1,3 +1,3 @@
 bugfixes:
   - zabbix inventory plugin - do not require ``login_user`` and ``login_password`` to be present
-  when ``auth_token`` is provided (https://github.com/ansible-collections/community.zabbix/pull/1439).
+    when ``auth_token`` is provided (https://github.com/ansible-collections/community.zabbix/pull/1439).

--- a/changelogs/fragments/1439-inventory-required-fix.yml
+++ b/changelogs/fragments/1439-inventory-required-fix.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - zabbix inventory plugin - do not require ``login_user`` and ``login_password`` to be present
+  when ``auth_token`` is provided (https://github.com/ansible-collections/community.zabbix/pull/1439).

--- a/plugins/inventory/zabbix_inventory.py
+++ b/plugins/inventory/zabbix_inventory.py
@@ -190,14 +190,12 @@ options:
         description:
             - Zabbix user name.
         type: str
-        required: true
         env:
           - name: ZABBIX_USERNAME
     login_password:
         description:
             - Zabbix user password.
         type: str
-        required: true
         env:
           - name: ZABBIX_PASSWORD
     auth_token:
@@ -205,7 +203,6 @@ options:
             - Zabbix authentication token (see https://www.zabbix.com/documentation/current/en/manual/web_interface/frontend_sections/users/api_tokens)
             - If provided then C(login_user) and C(login_password) are ignored
         type: str
-        required: false
     http_login_user:
         description:
             - Basic Auth login


### PR DESCRIPTION
##### SUMMARY
Simple fix to not require `login_user` and `login_password` to be entered when `auth_token` is used.

Resolves #1434, resolves #1348

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.zabbix.zabbix_inventory