### PR TITLE
[Suggestion] Change ansible-core version of role tests

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -26,14 +26,16 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - rockylinux9
-          - rockylinux8
-          - ubuntu2404
-          - ubuntu2204
-          - ubuntu2004
-          - debian12
-          - debian11
-          - opensuseleap15
+          - image: rockylinux9
+          - image: rockylinux8
+            ansible_core: ansible-core<2.17
+          - image: ubuntu2404
+          - image: ubuntu2204
+          - image: ubuntu2004
+          - image: debian12
+          - image: debian11
+          - image: opensuseleap15
+            ansible_core: ansible-core<2.17
         version:
           - v72
           - v70
@@ -53,10 +55,15 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Install latest pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install specific version ansible-core
+        if: matrix.container.ansible_core != null
+        run: pip install "${{ matrix.container.ansible_core }}"
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r molecule/requirements.txt
+        run: pip install -r molecule/requirements.txt
 
       - name: Build the collection
         run: |
@@ -77,8 +84,8 @@ jobs:
       - name: Run role tests
         working-directory: molecule/zabbix_agent_tests
         run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container }}
-          MY_MOLECULE_IMAGE=${{ matrix.container }}
+          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
+          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
           MY_MOLECULE_VERSION=${{ matrix.version }}
           MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
           molecule -c common/molecule.yml test -s ${{ matrix.scenario_name }}

--- a/.github/workflows/javagateway.yml
+++ b/.github/workflows/javagateway.yml
@@ -26,14 +26,16 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - rockylinux9
-          - rockylinux8
-          - ubuntu2404
-          - ubuntu2204
-          - ubuntu2004
-          - debian12
-          - debian11
-          - opensuseleap15
+          - image: rockylinux9
+          - image: rockylinux8
+            ansible_core: ansible-core<2.17
+          - image: ubuntu2404
+          - image: ubuntu2204
+          - image: ubuntu2004
+          - image: debian12
+          - image: debian11
+          - image: opensuseleap15
+            ansible_core: ansible-core<2.17
         version:
           - v72
           - v70
@@ -49,10 +51,15 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Install latest pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install specific version ansible-core
+        if: matrix.container.ansible_core != null
+        run: pip install "${{ matrix.container.ansible_core }}"
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r molecule/requirements.txt
+        run: pip install -r molecule/requirements.txt
 
       - name: Build the collection
         run: |
@@ -72,8 +79,8 @@ jobs:
 
       - name: Run role tests
         run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container }}
-          MY_MOLECULE_IMAGE=${{ matrix.container }}
+          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
+          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
           MY_MOLECULE_VERSION=${{ matrix.version }}
           MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
           molecule test -s ${{ matrix.collection_role }}

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -26,14 +26,16 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - rockylinux9
-          - rockylinux8
-          - ubuntu2404
-          - ubuntu2204
-          - ubuntu2004
-          - debian12
-          - debian11
-          - opensuseleap15
+          - image: rockylinux9
+          - image: rockylinux8
+            ansible_core: ansible-core<2.17
+          - image: ubuntu2404
+          - image: ubuntu2204
+          - image: ubuntu2004
+          - image: debian12
+          - image: debian11
+          - image: opensuseleap15
+            ansible_core: ansible-core<2.17
         collection_role:
           - zabbix_proxy
           - zabbix_proxy_psk
@@ -55,10 +57,15 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Install latest pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install specific version ansible-core
+        if: matrix.container.ansible_core != null
+        run: pip install "${{ matrix.container.ansible_core }}"
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r molecule/requirements.txt
+        run: pip install -r molecule/requirements.txt
 
       - name: Build the collection
         run: |
@@ -78,8 +85,8 @@ jobs:
 
       - name: Run role tests
         run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container }}
-          MY_MOLECULE_IMAGE=${{ matrix.container }}
+          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
+          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
           MY_MOLECULE_VERSION=${{ matrix.version }}
           MY_MOLECULE_DATABASE=${{ matrix.database }}
           MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -20,14 +20,16 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - rockylinux9
-          - rockylinux8
-          - ubuntu2404
-          - ubuntu2204
-          - ubuntu2004
-          - debian12
-          - debian11
-          - opensuseleap15
+          - image: rockylinux9
+          - image: rockylinux8
+            ansible_core: ansible-core<2.17
+          - image: ubuntu2404
+          - image: ubuntu2204
+          - image: ubuntu2004
+          - image: debian12
+          - image: debian11
+          - image: opensuseleap15
+            ansible_core: ansible-core<2.17
         collection_role:
           - zabbix_repo
         version:
@@ -44,10 +46,15 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Install latest pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install specific version ansible-core
+        if: matrix.container.ansible_core != null
+        run: pip install "${{ matrix.container.ansible_core }}"
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r molecule/requirements.txt
+        run: pip install -r molecule/requirements.txt
 
       - name: Build the collection
         run: |
@@ -67,8 +74,8 @@ jobs:
 
       - name: Run role tests
         run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container }}
-          MY_MOLECULE_IMAGE=${{ matrix.container }}
+          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
+          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
           MY_MOLECULE_VERSION=${{ matrix.version }}
           MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
           molecule test -s ${{ matrix.collection_role }}

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -26,14 +26,16 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - rockylinux9
-          - rockylinux8
-          - ubuntu2404
-          - ubuntu2204
-          - ubuntu2004
-          - debian12
-          - debian11
-          - opensuseleap15
+          - image: rockylinux9
+          - image: rockylinux8
+            ansible_core: ansible-core<2.17
+          - image: ubuntu2404
+          - image: ubuntu2204
+          - image: ubuntu2004
+          - image: debian12
+          - image: debian11
+          - image: opensuseleap15
+            ansible_core: ansible-core<2.17
         collection_role:
           - zabbix_server
         database:
@@ -44,13 +46,17 @@ jobs:
           - v70
           - v60
         exclude:
-          - container: ubuntu2004
+          - container:
+              image: ubuntu2004
             version: v72
-          - container: ubuntu2004
+          - container:
+              image: ubuntu2004
             version: v70
-          - container: debian11
+          - container:
+              image: debian11
             version: v72
-          - container: debian11
+          - container:
+              image: debian11
             version: v70
     steps:
       - name: Check out code
@@ -61,10 +67,15 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Install latest pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install specific version ansible-core
+        if: matrix.container.ansible_core != null
+        run: pip install "${{ matrix.container.ansible_core }}"
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r molecule/requirements.txt
+        run: pip install -r molecule/requirements.txt
 
       - name: Build the collection
         run: |
@@ -84,8 +95,8 @@ jobs:
 
       - name: Run role tests
         run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container }}
-          MY_MOLECULE_IMAGE=${{ matrix.container }}
+          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
+          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
           MY_MOLECULE_VERSION=${{ matrix.version }}
           MY_MOLECULE_DATABASE=${{ matrix.database }}
           MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -26,14 +26,14 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - rockylinux9
-          - rockylinux8
-          - ubuntu2404
-          - ubuntu2204
-          - ubuntu2004
-          - debian12
-          - debian11
-          # - opensuseleap15
+          - image: rockylinux9
+          - image: rockylinux8
+            ansible_core: ansible-core<2.17
+          - image: ubuntu2404
+          - image: ubuntu2204
+          - image: ubuntu2004
+          - image: debian12
+          - image: debian11
         collection_role:
           - zabbix_web
         database:
@@ -48,13 +48,17 @@ jobs:
           - v70
           - v60
         exclude:
-          - container: ubuntu2004
+          - container:
+              image: ubuntu2004
             version: v72
-          - container: ubuntu2004
+          - container:
+              image: ubuntu2004
             version: v70
-          - container: debian11
+          - container:
+              image: debian11
             version: v72
-          - container: debian11
+          - container:
+              image: debian11
             version: v70
     steps:
       - name: Check out code
@@ -65,10 +69,15 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Install latest pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install specific version ansible-core
+        if: matrix.container.ansible_core != null
+        run: pip install "${{ matrix.container.ansible_core }}"
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r molecule/requirements.txt
+        run: pip install -r molecule/requirements.txt
 
       - name: Build the collection
         run: |
@@ -88,8 +97,8 @@ jobs:
 
       - name: Run role tests
         run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container }}
-          MY_MOLECULE_IMAGE=${{ matrix.container }}
+          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
+          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
           MY_MOLECULE_VERSION=${{ matrix.version }}
           MY_MOLECULE_DATABASE=${{ matrix.database }}
           MY_MOLECULE_WEB_SERVER=${{ matrix.web_server }}

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,7 +1,7 @@
 # Install CI dependencies for the Zabbix Roles
-ansible-core<2.17
+ansible-core
 docker
-molecule>=6,<24.7.0
+molecule
 netaddr>=1.2.1
-pytest<8           # newer versions require python>=3.8
-pytest-testinfra<9 # newer versions require python>=3.9
+pytest
+pytest-testinfra


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change ansible-core version of role tests
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
all roles
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- currently, we are test roles with ansible-core 2.16.
- The version is older, therefore, I'd like to use latest ansible-core if there is no specific reason.
  - ex) ansible-core < 2.17 can run playbook against to RHEL 8 famiy. 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
