### PR TITLE
Fix zabbix.conf.php permissions

### DIFF
--- a/changelogs/fragments/fix_zabbix_conf_php_filemode.yml
+++ b/changelogs/fragments/fix_zabbix_conf_php_filemode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_web role - fix /etc/zabbix/web/zabbix.conf.php file mode.

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -147,7 +147,6 @@ The following properties are specific to Zabbix 5.0 and for the PHP(-FPM) config
 * `zabbix_php_fpm_listen`: The path to a socket file or ipaddress:port combination on which PHP-FPM needs to listen. If none are provided, defaults are used.
 * `zabbix_php_fpm_conf_listen`: Default: `true`. If we want to configure the `zabbix_php_fpm_listen` in the PHP-FPM configuration file.
 * `zabbix_php_fpm_conf_user`: The owner of the socket file (When `zabbix_php_fpm_listen` contains a patch to a socket file).
-
 * `zabbix_php_fpm_conf_group`: The group of the owner of the socket file (When `zabbix_php_fpm_listen` contains a patch to a socket file).
 
 ### SElinux

--- a/molecule/zabbix_web/tests/test_default.py
+++ b/molecule/zabbix_web/tests/test_default.py
@@ -43,7 +43,7 @@ def test_zabbix_web(host):
         elif zabbix_websrv == "nginx":
             assert zabbix_web.user == "nginx"
             assert zabbix_web.group == "nginx"
-    assert zabbix_web.mode == 0o644
+    assert zabbix_web.mode == 0o640
 
 
 def test_zabbix_api(host):

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -6,7 +6,7 @@ zabbix_web_version_check: true
 # zabbix_web_version:
 zabbix_web_package_state: present
 zabbix_web_doubleprecision: false
-zabbix_web_conf_mode: "0644"
+zabbix_web_conf_mode: "0640"
 zabbix_web_connect_ha_backend: false
 zabbix_api_server_url: zabbix.example.com
 zabbix_web_http_server: apache

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -38,6 +38,8 @@ zabbix_php_fpm_conf_listen: true
 # zabbix_web_max_input_time: 300
 # zabbix_web_max_input_vars: 10000
 zabbix_apache_custom_includes: []
+zabbix_php_fpm_conf_user: "{{ zabbix_web_user }}"
+zabbix_php_fpm_conf_group: "{{ zabbix_web_group }}"
 
 # Database
 zabbix_server_database: pgsql

--- a/roles/zabbix_web/handlers/main.yml
+++ b/roles/zabbix_web/handlers/main.yml
@@ -36,4 +36,6 @@
     state: restarted
     enabled: true
   become: true
-  when: ansible_facts['os_family'] == 'Suse'
+  when: >
+    ansible_facts['os_family'] == 'Suse' or
+    ansible_facts['os_family'] == 'RedHat'

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -95,8 +95,8 @@
 - name: "Create zabbix-web directory"
   ansible.builtin.file:
     path: /etc/zabbix/web
-    owner: "{{ zabbix_web_user }}"
-    group: "{{ zabbix_web_group }}"
+    owner: "{{ zabbix_php_fpm_conf_user }}"
+    group: "{{ zabbix_php_fpm_conf_group }}"
     state: directory
     mode: 0755
   become: true
@@ -108,8 +108,8 @@
   ansible.builtin.template:
     src: zabbix.conf.php.j2
     dest: /etc/zabbix/web/zabbix.conf.php
-    owner: "{{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is defined else zabbix_web_user }}"
-    group: "{{ zabbix_php_fpm_conf_group if zabbix_php_fpm_conf_group is defined else zabbix_web_group }}"
+    owner: "{{ zabbix_php_fpm_conf_user }}"
+    group: "{{ zabbix_php_fpm_conf_group }}"
     mode: "{{ zabbix_web_conf_mode }}"
   become: true
   tags:
@@ -119,8 +119,8 @@
   ansible.builtin.template:
     src: php-fpm.conf.j2
     dest: "{{ zabbix_php_fpm_dir }}/zabbix.conf"
-    owner: "{{ zabbix_web_user }}"
-    group: "{{ zabbix_web_group }}"
+    owner: "{{ zabbix_php_fpm_conf_user }}"
+    group: "{{ zabbix_php_fpm_conf_group }}"
     mode: 0644
   become: true
   when:

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -115,7 +115,7 @@
   tags:
     - config
 
-- name: "Debian / Suse | Install PHP"
+- name: "Install PHP"
   ansible.builtin.template:
     src: php-fpm.conf.j2
     dest: "{{ zabbix_php_fpm_dir }}/zabbix.conf"
@@ -125,7 +125,6 @@
   become: true
   when:
     - zabbix_web_create_php_fpm
-    - ansible_facts['os_family'] in ["Debian", "Suse"]
   notify:
     - restart php-fpm-version
     - restart php-fpm

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -108,8 +108,8 @@
   ansible.builtin.template:
     src: zabbix.conf.php.j2
     dest: /etc/zabbix/web/zabbix.conf.php
-    owner: "{{ zabbix_web_user }}"
-    group: "{{ zabbix_web_group }}"
+    owner: "{{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is defined else zabbix_web_user }}"
+    group: "{{ zabbix_php_fpm_conf_group if zabbix_php_fpm_conf_group is defined else zabbix_web_group }}"
     mode: "{{ zabbix_web_conf_mode }}"
   become: true
   tags:

--- a/roles/zabbix_web/templates/php-fpm.conf.j2
+++ b/roles/zabbix_web/templates/php-fpm.conf.j2
@@ -1,12 +1,12 @@
 [zabbix]
-user = {{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is defined else zabbix_web_user }}
-group = {{ zabbix_php_fpm_conf_group if zabbix_php_fpm_conf_group is defined else zabbix_web_group }}
+user = {{ zabbix_php_fpm_conf_user }}
+group = {{ zabbix_php_fpm_conf_group }}
 
 listen = {{ zabbix_php_fpm_listen }}
 {% if zabbix_php_fpm_conf_listen and ansible_facts['os_family'] not in ['Debian', 'Suse'] %}
-listen.acl_users = {{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is defined else zabbix_web_user }}
+listen.acl_users = {{ zabbix_php_fpm_conf_user }}
 {% endif %}
-listen.owner = {{ zabbix_php_fpm_conf_user if zabbix_php_fpm_conf_user is defined else zabbix_web_user }}
+listen.owner = {{ zabbix_php_fpm_conf_user }}
 listen.group = {{ _nginx_group if zabbix_web_http_server=='nginx' else _apache_group }}
 listen.mode = 0660
 listen.allowed_clients = 127.0.0.1


### PR DESCRIPTION
##### SUMMARY
Replacement for https://github.com/ansible-collections/community.zabbix/pull/1489

Restrict access to the web frontend config file /etc/zabbix/web/zabbix.conf.php.
The file contains passwords, so should not be publicly readable. Also fix the owner for the case that the fpm user differs from the www user.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_web role