### PR TITLE
When creating a zabbix_item on a host of type zabbix_agent, snmp_trap…

### DIFF
--- a/plugins/modules/zabbix_item.py
+++ b/plugins/modules/zabbix_item.py
@@ -377,6 +377,12 @@ class Item(ZabbixBase):
                   'snmp_agent': 20,
                   'script': 21}
 
+    ITEM_TYPES_REQUIRING_INTERFACE_IF_HOST = {ITEM_TYPES['zabbix_agent']: 1,
+                                              ITEM_TYPES['snmp_trap']: 2,
+                                              ITEM_TYPES['snmp_agent']: 2,
+                                              ITEM_TYPES['ipmi_agent']: 3,
+                                              ITEM_TYPES['jmx_agent']: 4}
+
     VALUE_TYPES = {'numeric_float': 0,
                    'character': 1,
                    'log': 2,
@@ -528,6 +534,11 @@ class Item(ZabbixBase):
             self._module.fail_json(msg="Failed to delete item: %s" % e)
         return results
 
+    def get_host_main_interfaces_for_type(self, host_id, type_id):
+        try:
+            return self._zapi.hostinterface.get({"hostids": host_id, "filter": {"type": type_id, "main": "1"}})
+        except Exception as e:
+            self._module.fail_json(msg="Failed to get interfaces for host: %s" % e)
 
 def main():
     argument_spec = zabbix_utils.zabbix_common_argument_spec()
@@ -586,6 +597,12 @@ def main():
             for host_template in hosts_templates:
                 if 'hostid' in host_template:
                     params['hostid'] = host_template['hostid']
+                    if params['type'] in item.ITEM_TYPES_REQUIRING_INTERFACE_IF_HOST:
+                        host_interfaces = item.get_host_main_interfaces_for_type(host_template['hostid'], item.ITEM_TYPES_REQUIRING_INTERFACE_IF_HOST[params['type']])
+                        if(len(host_interfaces) > 0):
+                            params['interfaceid'] = host_interfaces[0]['interfaceid']
+                        else:
+                            module.fail_json(msg="interface not found on host")
                 elif 'templateid' in host_template:
                     params['hostid'] = host_template['templateid']
                 else:

--- a/tests/integration/targets/test_zabbix_item/tasks/zabbix_tests.yml
+++ b/tests/integration/targets/test_zabbix_item/tasks/zabbix_tests.yml
@@ -284,3 +284,19 @@
 - name: assert that nothing has been changed
   ansible.builtin.assert:
     that: not zbxtempitem_missing_delete is changed
+
+- name: test - create new Zabbix item on host using type zabbix_agent
+  community.zabbix.zabbix_item:
+    name: TestItem
+    host_name: ExampleHost
+    params:
+      type: zabbix_agent
+      key: agent.version
+      value_type: text
+      interval: 1m
+    state: present
+  register: zbxhostitemagent_new
+
+- name: assert that item was created
+  ansible.builtin.assert:
+    that: zbxhostitemagent_new is changed


### PR DESCRIPTION
##### SUMMARY
When creating a zabbix_item directly on a host using type zabbix_agent, snmp_trap, snmp_agent, ipmi_agent or jmx_agent, we must provide the interfaceid according to the zabbix API. This PR does implement this.
Fixes #1478

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.zabbix.zabbix_item

##### ADDITIONAL INFORMATION
Detailed information in #1478 1478