### PR TITLE
Bugfix: Too many requests to check zabbix version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ antsibull-env
 
 # Ignore Dependency Roles that may get downloaded
 geerlingguy*
+
+# Ignore visual studio code Ansible extension things
+.ansible

--- a/changelogs/fragments/1583.yml
+++ b/changelogs/fragments/1583.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_agent role - fixes too many requests to check latest zabbix release

--- a/roles/zabbix_agent/tasks/install-Windows.yml
+++ b/roles/zabbix_agent/tasks/install-Windows.yml
@@ -5,6 +5,7 @@
     url: https://services.zabbix.com/updates/v1
     return_content: true
   register: _zabbix_versions
+  run_once: true
 
 - name: Set zabbix_version_long
   set_fact:


### PR DESCRIPTION
##### SUMMARY
Fixes #1583 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/zabbix_agent/tasks/configure-Windows.yml

##### ADDITIONAL INFORMATION
fixes too many requests to check latest zabbix release for Windows installation
