### PR TITLE
Add ansible-core 2.19 to plugins-integration test target

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -29,6 +29,7 @@ jobs:
           - stable-2.16
           - stable-2.17
           - stable-2.18
+          - stable-2.19
           - devel
         python:
           - '3.9'
@@ -37,6 +38,10 @@ jobs:
           - '3.12'
           - '3.13'
         exclude:
+          - ansible: stable-2.19
+            python: '3.10'
+          - ansible: stable-2.19
+            python: '3.9'
           - ansible: stable-2.18
             python: '3.10'
           - ansible: stable-2.18

--- a/changelogs/fragments/1515_plugins-integration-test_ansible219.yml
+++ b/changelogs/fragments/1515_plugins-integration-test_ansible219.yml
@@ -1,5 +1,2 @@
-major_changes:
-  - Add ansible-core 2.19 to plugins-integration test target
-
 bugfixes:
   - zabbix_template_info module - Dump YAML formatted template data without date in Zabbix 7.0 or higher.

--- a/changelogs/fragments/1515_plugins-integration-test_ansible219.yml
+++ b/changelogs/fragments/1515_plugins-integration-test_ansible219.yml
@@ -1,0 +1,5 @@
+major_changes:
+  - Add ansible-core 2.19 to plugins-integration test target
+
+bugfixes:
+  - zabbix_template_info module - Dump YAML formatted template data without date in Zabbix 7.0 or higher.

--- a/plugins/modules/zabbix_template_info.py
+++ b/plugins/modules/zabbix_template_info.py
@@ -32,6 +32,7 @@ options:
     omit_date:
         description:
             - Removes the date field for the dumped template
+            - This parameter will be ignored since Zabbix 6.4.
         required: false
         type: bool
         default: false
@@ -210,6 +211,7 @@ import json
 import xml.etree.ElementTree as ET
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.compat.version import LooseVersion
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import PY2
 
@@ -242,7 +244,7 @@ class TemplateInfo(ZabbixBase):
             self._module.fail_json(msg="Invalid JSON provided", details=to_native(e), exception=traceback.format_exc())
 
     def load_yaml_template(self, template_yaml, omit_date=False):
-        if omit_date:
+        if omit_date and LooseVersion(self._zbx_api_version) < LooseVersion("6.4"):
             yaml_lines = template_yaml.splitlines(True)
             for index, line in enumerate(yaml_lines):
                 if "date:" in line:

--- a/tests/integration/targets/test_zabbix_host_events_update/tasks/zabbix_tests.yml
+++ b/tests/integration/targets/test_zabbix_host_events_update/tasks/zabbix_tests.yml
@@ -21,7 +21,7 @@
 
 - name: assert that event was acknowledged
   ansible.builtin.assert:
-    that: zabbix_host_events_ack.triggers_problem[0].last_event.acknowledged
+    that: zabbix_host_events_ack.triggers_problem[0].last_event.acknowledged == "1"
 
 - name: test - change severity and unacknowledge
   community.zabbix.zabbix_host_events_update:

--- a/tests/integration/targets/test_zabbix_template/files/template1_50_higher_decode_unicode.json
+++ b/tests/integration/targets/test_zabbix_template/files/template1_50_higher_decode_unicode.json
@@ -22,8 +22,8 @@
                         "type": "ZABBIX_ACTIVE",
                         "key": "logrt[\"/test.*test.log\",\"test.*total=([0-9.]+)\",,,skip,\\1]"
                     }
-                ],
+                ]
             }
-        ],
+        ]
     }
 }

--- a/tests/integration/targets/test_zabbix_template/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template/tasks/main.yml
@@ -70,10 +70,7 @@
 
 - name: "test - Set key to template_export_key variable(This deals with the key being masked)"
   ansible.builtin.set_fact:
-    template_export_key: "{{ item }}"
-  loop: "{{ gather_template_result.template_json.keys() | list }}"
-  when:
-    - item | regex_search('_export')
+    template_export_key: 'zabbix_export'
 
 - ansible.builtin.assert:
     that:

--- a/tests/integration/targets/test_zabbix_template_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_template_info/tasks/main.yml
@@ -19,11 +19,7 @@
 
 - name: "test - Set key to template_export_key variable(This deals with the key being masked)"
   ansible.builtin.set_fact:
-    template_export_key: "{{ item }}"
-  loop: "{{ fetch_template_json_format_result.template_json.keys() | list }}"
-  when:
-    - item | regex_search('_export')
-
+    template_export_key: 'zabbix_export'
 - ansible.builtin.assert:
     that:
       - fetch_template_json_format_result.template_json[template_export_key].date is defined
@@ -60,6 +56,13 @@
       - fetch_template_xml_format_result.template_xml | regex_search('<date>.*</date>') is defined
       - fetch_template_xml_format_result.template_xml | regex_search('</date><groups><group><name>Templates</name></group></groups><templates>') is defined
       - fetch_template_xml_format_result.template_xml | regex_search('<templates><template><template>ExampleTemplateForTempleteInfoModule</template><name>ExampleTemplateForTempleteInfoModule</name><groups><group><name>Templates</name></group></groups></template></templates>') is defined
+  when: zabbix_version is version('6.0', '<=')
+
+- ansible.builtin.assert:
+    that:
+      - fetch_template_xml_format_result.template_xml | regex_search('</date><groups><group><name>Templates</name></group></groups><templates>') is defined
+      - fetch_template_xml_format_result.template_xml | regex_search('<templates><template><template>ExampleTemplateForTempleteInfoModule</template><name>ExampleTemplateForTempleteInfoModule</name><groups><group><name>Templates</name></group></groups></template></templates>') is defined
+  when: zabbix_version is version('7.0', '>=')
 
 - name: "test - Fetch template info as a XML format with omit_date parameter from Zabbix Server"
   community.zabbix.zabbix_template_info:
@@ -82,9 +85,16 @@
 
 - ansible.builtin.assert:
     that:
-      - fetch_template_yaml_format_result.template_yaml | regex_search('date: .+') is defined
-      - fetch_template_yaml_format_result.template_yaml | regex_search('name: Templates') is defined
-      - fetch_template_yaml_format_result.template_yaml | regex_search('template: ExampleTemplateForTempleteInfoModule') is defined
+      - (fetch_template_yaml_format_result.template_yaml | from_yaml).zabbix_export.date is defined
+      - (fetch_template_yaml_format_result.template_yaml | from_yaml).zabbix_export.groups | selectattr("name", "eq", "Templates") | length > 0
+      - (fetch_template_yaml_format_result.template_yaml | from_yaml).zabbix_export.templates | selectattr("template", "eq", "ExampleTemplateForTempleteInfoModule") | length > 0
+  when: zabbix_version is version('6.0', '<=')
+
+- ansible.builtin.assert:
+    that:
+      - (fetch_template_yaml_format_result.template_yaml | from_yaml).zabbix_export.template_groups | selectattr("name", "eq", "Templates") | length > 0
+      - (fetch_template_yaml_format_result.template_yaml | from_yaml).zabbix_export.templates | selectattr("template", "eq", "ExampleTemplateForTempleteInfoModule") | length > 0
+  when: zabbix_version is version('7.0', '>=')
 
 - name: "test - Fetch template info as a YAML format with omit_date parameter from Zabbix Server"
   community.zabbix.zabbix_template_info:
@@ -95,9 +105,16 @@
 
 - ansible.builtin.assert:
     that:
-      - fetch_template_yaml_format_result.template_yaml | regex_search('date: .+') is not defined
-      - fetch_template_yaml_format_result.template_yaml | regex_search('name: Templates') is defined
-      - fetch_template_yaml_format_result.template_yaml | regex_search('template: ExampleTemplateForTempleteInfoModule') is defined
+      - (fetch_template_yaml_format_omit_date_result.template_yaml | from_yaml).zabbix_export.date is not defined
+      - (fetch_template_yaml_format_omit_date_result.template_yaml | from_yaml).zabbix_export.groups | selectattr("name", "eq", "Templates") | length > 0
+      - (fetch_template_yaml_format_omit_date_result.template_yaml | from_yaml).zabbix_export.templates | selectattr("template", "eq", "ExampleTemplateForTempleteInfoModule") | length > 0
+  when: zabbix_version is version('6.0', '<=')
+
+- ansible.builtin.assert:
+    that:
+      - (fetch_template_yaml_format_omit_date_result.template_yaml | from_yaml).zabbix_export.template_groups | selectattr("name", "eq", "Templates") | length > 0
+      - (fetch_template_yaml_format_omit_date_result.template_yaml | from_yaml).zabbix_export.templates | selectattr("template", "eq", "ExampleTemplateForTempleteInfoModule") | length > 0
+  when: zabbix_version is version('7.0', '>=')
 
 - name: "test - Fetch template info with none format from Zabbix Server"
   community.zabbix.zabbix_template_info:

--- a/tests/integration/targets/test_zabbix_user_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_user_info/tasks/main.yml
@@ -36,9 +36,17 @@
     that:
       - create_zabbix_user_result.changed is sameas true
 
-- name: test - Set definition_of_results variable
+- name: "test - Get a zabbix user information"
+  community.zabbix.zabbix_user_info:
+    username: example
+  register: get_user_info_result
+
+- name: "test - Set key to user_info_key variable(This deals with the key being masked)"
   ansible.builtin.set_fact:
-    definition_of_results:
+    user_info_key: 'zabbix_user'
+
+- ansible.builtin.assert:
+    that:
       - get_user_info_result[user_info_key].username == "example"
       - get_user_info_result[user_info_key].autologin is defined
       - get_user_info_result[user_info_key].autologout is defined
@@ -70,21 +78,42 @@
       - get_user_info_result[user_info_key].usrgrps.1.name is defined
       - get_user_info_result[user_info_key].usrgrps.1.users_status is defined
       - get_user_info_result[user_info_key].usrgrps.1.usrgrpid is defined
-
-- name: "test - Get a zabbix user information"
-  community.zabbix.zabbix_user_info:
-    username: example
-  register: get_user_info_result
-
-- name: "test - Set key to user_info_key variable(This deals with the key being masked)"
-  ansible.builtin.set_fact:
-    user_info_key: "{{ item }}"
-  loop: "{{ get_user_info_result.keys() | list }}"
-  when:
-    - item | regex_search('_user')
+  when: zabbix_version is version('6.0', '<=')
 
 - ansible.builtin.assert:
-    that: definition_of_results
+    that:
+      - get_user_info_result[user_info_key].username == "example"
+      - get_user_info_result[user_info_key].autologin is defined
+      - get_user_info_result[user_info_key].autologout is defined
+      - get_user_info_result[user_info_key].lang is defined
+      - get_user_info_result[user_info_key].medias.0.active is defined
+      - get_user_info_result[user_info_key].medias.0.mediaid is defined
+      - get_user_info_result[user_info_key].medias.0.period is defined
+      - get_user_info_result[user_info_key].medias.0.sendto is defined
+      - get_user_info_result[user_info_key].medias.0.severity is defined
+      - get_user_info_result[user_info_key].medias.0.userdirectory_mediaid is defined
+      - get_user_info_result[user_info_key].name is defined
+      - get_user_info_result[user_info_key].refresh is defined
+      - get_user_info_result[user_info_key].rows_per_page is defined
+      - get_user_info_result[user_info_key].surname is defined
+      - get_user_info_result[user_info_key].theme is defined
+      - get_user_info_result[user_info_key].roleid is defined
+      - get_user_info_result[user_info_key].url is defined
+      - get_user_info_result[user_info_key].userid is defined
+      - get_user_info_result[user_info_key].users_status is defined
+      - get_user_info_result[user_info_key].timezone is defined
+      - get_user_info_result[user_info_key].usrgrps | length == 2
+      - get_user_info_result[user_info_key].usrgrps.0.debug_mode is defined
+      - get_user_info_result[user_info_key].usrgrps.0.gui_access is defined
+      - get_user_info_result[user_info_key].usrgrps.0.name is defined
+      - get_user_info_result[user_info_key].usrgrps.0.users_status is defined
+      - get_user_info_result[user_info_key].usrgrps.0.usrgrpid is defined
+      - get_user_info_result[user_info_key].usrgrps.1.debug_mode is defined
+      - get_user_info_result[user_info_key].usrgrps.1.gui_access is defined
+      - get_user_info_result[user_info_key].usrgrps.1.name is defined
+      - get_user_info_result[user_info_key].usrgrps.1.users_status is defined
+      - get_user_info_result[user_info_key].usrgrps.1.usrgrpid is defined
+  when: zabbix_version is version('7.0', '>=')
 
 - name: test - Create a new Zabbix user
   community.zabbix.zabbix_user:
@@ -104,13 +133,6 @@
   community.zabbix.zabbix_user_info:
     username: example2
   register: get_user_info_result2
-
-- name: "test - Set key to user_info_key variable(This deals with the key being masked)"
-  ansible.builtin.set_fact:
-    user_info_key: "{{ item }}"
-  loop: "{{ get_user_info_result2.keys() | list }}"
-  when:
-    - item | regex_search('_user')
 
 - ansible.builtin.assert:
     that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add ansible-core 2.19 to CI target
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- The zabbix >= 6.4 dumps data without date. therefore, omit_date parameter of zabbix_template_info module will be useless paeameter.
  - https://www.zabbix.com/documentation/6.4/en/manual/api/reference/configuration/export
- This PR is for https://github.com/ansible-collections/community.zabbix/issues/1513
  - but, this PR does not contain roles test. 

```paste below

```
