### PR TITLE
This sanitize function is really bad, just made a quick fix for this …

### DIFF
--- a/plugins/modules/zabbix_trigger.py
+++ b/plugins/modules/zabbix_trigger.py
@@ -330,6 +330,7 @@ class Trigger(ZabbixBase):
                 params['type'] = 1
             else:
                 params['type'] = 0
+            del params['generate_multiple_events']
         if 'recovery_mode' in params:
             recovery_mode_id = self.RECOVERY_MODES[params['recovery_mode']]
             params['recovery_mode'] = recovery_mode_id


### PR DESCRIPTION
…option since the API returns Error on unexisting generate_multiple_events parameter.

It should use a brand new dictionnary to really sanitize anything

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
No time to make a full rebuild. Quick fix for API error with this option.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
No issue

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

zabbix_trigger

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Add the option generate_multiple_events and send it as a creation for a trigger in a up to date zabbix API server.

It will return an error since generate_multiple_events param doesn't exists on API side.

I added a delete on the generate_multiple_events key so it doesn't send it to the API.

The whole sanitize function is actually to rewrite.