### PR TITLE
added possibility to tune php-fpm process management

### DIFF
--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -148,6 +148,22 @@ The following properties are specific to Zabbix 5.0 and for the PHP(-FPM) config
 * `zabbix_php_fpm_conf_user`: The owner of the socket file (When `zabbix_php_fpm_listen` contains a patch to a socket file).
 * `zabbix_php_fpm_conf_group`: The group of the owner of the socket file (When `zabbix_php_fpm_listen` contains a patch to a socket file).
 
+The following values can be used to tune php-fpm for better performance on the frontend:
+
+* `zabbix_web_php_fpm_process_manager_mode`: Set the mode the php process management will work in. Available dynamic, static, ondemand - default: dynamic
+* `zabbix_web_php_fpm_process_manager_max_childs`: Set maximum number of process children php-fpm can spawn - default: 50
+* `zabbix_web_php_fpm_process_manager_start_servers`: The number of child process to be spawned on start. default: 5
+* `zabbix_web_php_fpm_process_manager_min_spare_servers`: The minimum number of idle child processes PHP-FPM will create. More are created if fewer than this number are available. - default: 5
+* `zabbix_web_php_fpm_process_manager_max_spare_servers`: The maximum number of idle child processes PHP-FPM will create. If there are more child processes available than this value, then some will be killed off. - default: 35
+
+##### Tunning recommendations
+| Setting                                              | Value |
+|------------------------------------------------------|-----------------------------------------------|
+| zabbix_web_php_fpm_process_manager_max_childs        | (Total RAM – Memory used for Linux, DB, etc.) / process size |
+| zabbix_web_php_fpm_process_manager_start_servers     | Number of CPU cores x 4 |
+| zabbix_web_php_fpm_process_manager_min_spare_servers | Number of CPU cores x 2 |
+| zabbix_web_php_fpm_process_manager_max_spare_servers | Same as start_servers   |
+
 ### SElinux
 
 Selinux changes will be installed based on the status of selinux running on the target system.

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -40,6 +40,12 @@ zabbix_php_fpm_conf_listen: true
 zabbix_apache_custom_includes: []
 zabbix_php_fpm_conf_user: "{{ zabbix_web_user }}"
 zabbix_php_fpm_conf_group: "{{ zabbix_web_group }}"
+zabbix_web_php_fpm_process_manager_mode: dynamic
+zabbix_web_php_fpm_process_manager_max_childs: 50
+zabbix_web_php_fpm_process_manager_start_servers: 5
+zabbix_web_php_fpm_process_manager_min_spare_servers: 5
+zabbix_web_php_fpm_process_manager_max_spare_servers: 35
+
 
 # Database
 zabbix_server_database: pgsql

--- a/roles/zabbix_web/templates/php-fpm.conf.j2
+++ b/roles/zabbix_web/templates/php-fpm.conf.j2
@@ -11,11 +11,11 @@ listen.group = {{ _nginx_group if zabbix_web_http_server=='nginx' else _apache_g
 listen.mode = 0660
 listen.allowed_clients = 127.0.0.1
 
-pm = dynamic
-pm.max_children = 50
-pm.start_servers = 5
-pm.min_spare_servers = 5
-pm.max_spare_servers = 35
+pm = {{ zabbix_web_php_fpm_process_manager_mode }}
+pm.max_children = {{ zabbix_web_php_fpm_process_manager_max_childs }}
+pm.start_servers = {{ zabbix_web_php_fpm_process_manager_start_servers }}
+pm.min_spare_servers = {{ zabbix_web_php_fpm_process_manager_min_spare_servers }}
+pm.max_spare_servers = {{ zabbix_web_php_fpm_process_manager_max_spare_servers }}
 
 php_value[session.save_handler] = files
 php_value[session.save_path]    = {{ zabbix_php_fpm_session }}


### PR DESCRIPTION
##### SUMMARY
In our environment we had performance issues at the frontend and the frontend "crashing" multiple times since php-fpm processes were busy at 100% with serving dashboards and graphs. After tuning the process management and adapt it to our environment by allowing more process to be spawned the situation was greatly improved.

Since the role zabbix_web delivers constant values for the process management of php-fpm this change is to allow the tuning of these values.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
role zabbix_web - task copy php-fpm config

##### ADDITIONAL INFORMATION
Tuning of php-fpm was done according to this [guide](https://tideways.com/profiler/blog/an-introduction-to-php-fpm-tuning).  Added recommendations also to Readme.
