### PR TITLE
Fix status of zabbix token

### DIFF
--- a/changelogs/fragments/zabbix_token_module_inverted_value.yaml
+++ b/changelogs/fragments/zabbix_token_module_inverted_value.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - zabbix_token module - Fix status value for zabbix Auth token. 

--- a/plugins/modules/zabbix_token.py
+++ b/plugins/modules/zabbix_token.py
@@ -194,11 +194,11 @@ class Token(ZabbixBase):
 
             if isinstance(status, bool):
                 if status:
-                    if token["status"] != "0":
-                        params["status"] = "0"
-                else:
                     if token["status"] != "1":
                         params["status"] = "1"
+                else:
+                    if token["status"] != "0":
+                        params["status"] = "0"
 
             if isinstance(expires_at, int) and str(expires_at) != token["expires_at"]:
                 params["expires_at"] = str(expires_at)

--- a/plugins/modules/zabbix_token.py
+++ b/plugins/modules/zabbix_token.py
@@ -158,9 +158,9 @@ class Token(ZabbixBase):
 
             if isinstance(status, bool):
                 if status:
-                    params["status"] = "1"
-                else:
                     params["status"] = "0"
+                else:
+                    params["status"] = "1"
 
             if isinstance(expires_at, str):
                 params["expires_at"] = str(expires_at)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For creation of Zabbix Auth Token via Ansible the option status should create an Enabled or Disabled token. 
Aktuelly the task with Status:true will create a disabled token. 
Accordingly to the documentation the value are inverted. 
https://www.zabbix.com/documentation/7.0/en/manual/api/reference/token/object

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_token.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
[...]
community.zabbix.zabbix_token:
    name: Zabbix CI Token
    description: "{{ zabbix_hvrz_api_ansible_user }} auth token"
    username: "{{ zabbix_hvrz_api_ansible_user }}"
    status: true
    generate_token: true
    state: present
```
Will generate a disable token. 
With option  status: false the token will be enabled. 
