### PR TITLE
Fixing the zabbix_proxy_proxyconfigfrequency

### DIFF
--- a/changelogs/fragments/1558_fixing_zabbix_proxy_proxyconfigfrequency.yml
+++ b/changelogs/fragments/1558_fixing_zabbix_proxy_proxyconfigfrequency.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - roles/proxy - Fixing the zabbix_proxy_proxyconfigfrequency functionality

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -308,7 +308,7 @@ The following table lists all variables that are exposed to modify the configura
 | AllowRoot | zabbix_proxy_allowroot | `False` | `True`/`False` |
 | AllowUnsupportedDBVersions | zabbix_proxy_allowunsupporteddbversions | `False` | `True`/`False` |
 | CacheSize | zabbix_proxy_cachesize | 32M | |
-| ConfigFrequency | zabbix_proxy_configfrequency | 3600 | |
+| ConfigFrequency | zabbix_proxy_configfrequency | 3600 | Being deprecated. In conflict with ProxyConfigFrequency. |
 | DataSenderFrequency | zabbix_proxy_datasenderfrequency | 1 | |
 | DBHost | zabbix_proxy_dbhost | localhost| |
 | DBName | zabbix_proxy_dbname | zabbix_proxy| |
@@ -350,7 +350,7 @@ The following table lists all variables that are exposed to modify the configura
 | MaxConcurrentChecksPerPoller | zabbix_proxy_maxconcurrentchecksperpoller | 1000 | Version 7.0 or Greater |
 | PidFile | zabbix_proxy_pidfile | /var/run/zabbix/zabbix_proxy.pid| |
 | ProxyBufferMode | zabbix_proxy_proxybuffermode | disk | Version 7.0 or Greater |
-| ProxyConfigFrequency | zabbix_proxy_proxyconfigfrequency | 10 | Version 6.4 or Lower |
+| ProxyConfigFrequency | zabbix_proxy_proxyconfigfrequency | 10 | Version 6.4 or Greater |
 | ProxyLocalBuffer | zabbix_proxy_proxylocalbuffer |0| |
 | ProxyMemoryBufferAge | zabbix_proxy_proxymemorybufferage | 0 | Version 7.0 or Greater |
 | ProxyMemoryBufferSize | zabbix_proxy_proxymemorybuffersize | 0 | Version 7.0 or Greater |

--- a/roles/zabbix_proxy/defaults/main.yml
+++ b/roles/zabbix_proxy/defaults/main.yml
@@ -77,7 +77,7 @@ zabbix_proxy_logtype: file
 zabbix_proxy_maxconcurrentchecksperpoller: 1000
 zabbix_proxy_pidfile: /var/run/zabbix/zabbix_proxy.pid
 zabbix_proxy_proxybuffermode: disk
-ProxyConfigFrequency: 10
+zabbix_proxy_proxyconfigfrequency: 10
 zabbix_proxy_proxylocalbuffer: 0
 zabbix_proxy_proxymemorybufferage: 0
 zabbix_proxy_proxymemorybuffersize: 0

--- a/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
+++ b/roles/zabbix_proxy/templates/zabbix_proxy.conf.j2
@@ -9,7 +9,11 @@
 {{ (zabbix_proxy_allowroot is defined and zabbix_proxy_allowroot is not none) | ternary('','# ') }}AllowRoot={{ zabbix_proxy_allowroot | default (false) | ternary('1', '0') }}
 {{ (zabbix_proxy_allowunsupporteddbversions is defined and zabbix_proxy_allowunsupporteddbversions is not none) | ternary('','# ') }}AllowUnsupportedDBVersions={{ zabbix_proxy_allowunsupporteddbversions | default (false) | ternary('1', '0') }}
 {{ (zabbix_proxy_cachesize is defined and zabbix_proxy_cachesize is not none) | ternary('','# ') }}CacheSize={{ zabbix_proxy_cachesize | default('') }}
+
+{% if zabbix_proxy_version is version('6.4', '<=') %}
 {{ (zabbix_proxy_configfrequency is defined and zabbix_proxy_configfrequency is not none) | ternary('','# ') }}ConfigFrequency={{ zabbix_proxy_configfrequency | default('') }}
+{% endif %}
+
 {{ (zabbix_proxy_datasenderfrequency is defined and zabbix_proxy_datasenderfrequency is not none) | ternary('','# ') }}DataSenderFrequency={{ zabbix_proxy_datasenderfrequency | default('') }}
 {{ (zabbix_proxy_dbhost is defined and zabbix_proxy_dbhost is not none) | ternary('','# ') }}DBHost={{ zabbix_proxy_dbhost | default('') }}
 {{ (zabbix_proxy_dbname is defined and zabbix_proxy_dbname is not none) | ternary('','# ') }}DBName={{ zabbix_proxy_dbname | default('') }}
@@ -57,7 +61,7 @@
 {{ (zabbix_proxy_proxybuffermode is defined and zabbix_proxy_proxybuffermode is not none) | ternary('','# ') }}ProxyBufferMode={{ zabbix_proxy_proxybuffermode | default('') }}
 {% endif %}
 
-{% if zabbix_proxy_version is version('6.4', '<=') %}
+{% if zabbix_proxy_version is version('6.4', '>=') %}
 {{ (zabbix_proxy_proxyconfigfrequency is defined and zabbix_proxy_proxyconfigfrequency is not none) | ternary('','# ') }}ProxyConfigFrequency={{ zabbix_proxy_proxyconfigfrequency | default('') }}
 {% endif %}
 


### PR DESCRIPTION
##### SUMMARY
Fixing the zabbix_proxy_proxyconfigfrequency functionality.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_proxy

##### ADDITIONAL INFORMATION
The ProxyConfigFrequency is actually new as of v6.4 and the ConfigFrequency is being deprecated.
Found several issues in the YML configs.