### PR TITLE
Sane Selinux defaults

### DIFF
--- a/changelogs/fragments/1537_selinux.yml
+++ b/changelogs/fragments/1537_selinux.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - roles - sane selinux defaults

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -142,6 +142,9 @@ The following is an overview of all available configuration default for this rol
 
 Selinux changes will be installed based on the status of selinux running on the target system.
 
+* `selinux_allow_zabbix_can_network`: Default: `True`.
+* `selinux_allow_daemons_enable_cluster_mode`: Default: `False`.
+
 ## Proxy
 
 When the target host does not have access to the internet, but you do have a proxy available then the following properties needs to be set to download the packages via the proxy:

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -143,7 +143,6 @@ The following is an overview of all available configuration default for this rol
 Selinux changes will be installed based on the status of selinux running on the target system.
 
 * `selinux_allow_zabbix_can_network`: Default: `True`.
-* `selinux_allow_daemons_enable_cluster_mode`: Default: `False`.
 
 ## Proxy
 

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -114,7 +114,7 @@ The following is an overview of all available configuration default for this rol
 
 Selinux changes will be installed based on the status of selinux running on the target system.
 
-* `selinux_allow_zabbix_can_network`: Default: `False`. 
+* `selinux_allow_zabbix_can_network`: Default: `True`.
 
 ### Zabbix Server
 

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -153,9 +153,9 @@ The following properties are specific to Zabbix 5.0 and for the PHP(-FPM) config
 
 Selinux changes will be installed based on the status of selinux running on the target system.
 
-* `selinux_allow_httpd_can_connect_zabbix`: Default: `false`. Set SELinux boolean to allow httpd to connect to zabbix.
-* `selinux_allow_httpd_can_connect_ldap`: Default: `false`. Set SELinux boolean to allow httpd to connect to LDAP.
-* `selinux_allow_httpd_can_network_connect_db`: Default: `false` Set SELinux boolean to allow httpd to connect databases over the network.
+* `selinux_allow_httpd_can_connect_ldap`: Default: `False`. Set SELinux boolean to allow httpd to connect to LDAP.
+* `selinux_allow_httpd_can_connect_zabbix`: Default: `True`. Set SELinux boolean to allow httpd to connect to zabbix.
+* `selinux_allow_httpd_can_network_connect_db`: Default: `True` Set SELinux boolean to allow httpd to connect databases over the network.
 
 ### Zabbix Server
 

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -31,7 +31,6 @@ zabbix_proxy_database_file_dir: "{{ zabbix_proxy_version is version('7.0', '>') 
 
 # SELinux specific
 selinux_allow_zabbix_can_network: true
-selinux_allow_daemons_enable_cluster_mode: false
 
 # Misc.
 zabbix_proxy_cat_cmd: cat

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -30,7 +30,7 @@ zabbix_proxy_install_database_client: true
 zabbix_proxy_database_file_dir: "{{ zabbix_proxy_version is version('7.0', '>') | ternary(_zabbix_proxy_database_file_dir_post72, _zabbix_proxy_database_file_dir_pre72 ) }}"
 
 # SELinux specific
-selinux_allow_zabbix_can_network: false
+selinux_allow_zabbix_can_network: true
 selinux_allow_daemons_enable_cluster_mode: false
 
 # Misc.

--- a/roles/zabbix_proxy/tasks/selinux.yml
+++ b/roles/zabbix_proxy/tasks/selinux.yml
@@ -25,5 +25,3 @@
   loop:
     - name: zabbix_can_network
       state: "{{ selinux_allow_zabbix_can_network }}"
-    - name: daemons_enable_cluster_mode
-      state: "{{ selinux_allow_daemons_enable_cluster_mode }}"

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -29,7 +29,7 @@ zabbix_server_install_database_client: true
 zabbix_server_database_schemas: "{{ _zabbix_server_database_schemas[zabbix_server_database] }}"
 
 # SELinux specific
-selinux_allow_zabbix_can_network: false
+selinux_allow_zabbix_can_network: true
 
 #Misc.
 zabbix_server_include_mode: "0755"

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -71,8 +71,8 @@ zabbix_server_history_types:
 
 # SELinux specific
 selinux_allow_httpd_can_connect_ldap: false
-selinux_allow_httpd_can_network_connect_db: false
-selinux_allow_httpd_can_connect_zabbix: false
+selinux_allow_httpd_can_connect_zabbix: true
+selinux_allow_httpd_can_network_connect_db: true
 
 zabbix_repo_deb_gpg_key_url: http://repo.zabbix.com/zabbix-official-repo.key
 zabbix_repo_deb_include_deb_src: true


### PR DESCRIPTION
##### SUMMARY
Deal with selinux variables we know something about so this just works out of the box.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles for server, proxy and web

##### ADDITIONAL INFORMATION
This alters the defaults, but for good reason, and the people deploying are probably already setting these, so there shouldn't be any surprises.