### PR TITLE
Overridable zabbix_server variables

### DIFF
--- a/changelogs/fragments/zabbix_server_overrides.yml
+++ b/changelogs/fragments/zabbix_server_overrides.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - zabbix_server role - facilitate overriding packages installed
+  - zabbix_server role - facilitate overriding database schemas loaded

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -141,6 +141,7 @@ Selinux changes will be installed based on the status of selinux running on the 
 * `zabbix_server_install_database_client`: Default: `True`. False does not install database client. Default true
 * `zabbix_server_database_sqlload`:True / False. When you don't want to load the sql files into the database, you can set it to False.
 * `zabbix_server_database_timescaledb`:False / True. When you want to use timescaledb extension into the database, you can set it to True (this option only works for postgreSQL database).
+* `zabbix_server_database_schemas`: List of schemas to load, can be overridden for a non-supported/custom setup.
 * `zabbix_server_dbencoding`: Default: `utf8`. The encoding for the MySQL database.
 * `zabbix_server_dbcollation`: Default: `utf8_bin`. The collation for the MySQL database.
 

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -118,6 +118,7 @@ Selinux changes will be installed based on the status of selinux running on the 
 
 ### Zabbix Server
 
+* `zabbix_server_packages`: List of packages to install, can be overridden for a non-supported/custom setup.
 * `zabbix_server_package_state`: Default: `present`. Can be overridden to `latest` to update packages when needed.
 * `zabbix_server_install_recommends`: Default: `True`. `False` does not install the recommended packages that come with the zabbix-server install.
 * `zabbix_server_manage_service`: Default: `True`. When you run multiple Zabbix servers in a High Available cluster setup (e.g. pacemaker), you don't want Ansible to manage the zabbix-server service, because Pacemaker is in control of zabbix-server service and in this case, it needs to be set to `False`.

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -39,6 +39,7 @@ zabbix_service_state: started
 
 # Yum/APT  Variables
 zabbix_server_version_minor: "*"
+zabbix_server_packages: "{{ _zabbix_server_packages }}"
 zabbix_server_package_state: present
 zabbix_server_conf_mode: 0640
 

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -26,8 +26,6 @@ zabbix_server_dbhost_run_install: true
 zabbix_server_database: pgsql
 zabbix_server_database_creation: true
 zabbix_server_install_database_client: true
-
-zabbix_server_database_file_dir: "{{ zabbix_server_version is version('7.0', '>') | ternary(_zabbix_server_database_file_dir_post72, _zabbix_server_database_file_dir_pre72) }}"
 zabbix_server_database_schemas: "{{ _zabbix_server_database_schemas[zabbix_server_database] }}"
 
 # SELinux specific

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -28,6 +28,7 @@ zabbix_server_database_creation: true
 zabbix_server_install_database_client: true
 
 zabbix_server_database_file_dir: "{{ zabbix_server_version is version('7.0', '>') | ternary(_zabbix_server_database_file_dir_post72, _zabbix_server_database_file_dir_pre72) }}"
+zabbix_server_database_schemas: "{{ _zabbix_server_database_schemas[zabbix_server_database] }}"
 
 # SELinux specific
 selinux_allow_zabbix_can_network: false

--- a/roles/zabbix_server/tasks/initialize-mysql.yml
+++ b/roles/zabbix_server/tasks/initialize-mysql.yml
@@ -148,7 +148,8 @@
         encoding: "{{ zabbix_server_dbencoding }}"
         collation: "{{ zabbix_server_dbcollation }}"
         state: import
-        target: "{{ zabbix_server_database_file_dir }}/mysql/server.sql.gz"
+        target: "{{ item }}"
+      loop: "{{ zabbix_server_database_schemas }}"
 
   always:
     - name: "MySQL | Revert variable overrides for schema import"

--- a/roles/zabbix_server/tasks/initialize-pgsql.yml
+++ b/roles/zabbix_server/tasks/initialize-pgsql.yml
@@ -128,7 +128,7 @@
         port: "{{ zabbix_server_dbport }}"
         db: "{{ zabbix_server_dbname }}"
         state: restore
-        target: "{{ zabbix_server_database_file_dir }}/{{ _is_pre70 | ternary(legacy_path, modern_path) }}"
+        target: "{{ _zabbix_server_database_scripts_dir }}/{{ _is_pre70 | ternary(legacy_path, modern_path) }}"
       vars:
         _is_pre70: "{{ zabbix_server_version is version('7.0', '<') }}"
         legacy_path: postgresql/timescaledb.sql

--- a/roles/zabbix_server/tasks/initialize-pgsql.yml
+++ b/roles/zabbix_server/tasks/initialize-pgsql.yml
@@ -89,7 +89,8 @@
         port: "{{ zabbix_server_dbport }}"
         db: "{{ zabbix_server_dbname }}"
         state: restore
-        target: "{{ zabbix_server_database_file_dir }}/postgresql/server.sql.gz"
+        target: "{{ item }}"
+      loop: "{{ zabbix_server_database_schemas }}"
 
 - name: "Configure Timescale"
   when: zabbix_server_database_timescaledb

--- a/roles/zabbix_server/tasks/main.yml
+++ b/roles/zabbix_server/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - name: Install zabbix-server packages
   ansible.builtin.package:
-    name: "{{ _zabbix_server_packages }}"
+    name: "{{ zabbix_server_packages }}"
     state: "{{ zabbix_server_package_state }}"
     update_cache: true
     disablerepo: "{{ zabbix_server_disable_repo | default(_zabbix_server_disable_repo | default(omit)) }}"

--- a/roles/zabbix_server/vars/main.yml
+++ b/roles/zabbix_server/vars/main.yml
@@ -3,11 +3,12 @@ _zabbix_server_database_default_port:
   mysql: 3306
   pgsql: 5432
 
-_zabbix_server_database_file_dir_post72: /usr/share/zabbix/sql-scripts
-_zabbix_server_database_file_dir_pre72: /usr/share/zabbix-sql-scripts
+_zabbix_server_database_scripts_dir: "{{ zabbix_server_version is version('7.0', '>') | ternary(_zabbix_server_database_scripts_dir_post72, _zabbix_server_database_scripts_dir_pre72) }}"
+_zabbix_server_database_scripts_dir_post72: /usr/share/zabbix/sql-scripts
+_zabbix_server_database_scripts_dir_pre72: /usr/share/zabbix-sql-scripts
 
 _zabbix_server_database_schemas:
   mysql:
-    - "{{ zabbix_server_database_file_dir }}/mysql/server.sql.gz"
+    - "{{ _zabbix_server_database_scripts_dir }}/mysql/server.sql.gz"
   pgsql:
-    - "{{ zabbix_server_database_file_dir }}/postgresql/server.sql.gz"
+    - "{{ _zabbix_server_database_scripts_dir }}/postgresql/server.sql.gz"

--- a/roles/zabbix_server/vars/main.yml
+++ b/roles/zabbix_server/vars/main.yml
@@ -5,3 +5,9 @@ _zabbix_server_database_default_port:
 
 _zabbix_server_database_file_dir_post72: /usr/share/zabbix/sql-scripts
 _zabbix_server_database_file_dir_pre72: /usr/share/zabbix-sql-scripts
+
+_zabbix_server_database_schemas:
+  mysql:
+    - "{{ zabbix_server_database_file_dir }}/mysql/server.sql.gz"
+  pgsql:
+    - "{{ zabbix_server_database_file_dir }}/postgresql/server.sql.gz"


### PR DESCRIPTION
##### SUMMARY
Additional zabbix_server variables for deployers to override (for unsupported/custom setups.)

Fixes #1508

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles/zabbix_server

##### ADDITIONAL INFORMATION
Cleaning up the undocumented `...database_file_dir`, and moving it to "internal" variables and renaming it. As the new variables are a better way for users to override.