### PR TITLE
Remove ansible-core 2.15 from integration-test target

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -25,7 +25,6 @@ jobs:
           - version: "7.2"
         ansible:
           # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs
-          - stable-2.15
           - stable-2.16
           - stable-2.17
           - stable-2.18
@@ -45,10 +44,6 @@ jobs:
             python: '3.13'
           - ansible: stable-2.16
             python: '3.13'
-          - ansible: stable-2.15
-            python: '3.13'
-          - ansible: stable-2.15
-            python: '3.12'
           - ansible: stable-2.16
             python: '3.9'
           - ansible: stable-2.17

--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -30,7 +30,6 @@ jobs:
           - stable-2.18
           - devel
         python:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
@@ -38,18 +37,10 @@ jobs:
         exclude:
           - ansible: stable-2.18
             python: '3.10'
-          - ansible: stable-2.18
-            python: '3.9'
           - ansible: stable-2.17
             python: '3.13'
           - ansible: stable-2.16
             python: '3.13'
-          - ansible: stable-2.16
-            python: '3.9'
-          - ansible: stable-2.17
-            python: '3.9'
-          - ansible: devel
-            python: '3.9'
           - ansible: devel
             python: '3.10'
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Click on the name of a plugin or module to view that content's documentation:
 
 Some of the components in this collection requires additional dependencies. Review components you are interested in by visiting links present in the [Included content](#included-content) section.
 
-While the various roles and modules may work with earlier versions of Python and Ansible, they are only tested and maintained against Ansible Core >= 2.15 and python >= 3.9 
+While the various roles and modules may work with earlier versions of Python and Ansible, they are only tested and maintained against Ansible Core >= 2.16 and python >= 3.9
 
 #### External Collections
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove ansible-core 2.15 from test target
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- all modules
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- ansible-core 2.15 is EoL at Nov. 2024
  - https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
- We can remove 2.15 from integration-test target.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
