### PR TITLE
Restrict access to the frontend config

### DIFF
--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -4,7 +4,7 @@
 # zabbix_web_version: 6.4
 zabbix_web_package_state: present
 zabbix_web_doubleprecision: false
-zabbix_web_conf_mode: "0644"
+zabbix_web_conf_mode: "0640"
 zabbix_web_connect_ha_backend: false
 zabbix_api_server_url: zabbix.example.com
 zabbix_web_http_server: apache

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -108,8 +108,8 @@
   ansible.builtin.template:
     src: zabbix.conf.php.j2
     dest: /etc/zabbix/web/zabbix.conf.php
-    owner: "{{ zabbix_web_user }}"
-    group: "{{ zabbix_web_group }}"
+    owner: "{{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is defined else zabbix_web_user }}"
+    group: "{{ zabbix_php_fpm_conf_group if zabbix_php_fpm_conf_group is defined else zabbix_web_group }}"
     mode: "{{ zabbix_web_conf_mode }}"
   become: true
   tags:


### PR DESCRIPTION

##### SUMMARY
Restrict access to the web frontend config file `/etc/zabbix/web/zabbix.conf.php`.
The file contains passwords, so should not be publicly readable. Also fix the owner for the case that the fpm user differs from the www user.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_web

##### ADDITIONAL INFORMATION
Currently, the config file gets these permissions:
```
-rw-r--r--  1 www-data www-data 756 Mar 27 20:38 /etc/zabbix/web/zabbix.conf.php
```
This is undesired, as the file contains the database password.  Also, the owner/group are wrong in the case that the `zabbix_php_fpm_conf_user` differs from `zabbix_web_user`.

This patch restricts the (default) permissions to 0640, changes the owner to `zabbix_web_user` (or `zabbix_php_fpm_conf_user` if it is defined) and the group to `zabbix_web_group` (or `zabbix_php_fpm_conf_group` if it is defined).