### PR TITLE
Add tag support for zabbix_group_events_info module

### DIFF
--- a/changelogs/fragments/pr_1446.yml
+++ b/changelogs/fragments/pr_1446.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_group_events_info - add tag support

--- a/plugins/modules/zabbix_group_events_info.py
+++ b/plugins/modules/zabbix_group_events_info.py
@@ -276,10 +276,10 @@ class Host(ZabbixBase):
         output = "extend"
         if tags:
             triggers_list = self._zapi.trigger.get({"output": output, "groupids": group_id,
-                                                "min_severity": trigger_severity, "tags": tags})
+                                                    "min_severity": trigger_severity, "tags": tags})
         else:
             triggers_list = self._zapi.trigger.get({"output": output, "groupids": group_id,
-                                                "min_severity": trigger_severity})
+                                                    "min_severity": trigger_severity})
         return triggers_list
 
     def get_last_event_by_trigger_id(self, triggers_id):

--- a/plugins/modules/zabbix_group_events_info.py
+++ b/plugins/modules/zabbix_group_events_info.py
@@ -105,6 +105,9 @@ triggers_problem:
                 eventid:
                     description: ID of the event
                     type: int
+                tags:
+                    description: List of tags
+                    type: list
                 value:
                     description: State of the related object
                     type: int
@@ -167,6 +170,36 @@ options:
             - high
             - disaster
         type: str
+    tags:
+        description:
+            - list of tags to filter by
+        required: false
+        type: list
+        elements: dict
+        suboptions:
+          tag:
+            description:
+                - the tag name
+            required: true
+            type: str
+          value:
+            description:
+                - the tag value
+            required: true
+            type: str
+          operator:
+            description:
+                - how to match tags
+            required: true
+            type: str
+            choices:
+                - like
+                - equal
+                - not_like
+                - not_equal
+                - exists
+                - not_exists
+
 extends_documentation_fragment:
 - community.zabbix.zabbix
 
@@ -202,6 +235,23 @@ EXAMPLES = """
 - fail:
     msg: "Active alert in zabbix"
   when: zbx_hostgroup["triggers_problem"] | length > 0
+
+- name: filter events for host based on tag
+  # set task level variables as we change ansible_connection plugin here
+  vars:
+      ansible_network_os: community.zabbix.zabbix
+      ansible_connection: httpapi
+      ansible_httpapi_port: 443
+      ansible_httpapi_use_ssl: true
+      ansible_httpapi_validate_certs: false
+      ansible_zabbix_url_path: "zabbixeu"  # If Zabbix WebUI runs on non-default (zabbix) path ,e.g. http://<FQDN>/zabbixeu
+      ansible_host: zabbix-example-fqdn.org
+  community.zabbix.zabbix_group_events_info:
+      hostgroup_name: "{{ inventory_hostname }}"
+      tags:
+        - tag: ExampleTag
+          value: ExampleValue
+          operator: equal
 """
 
 
@@ -221,10 +271,14 @@ class Host(ZabbixBase):
             self._module.fail_json(msg="Hostgroup not found: %s" % group_names)
         return group_list
 
-    def get_triggers_by_group_id_in_problem_state(self, group_id, trigger_severity):
+    def get_triggers_by_group_id_in_problem_state(self, group_id, trigger_severity, tags=None):
         """ Get triggers in problem state from a groupid"""
         output = "extend"
-        triggers_list = self._zapi.trigger.get({"output": output, "groupids": group_id,
+        if tags:
+            triggers_list = self._zapi.trigger.get({"output": output, "groupids": group_id,
+                                                "min_severity": trigger_severity, "tags": tags})
+        else:
+            triggers_list = self._zapi.trigger.get({"output": output, "groupids": group_id,
                                                 "min_severity": trigger_severity})
         return triggers_list
 
@@ -233,11 +287,11 @@ class Host(ZabbixBase):
         output = ["eventid", "clock", "acknowledged", "value"]
         if LooseVersion(self._zbx_api_version) < LooseVersion("7.0"):
             event = self._zapi.event.get({"output": output, "objectids": triggers_id,
-                                          "select_acknowledges": "extend", "limit": 1, "sortfield": "clock",
+                                          "select_acknowledges": "extend", "selectTags": "extend", "limit": 1, "sortfield": "clock",
                                           "sortorder": "DESC"})
         else:
             event = self._zapi.event.get({"output": output, "objectids": triggers_id,
-                                          "selectAcknowledges": "extend", "limit": 1, "sortfield": "clock",
+                                          "selectAcknowledges": "extend", "selectTags": "extend", "limit": 1, "sortfield": "clock",
                                           "sortorder": "DESC"})
         return event[0]
 
@@ -251,6 +305,10 @@ def main():
             required=False,
             default="average",
             choices=["not_classified", "information", "warning", "average", "high", "disaster"]),
+        tags=dict(
+            type="list",
+            required=False,
+            elements="dict"),
     ))
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -258,7 +316,9 @@ def main():
     )
 
     trigger_severity_map = {"not_classified": 0, "information": 1, "warning": 2, "average": 3, "high": 4, "disaster": 5}
+    tags_operator_map = {"like": 0, "equal": 1, "not_like": 2, "not_equal": 3, "exists": 4, "not_exists": 5}
     trigger_severity = trigger_severity_map[module.params["trigger_severity"]]
+    tags = module.params["tags"]
 
     hostgroup_name = module.params["hostgroup_name"]
 
@@ -268,7 +328,10 @@ def main():
 
     for host_group in host_groups:
         host_group_id = host_group["groupid"]
-        host_group_triggers = host.get_triggers_by_group_id_in_problem_state(host_group_id, trigger_severity)
+        if tags:
+            for tag in tags:
+                tag["operator"] = tags_operator_map[tag["operator"]]
+        host_group_triggers = host.get_triggers_by_group_id_in_problem_state(host_group_id, trigger_severity, tags)
         triggers = triggers + host_group_triggers
 
     triggers_ok = []

--- a/tests/integration/targets/test_zabbix_group_events_info/files/trigger_testing.json
+++ b/tests/integration/targets/test_zabbix_group_events_info/files/trigger_testing.json
@@ -37,7 +37,13 @@
                                 "uuid": "f17f4b4f7fe444dfb856bc9d6366d0fe",
                                 "expression": "last(/Trigger testing/test)=1",
                                 "name": "Problem Trigger",
-                                "priority": "AVERAGE"
+                                "priority": "AVERAGE",
+                                 "tags": [
+                                     {
+                                         "tag": "ExampleTag",
+                                         "value": "ExampleValue"
+                                     }
+                                 ]
                             }
                         ]
                     }

--- a/tests/integration/targets/test_zabbix_group_events_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_group_events_info/tasks/main.yml
@@ -41,6 +41,22 @@
       # - hostgroup_events_results.triggers_problem[0].last_event.acknowledged == "0"
       # - hostgroup_events_results.triggers_problem[0].last_event.value == "1"
 
+- name: Get hostgroup events with tags
+  zabbix_group_events_info:
+    hostgroup_name: Example group
+    trigger_severity: not_classified
+    tags:
+      - tag: ExampleTag
+        value: ExampleValue
+        operator: equal
+  register: hostgroup_events_tags_results
+
+- name: Assert that trigger results are as expected
+  ansible.builtin.assert:
+    that:
+      - hostgroup_events_tags_results.triggers_ok | length == 0
+      - hostgroup_events_tags_results.triggers_problem | length == 1
+
 - name: Clean up host
   zabbix_host:
     host_name: Example host


### PR DESCRIPTION
##### SUMMARY

Adds support to the zabbix_group_events_info module to filter events by tag. It also adds the tags returned by last_event

This is similar to what I did for the zabbix_host_events_info (see: https://github.com/ansible-collections/community.zabbix/pull/1258)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- zabbix_group_events_info

##### ADDITIONAL INFORMATION
Being able to filter events by tag is supported by the Zabbix API, but not the current zabbix_group_events_info module, so I've added support for it. An example of this can be seen below:

```
- community.zabbix.zabbix_group_events_info:
    hostgroup_name: ExampleGroup
    trigger_severity: warning
    tags:
      - tag: ExampleTag
        value: ExampleValue
        operator: equal
```

I believe it would also be useful to do the inverse, get a list of events for a host group and then be able to do something based on the tags the events return:

```
- community.zabbix.zabbix_group_events_info:
    hostgroup_name: ExampleGroup
    trigger_severity: warning
  register: zabbix_group_events_tags

- ansible.builtin.debug:
    msg: "{{ zabbix_group_events_tags.triggers_problem[0].last_event.tags }}"