### PR TITLE
Remove gather_facts variable set at task level

### DIFF
--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -76,7 +76,6 @@
 
 - name: "Run the API calls to Zabbix Server"
   vars:
-    gather_facts: false
     ansible_network_os: community.zabbix.zabbix
     ansible_connection: httpapi
     ansible_httpapi_use_ssl: "{{ zabbix_api_use_ssl }}"

--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -122,7 +122,6 @@
 
 - name: Ensure proxy definition is up-to-date (added/updated/removed) for Zabbix < 7.0
   vars:
-    gather_facts: false
     ansible_network_os: community.zabbix.zabbix
     ansible_connection: httpapi
     ansible_httpapi_use_ssl: "{{ zabbix_api_use_ssl }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ansible started reporting a reserved name variable (gather_facts) as being found. It's indeed set in some roles, but at task level, when that setting usually only applies at play level. So I simply removed it, as it didn't feel neither needed, nor useful.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent and zabbix_proxy roles

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```paste below
$ ansible-playbook test.yml
[WARNING]: Found variable using reserved name: gather_facts
PLAY [zabbix_agents] ************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************
ok: [...]

```
After:
```paste below
$ ansible-playbook test.yml
PLAY [zabbix_agents] ************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************
ok: [...]
```

I could not get molecule to run, but I guess the CI will pick it up...