### PR TITLE
Arm64

### DIFF
--- a/changelogs/fragments/1495_debian_arch.yml
+++ b/changelogs/fragments/1495_debian_arch.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - roles/zabbix_repo - debian/ubuntu arm64 repo url fixed for zabbix 7.2
+  - roles/zabbix_repo - debian architectures should map better for i386 and armhf

--- a/roles/zabbix_repo/defaults/main.yml
+++ b/roles/zabbix_repo/defaults/main.yml
@@ -4,7 +4,7 @@ zabbix_repo_version: "7.2"
 zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https
 _pre_72_deb_repo: "http://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
-_post_72_deb_repo: "http://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/stable/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
+_post_72_deb_repo: "http://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/stable/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}"
 zabbix_repo_deb_component: main
 _pre_72_yum_repo: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
 _post_72_yum_repo: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/stable/rhel/{{ ansible_distribution_major_version }}/$basearch/"

--- a/roles/zabbix_repo/defaults/main.yml
+++ b/roles/zabbix_repo/defaults/main.yml
@@ -4,6 +4,7 @@ zabbix_repo_version: "7.2"
 zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https
 zabbix_repo_deb_url: "{{ zabbix_repo_version is version('7.0', '>') | ternary(_post_72_deb_repo, _pre_72_deb_repo) }}"
+zabbix_repo_deb_arch: "{{ _zabbix_repo_deb_arch_map[ansible_facts['architecture']] }}"
 zabbix_repo_deb_component: main
 zabbix_repo_yum:
   - name: zabbix

--- a/roles/zabbix_repo/defaults/main.yml
+++ b/roles/zabbix_repo/defaults/main.yml
@@ -4,11 +4,7 @@ zabbix_repo_version: "7.2"
 zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https
 zabbix_repo_deb_url: "{{ zabbix_repo_version is version('7.0', '>') | ternary(_post_72_deb_repo, _pre_72_deb_repo) }}"
-_pre_72_deb_repo: "http://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
-_post_72_deb_repo: "http://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/stable/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}"
 zabbix_repo_deb_component: main
-_pre_72_yum_repo: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
-_post_72_yum_repo: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/stable/rhel/{{ ansible_distribution_major_version }}/$basearch/"
 zabbix_repo_yum:
   - name: zabbix
     description: Zabbix Official Repository - $basearch
@@ -32,8 +28,6 @@ zabbix_repo_rpm_gpg_key_url: http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD
 zabbix_repo_zypper_auto_import_keys: true
 zabbix_repo_zypper_disable_gpg_check: false
 zabbix_repo_zypper_schema: https
-_pre_72_suse_repo: "{{ zabbix_repo_zypper_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/sles/{{ ansible_distribution_major_version }}/$basearch/"
-_post_72_suse_repo: "{{ zabbix_repo_zypper_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/stable/sles/{{ ansible_distribution_major_version }}/$basearch/"
 zabbix_repo_zypper:
   - name: zabbix
     description: Zabbix Official Repository

--- a/roles/zabbix_repo/defaults/main.yml
+++ b/roles/zabbix_repo/defaults/main.yml
@@ -3,6 +3,7 @@
 zabbix_repo_version: "7.2"
 zabbix_repo_yum_gpgcheck: 0
 zabbix_repo_yum_schema: https
+zabbix_repo_deb_url: "{{ zabbix_repo_version is version('7.0', '>') | ternary(_post_72_deb_repo, _pre_72_deb_repo) }}"
 _pre_72_deb_repo: "http://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
 _post_72_deb_repo: "http://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/stable/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}"
 zabbix_repo_deb_component: main

--- a/roles/zabbix_repo/tasks/Debian.yml
+++ b/roles/zabbix_repo/tasks/Debian.yml
@@ -56,7 +56,7 @@
       URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
-      Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}
+      Architectures: {{ zabbix_repo_deb_arch }}
       Signed-By: {{ zabbix_repo_gpg_key }}
   register: zabbix_repo_apt_file
   become: true

--- a/roles/zabbix_repo/tasks/Debian.yml
+++ b/roles/zabbix_repo/tasks/Debian.yml
@@ -53,7 +53,7 @@
     content: |
       Types: deb{{ ' deb-src' if zabbix_repo_deb_include_deb_src }}
       Enabled: yes
-      URIs: {{ zabbix_repo_deb_url | default ( _post_72_deb_repo if zabbix_repo_version is version('7.0', '>') else _pre_72_deb_repo )}}
+      URIs: {{ zabbix_repo_deb_url }}
       Suites: {{ ansible_distribution_release }}
       Components: {{ zabbix_repo_deb_component }}
       Architectures: {{ 'amd64' if ansible_machine != 'aarch64' else 'arm64'}}

--- a/roles/zabbix_repo/vars/Debian.yml
+++ b/roles/zabbix_repo/vars/Debian.yml
@@ -1,3 +1,10 @@
 ---
+_zabbix_repo_deb_arch_map:
+  aarch64: "arm64"
+  arm6l: "armhf"
+  arm7l: "armhf"
+  i386: "i386"
+  x86_64: "amd64"
+
 zabbix_repo_keyring_path: /etc/apt/keyrings/
 zabbix_repo_gpg_key: "{{ zabbix_repo_keyring_path }}zabbix-repo.asc"

--- a/roles/zabbix_repo/vars/main.yml
+++ b/roles/zabbix_repo/vars/main.yml
@@ -1,2 +1,9 @@
 ---
-# vars file for zabbix_server
+_pre_72_deb_repo: "http://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
+_post_72_deb_repo: "http://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/stable/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}"
+
+_pre_72_yum_repo: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/rhel/{{ ansible_distribution_major_version }}/$basearch/"
+_post_72_yum_repo: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/stable/rhel/{{ ansible_distribution_major_version }}/$basearch/"
+
+_pre_72_suse_repo: "{{ zabbix_repo_zypper_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/sles/{{ ansible_distribution_major_version }}/$basearch/"
+_post_72_suse_repo: "{{ zabbix_repo_zypper_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/stable/sles/{{ ansible_distribution_major_version }}/$basearch/"


### PR DESCRIPTION
##### SUMMARY
Zabbix 7.2 put arm64 packages in the main repo for debian and ubuntu, so no need to postfix with -arm64 anymore.
This fixes #1491 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
roles/zabbix_repo

##### ADDITIONAL INFORMATION
Tested and confirmed working for debian bookworm on aarch64