### PR TITLE
Remove ansible-core 2.15 from repo-sanity test and add ansible-core 2.19 to the test

### DIFF
--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - '3.10'
+          - '3.12'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -39,12 +39,13 @@ jobs:
           # Testing against `devel` may fail as new tests are added.
 
           # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs
-          - stable-2.15
           - stable-2.16
           - stable-2.17
+          - stable-2.18
+          - stable-2.19
           - devel
         python:
-          - '3.11'
+          - '3.12'
     runs-on: ubuntu-latest
     steps:
       # ansible-test requires the collection to be in a directory in the form


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Remove ansible-core 2.15(EoL) from repo-sanity test
- Add ansible-core 2.19(Next Release) to the test
- Change python version from 3.11 to 3.12
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
