### PR TITLE
FIX: correct Windows paths for downloading and installing Zabbix Agent MSI

### DIFF
--- a/changelogs/fragments/1560.yml
+++ b/changelogs/fragments/1560.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - zabbix_agent role - Fix windows paths to download and install zabbix agent msi

--- a/roles/zabbix_agent/tasks/install-Windows.yml
+++ b/roles/zabbix_agent/tasks/install-Windows.yml
@@ -58,10 +58,14 @@
   vars:
     _install_latest: "{{ zabbix_agent_package_state == 'latest' }}"
   block:
+    - name: Get User Path
+      ansible.windows.win_shell: "echo $env:USERPROFILE"
+      register: _zabbix_agent_win_userprofile_path
+
     - name: Download Zabbix Agent
       ansible.windows.win_get_url:
         url: "{{ zabbix_agent_win_download_url }}"
-        dest: "C:/Users/{{ ansible_user }}/Downloads/{{ zabbix_agent_win_package }}"
+        dest: "{{ _zabbix_agent_win_userprofile_path.stdout | trim }}/Downloads/{{ zabbix_agent_win_package }}"
         url_username: "{{ zabbix_download_user | default(omit) }}"
         url_password: "{{ zabbix_download_pass | default(omit) }}"
         force: false
@@ -83,7 +87,7 @@
     # https://www.zabbix.com/documentation/current/en/manual/installation/install_from_packages/win_msi
     - name: Install Zabbix Agent
       ansible.windows.win_command:
-        chdir: "C:/Users/{{ ansible_user }}/Downloads"
+        chdir: "{{ _zabbix_agent_win_userprofile_path.stdout | trim }}/Downloads"
         argv:
           - msiexec
           - /i


### PR DESCRIPTION
##### SUMMARY
Fixes #1560 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_agent role

##### ADDITIONAL INFORMATION
Due to variability of paths to user profile paths in windows I added task to get this path beforehand.