### PR TITLE
Fix: Windows installation path variables in zabbix_agent role

### DIFF
--- a/changelogs/fragments/1580.yml
+++ b/changelogs/fragments/1580.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - zabbix_agent - Fix all variables related to windows installation paths
+
+minor_changes:
+  - zabbix_agent - Removed zabbix_win_install_dir_conf variable and replaced with zabbix_agent_win_install_dir_conf
+  - zabbix_agent - Removed zabbix_win_install_dir variable and replaced with zabbix_agent_win_install_dir

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -223,8 +223,8 @@ Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
 * `zabbix_version_long`: The long (major.minor.patch) version of the Zabbix Agent. This will be used to generate the `zabbix_win_package` and `zabbix_win_download_link` variables. This takes precedence over `zabbix_agent_version`.
 * `zabbix_win_download_link`: The download url to the `win.zip` file.
 * `zabbix_win_firewall_management`: Enable Windows firewall management (add service and port to allow rules). Default: `True`
-* `zabbix_win_install_dir`: The directory where Zabbix needs to be installed.
-* `zabbix_win_install_dir_conf`: The directory where Zabbix configuration file needs to be installed.
+* `zabbix_agent_win_install_dir`: The directory where Zabbix needs to be installed. Default: `C:\Program Files\Zabbix Agent 2` when variable `zabbix_agent2` is true, `C:\Program Files\Zabbix Agent` when `zabbix_agent2` is false.
+* `zabbix_agent_win_install_dir_conf`: The directory where Zabbix configuration file needs to be installed. Default: `zabbix_agent_win_install_dir`
 * `zabbix_win_install_dir_bin`: The directory where Zabbix binary file needs to be installed.
 * `zabbix_win_package`: file name pattern (zip only). This will be used to generate the `zabbix_win_download_link` variable.
 

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -114,6 +114,7 @@ zabbix_agent_win_package: "{{ zabbix_agent2 | ternary('zabbix_agent2', 'zabbix_a
 zabbix_agent_win_download_url: "{{ zabbix_agent_download_base_url }}/{{ zabbix_agent_version }}/{{ zabbix_agent_version_long }}/{{ zabbix_agent_win_package }}"
 
 zabbix_agent_win_install_dir: "C:/Program Files/{{ zabbix_agent2 | ternary('Zabbix Agent 2', 'Zabbix Agent') }}"
+zabbix_agent_win_install_dir_conf: "{{ zabbix_agent_win_install_dir }}"
 zabbix_agent_win_exe_path: "{{ zabbix_agent_win_install_dir }}/{{ zabbix_agent2 | ternary('zabbix_agent2.exe', 'zabbix_agentd.exe') }}"
 zabbix_agent_win_service: "{{ zabbix_agent2 | ternary('Zabbix Agent 2', 'Zabbix Agent') }}"
 

--- a/roles/zabbix_agent/tasks/userparameter.yml
+++ b/roles/zabbix_agent/tasks/userparameter.yml
@@ -16,7 +16,7 @@
         - name: Windows | Install user-defined scripts
           ansible.windows.win_copy:
             src: "{{ zabbix_agent_userparameters_scripts_src }}/{{ item.scripts_dir }}"
-            dest: '{{ zabbix_win_install_dir }}\scripts\'
+            dest: '{{ zabbix_agent_win_install_dir }}\scripts\'
           loop: "{{ zabbix_agent_userparameters | selectattr('scripts_dir', 'defined') }}"
 
     - when:

--- a/roles/zabbix_agent/templates/userparameters/win_sample.j2
+++ b/roles/zabbix_agent/templates/userparameters/win_sample.j2
@@ -1,1 +1,1 @@
-UserParameter=do.something, powershell -NoProfile -ExecutionPolicy Bypass -File {{ zabbix_win_install_dir }}\scripts\{{ item.name }}\doSomething.ps1
+UserParameter=do.something, powershell -NoProfile -ExecutionPolicy Bypass -File {{ zabbix_agent_win_install_dir }}\scripts\{{ item.name }}\doSomething.ps1

--- a/roles/zabbix_agent/vars/Windows.yml
+++ b/roles/zabbix_agent/vars/Windows.yml
@@ -1,12 +1,12 @@
 ---
 
-_zabbix_agent_logfile: "{{ zabbix_win_install_dir }}\\{{ zabbix_agent2 | ternary('zabbix_agent2.log', 'zabbix_agentd.log') }}"
+_zabbix_agent_logfile: "{{ zabbix_agent_win_install_dir }}\\{{ zabbix_agent2 | ternary('zabbix_agent2.log', 'zabbix_agentd.log') }}"
 _zabbix_agent_include_dirs:
-  - "{{ zabbix_win_install_dir_conf }}\\{{ zabbix_agent2 | ternary('zabbix_agent2.d', 'zabbix_agent.d') }}"
+  - "{{ zabbix_agent_win_install_dir_conf }}\\{{ zabbix_agent2 | ternary('zabbix_agent2.d', 'zabbix_agent.d') }}"
 _zabbix_agent_controlsocket: "\\\\.\\pipe\\agent.sock"
 _zabbix_agent_pluginsocket: "\\\\.\\pipe\\agent.plugin.sock"
-_zabbix_agent_tlspskfile: "{{ zabbix_win_install_dir }}\\tls_psk_auto.secret.txt"
-_zabbix_agent_tlspskidentity_file: "{{ zabbix_win_install_dir }}\\tls_psk_auto.identity.txt"
+_zabbix_agent_tlspskfile: "{{ zabbix_agent_win_install_dir }}\\tls_psk_auto.secret.txt"
+_zabbix_agent_tlspskidentity_file: "{{ zabbix_agent_win_install_dir }}\\tls_psk_auto.identity.txt"
 
 # Maps from ansible_facts['architecture']
 _zabbix_agent_win_arch:


### PR DESCRIPTION
##### SUMMARY
Fixes: #1580 

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
zabbix_agent role

##### ADDITIONAL INFORMATION
I am not sure of purpose or initial meaning of variable zabbix_agent_win_install_dir_conf, it is used only one time and it confuse me. I decided to keep it as it is and not change it as I do not understand roots if this variable.