### PR TITLE
The zabbix-agent service on Windows can be finicky

### DIFF
--- a/changelogs/fragments/1518_agent_win_service.yml
+++ b/changelogs/fragments/1518_agent_win_service.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - roles/zabbix_agent - Tweaking the windows service

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -229,6 +229,25 @@ Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
 * `zabbix_win_install_dir_bin`: The directory where Zabbix binary file needs to be installed.
 * `zabbix_win_package`: file name pattern (zip only). This will be used to generate the `zabbix_win_download_link` variable.
 
+### Tweaking the windows service
+
+There might be times where the service is unpredictable, and rather than
+investigating or dealing with it, you can just have it restart upon failure.
+Here are some suggested values for tweaking the service.
+
+* `zabbix_agent_service_start_mode:` `auto`, zabbix comes by default with `delayed`.
+* ```yaml
+  zabbix_agent_service_failure_actions:
+      - type: restart
+        delay_ms: 10000
+      - type: restart
+        delay_ms: 20000
+      - type: restart
+        delay_ms: 40000
+  ```
+* `zabbix_agent_service_failure_reset_period_sec:` `86400` is probably a reasonable time
+
+
 ## macOS Variables
 
 **NOTE**

--- a/roles/zabbix_agent/tasks/configure-Windows.yml
+++ b/roles/zabbix_agent/tasks/configure-Windows.yml
@@ -79,4 +79,8 @@
   ansible.windows.win_service:
     name: "{{ zabbix_agent_win_service }}"
     state: started
-    start_mode: delayed
+    start_mode: "{{ zabbix_agent_service_start_mode | default('delayed') }}"
+    failure_actions: "{{ zabbix_agent_service_failure_actions | default(omit) }}"
+    failure_reset_period_sec: "{{ zabbix_agent_service_failure_reset_period_sec | default(omit) }}"
+  register: _zabbix_agent_service_started
+  until: _zabbix_agent_service_started is succeeded


### PR DESCRIPTION
##### SUMMARY
We use the 'until' keyword incase the service is uncooperative during our deployment.
('until' has the defaults retries: 3, delay: 5)

Allow the user to override the service, by setting things like;
zabbix_agent_service_start_mode: auto
zabbix_agent_service_failure_actions: []
zabbix_agent_service_failure_reset_period_sec: 86400

I don't think altering the defaults for the service is something we should be doing, but we can enable deployers to do so if they so choose.

Fixes #1503

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles/zabbix_agent
