### PR TITLE
UserParameterDir not corretly templated

### DIFF
--- a/changelogs/fragments/1492_UserParameterDir _template.yml
+++ b/changelogs/fragments/1492_UserParameterDir _template.yml
@@ -1,0 +1,3 @@
+bugfix:
+  - roles/zabbix_agent - UserParameterDir get wrong value if var zabbix_agent_userparamaterdir is set
+  

--- a/changelogs/fragments/1492_UserParameterDir _template.yml
+++ b/changelogs/fragments/1492_UserParameterDir _template.yml
@@ -1,3 +1,3 @@
-bugfix:
+bugfixes:
   - roles/zabbix_agent - UserParameterDir get wrong value if var zabbix_agent_userparamaterdir is set
   

--- a/roles/zabbix_agent/templates/agent.conf.j2
+++ b/roles/zabbix_agent/templates/agent.conf.j2
@@ -152,4 +152,4 @@ Plugins.{{ my_name }}.{{ param }}={{ value }}
 {{ (zabbix_agent_runas_user is defined and zabbix_agent_runas_user is not none) | ternary('', '# ') }}User={{ zabbix_agent_runas_user | default('') }}
 {% endif %}
 {{ (zabbix_agent_userparamater is defined and zabbix_agent_userparamater is not none) | ternary('', '# ') }}UserParameter={{ zabbix_agent_userparamater | default('') }}
-{{ (zabbix_agent_userparamaterdir is defined and zabbix_agent_userparamaterdir is not none) | ternary('', '# ') }}UserParameterDir={{ zabbix_agent_userparamaterdir | default (false) | ternary('1', '0') }}
+{{ (zabbix_agent_userparamaterdir is defined and zabbix_agent_userparamaterdir is not none) | ternary('', '# ') }}UserParameterDir={{ zabbix_agent_userparamaterdir | default('') }}


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix the wrong zabbix_agent_userparamaterdir output in config template

Fixes #1492 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Zabbix agent role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The actual template do not template the config with the actual value of the var zabbix_agent_userparamaterdir 

Value UserParameterDir is the default search path for UserParameter commands. UserParameter commands can have a relative ./ prefix or a full path. 
https://www.zabbix.com/documentation/current/en/manual/appendix/config/zabbix_agent2#userparameterdir

