### PR TITLE
Add support for custom HTTP headers in Zabbix API requests

### DIFF
--- a/changelogs/fragments/ansible_zabbix_http_headers.yml
+++ b/changelogs/fragments/ansible_zabbix_http_headers.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add `zabbix_http_headers` variable to allow specifying custom HTTP headers for Zabbix API calls. This can be useful for authentication or other custom header requirements."

--- a/plugins/httpapi/zabbix.py
+++ b/plugins/httpapi/zabbix.py
@@ -48,6 +48,13 @@ options:
       - The http password to access zabbix url with Basic Auth
     vars:
       - name: http_login_password
+  zabbix_http_headers:
+    type: dict
+    description:
+      - A dictionary of additional HTTP headers to be sent with every request to the Zabbix API.
+      - These headers are applied first, and can be overridden by plugin-specific headers like 'Authorization'.
+    vars:
+      - name: ansible_zabbix_http_headers
 """
 
 import json
@@ -119,6 +126,11 @@ class HttpApi(HttpApiBase):
 
     def send_request(self, data, request_method="POST", path="/api_jsonrpc.php"):
         headers = {}
+        # Apply custom headers first. Plugin-specific headers set later will take precedence.
+        custom_headers = self.get_option('zabbix_http_headers')
+        if isinstance(custom_headers, dict):
+            headers.update(custom_headers)
+
         path = self.url_path + path
 
         if self.auth and data['method'] not in ['user.login', 'apiinfo.version']:


### PR DESCRIPTION
##### SUMMARY

Add custom header support via "ansible_zabbix_http_headers" var. 

```
ansible_zabbix_http_headers:
  custom-access-token: "abcdef"
```

Fixes #1119

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

All components
