### PR TITLE
Missing ZBX 7.2 Apache SSL new DocumentRoot /usr/share/zabbix/ui

### DIFF
--- a/roles/zabbix_web/templates/apache_vhost.conf.j2
+++ b/roles/zabbix_web/templates/apache_vhost.conf.j2
@@ -87,7 +87,11 @@ SSLRandomSeed connect builtin
   {% endfor %}
 
   ## Vhost docroot
+  {% if zabbix_web_version is version('7.0', '<=') %}
   DocumentRoot "/usr/share/zabbix"
+  {% else %}
+  DocumentRoot "/usr/share/zabbix/ui"
+  {% endif %}
 
 {% if zabbix_apache_custom_includes is iterable and (zabbix_apache_custom_includes | length>0) %}
   {% for include in zabbix_apache_custom_includes %}


### PR DESCRIPTION
##### SUMMARY
File apache_vhost.conf.j2 was missing the new ZBX 7.2 DocumentRoot /usr/share/zabbix/ui for the SSL.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_web

##### ADDITIONAL INFORMATION
After installing ZBX 7.2, using Apache & SSL
![image](https://github.com/user-attachments/assets/73e56382-a274-46ad-931c-513164695c1b)

