### PR TITLE
Feature: Clear and unlink all template from host

### DIFF
--- a/changelogs/fragments/281_add_clear_all_link_templates
+++ b/changelogs/fragments/281_add_clear_all_link_templates
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - zabbix_host - Add the ability to unlink and clear all the linked template to an host. 

--- a/plugins/modules/zabbix_host.py
+++ b/plugins/modules/zabbix_host.py
@@ -920,7 +920,7 @@ class Host(ZabbixBase):
         request_str = {"hostid": host_id, "templates": template_id_list_, "templates_clear": templates_clear_list_}
         error_msg = "Failed to link templates to host: %s"
         if clear_all_link_templates:
-            request_str = {"hostid": host_id,"templates_clear": templates_clear_list_}
+            request_str = {"hostid": host_id, "templates_clear": templates_clear_list_}
             error_msg = "Failed to clear all templates from host: %s"
         try:
             if self._module.check_mode:
@@ -1172,9 +1172,9 @@ def main():
     host = Host(module)
 
     template_ids = []
-    if link_templates or clear_all_link_templates:
+    if link_templates:
         template_ids = host.get_template_ids(link_templates)
-    
+
     group_ids = []
 
     if host_groups is not None:
@@ -1346,7 +1346,7 @@ def main():
                     monitored_by, proxy_group_id)
 
                 if clear_all_link_templates:
-                     host.link_or_clear_template(host_id, template_ids,clear_all_link_templates=True)
+                    host.link_or_clear_template(host_id, template_ids, clear_all_link_templates=True)
                 else:
                     host.link_or_clear_template(host_id, template_ids)
 

--- a/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
+++ b/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
@@ -408,6 +408,27 @@
     that:
       - "not zabbix_host1 is changed"
 
+- name: "test: change add linked templates"
+  community.zabbix.zabbix_host:
+    host_name: ExampleHost
+    link_templates:
+      - "IMAP Service"
+      - "NTP Service"
+      - "HTTP Service"
+      - "LDAP Service"
+  register: zabbix_host1
+
+- name: "test: Unlink and Clear all linked templates"
+  community.zabbix.zabbix_host:
+    host_name: ExampleHost
+    clear_all_link_templates: True
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  ansible.builtin.assert:
+    that:
+      -  zabbix_host1 is changed"
+
 - name: "test: change host status"
   community.zabbix.zabbix_host:
     host_name: ExampleHost

--- a/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
+++ b/tests/integration/targets/test_zabbix_host/tasks/zabbix_host_tests.yml
@@ -427,7 +427,7 @@
 - name: expect to succeed and that things have changed
   ansible.builtin.assert:
     that:
-      -  zabbix_host1 is changed"
+      -  "zabbix_host1 is changed"
 
 - name: "test: change host status"
   community.zabbix.zabbix_host:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add features discussed in Issue #241 to Clear and unlink all templated of an host. 

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_host.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Remove and clear all linked template
  community.zabbix.zabbix_host:
    host_name: ExampleHost
    clear_all_link_templates: True
```
