### PR TITLE
Add task to restart postgresql service

### DIFF
--- a/roles/zabbix_proxy/tasks/initialize-pgsql.yml
+++ b/roles/zabbix_proxy/tasks/initialize-pgsql.yml
@@ -56,12 +56,20 @@
         type: schema
         objs: public
         role: "{{ zabbix_proxy_dbuser }}"
+        
+
 
 - name: "PostgreSQL verify or create schema"
   when: zabbix_proxy_database_sqlload | bool
   tags:
     - database
   block:
+    - name: "PostgreSQL | Restart PostgreSQL service
+      ansible.builtin.systemd:
+        name: postgresql.service
+        state: restarted
+        become: true
+        
     - name: "PostgreSQL | Get current database version"
       community.postgresql.postgresql_query:
         login_user: "{{ zabbix_proxy_dbuser }}"


### PR DESCRIPTION

##### SUMMARY
If the service it's not restarted the db_user can not access the database. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Roles zabbix_proxy 

##### ADDITIONAL INFORMATION

zabbix_proxy_dbport: 5432
I think the problem is that the service is not runnin on stnadard port.

Here the error i'm getting

```
TASK [community.zabbix.zabbix_proxy : PostgreSQL | Import schema] **************
fatal: [HOST1]: FAILED! => {"changed": false, "cmd": "/usr/bin/psql --dbname=zabbix_proxy --host=localhost --port=5432 --username=zabbix_proxy --file=/usr/share/zabbix-sql-scripts/postgresql/proxy.sql < /usr/share/zabbix-sql-scripts/postgresql/proxy.sql", "msg": "psql: error: FATAL:  Ident authentication failed for user \"zabbix_proxy\"\n", "rc": 2, "stdout": "", "stdout_lines": []}
fatal: [HOST2]: FAILED! => {"changed": false, "cmd": "/usr/bin/psql --dbname=zabbix_proxy --host=localhost --port=5432 --username=zabbix_proxy --file=/usr/share/zabbix-sql-scripts/postgresql/proxy.sql < /usr/share/zabbix-sql-scripts/postgresql/proxy.sql", "msg": "psql: error: FATAL:  Ident authentication failed for user \"zabbix_proxy\"\n", "rc": 2, "stdout": "", "stdout_lines": []}
```

After a manual `systemctl restart postgresql.service` and relunch the playbook it works fine. 
