### PR TITLE
Add _zabbix_agent_pluginsocket variable for windows hosts

### DIFF
--- a/changelogs/fragments/1494_fix_windows_agent_pluginsocket.yml
+++ b/changelogs/fragments/1494_fix_windows_agent_pluginsocket.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_agent Role - Add _zabbix_agent_pluginsocket variable to override /tmp/agent.plugin.sock

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -39,7 +39,7 @@ zabbix_agent_logfilesize: 100
 zabbix_agent_logtype: file
 zabbix_agent_maxlinespersecond: 20
 zabbix_agent_persistentbufferperiod: 1h
-zabbix_agent_pluginsocket: /tmp/agent.plugin.sock
+zabbix_agent_pluginsocket: "{{ _zabbix_agent_pluginsocket | default('/tmp/agent.plugin.sock') }}"
 zabbix_agent_plugintimeout: 3
 zabbix_agent_refreshactivechecks: 120
 zabbix_agent_statusport: 9999

--- a/roles/zabbix_agent/vars/Windows.yml
+++ b/roles/zabbix_agent/vars/Windows.yml
@@ -4,6 +4,7 @@ _zabbix_agent_logfile: "{{ zabbix_win_install_dir }}\\{{ zabbix_agent2 | ternary
 _zabbix_agent_include_dirs:
   - "{{ zabbix_win_install_dir_conf }}\\{{ zabbix_agent2 | ternary('zabbix_agent2.d', 'zabbix_agent.d') }}"
 _zabbix_agent_controlsocket: "\\\\.\\pipe\\agent.sock"
+_zabbix_agent_pluginsocket: "\\\\.\\pipe\\agent.plugin.sock"
 _zabbix_agent_tlspskfile: "{{ zabbix_win_install_dir }}\\tls_psk_auto.secret.txt"
 _zabbix_agent_tlspskidentity_file: "{{ zabbix_win_install_dir }}\\tls_psk_auto.identity.txt"
 


### PR DESCRIPTION
##### SUMMARY
Fixes #1493

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent

##### ADDITIONAL INFORMATION
Fix the variable PluginSocket in zabbix_agent2.conf for windows hosts
