### PR TITLE
Add option to turn off installing dependencies AND database client in zabbix-server role

### DIFF
--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -138,7 +138,7 @@ Selinux changes will be installed based on the status of selinux running on the 
 * `zabbix_server_dbpassword_hash_method`: Default: `md5`. Allow switching postgresql user password creation to `scram-sha-256`, when anything other than `md5` is used then ansible won't hash the password with `md5`.
 * `zabbix_server_database_creation`: Default: `True`. When you don't want to create the database including user, you can set it to False.
 * `zabbix_server_install_database_client`: Default: `True`. False does not install database client.
-* `zabbix_server_database_install_dependencies`: Default: `True`. False does not install database and depenencies.
+* `zabbix_server_install_dependencies`: Default: `True`. False does not install database and depenencies.
 * `zabbix_server_database_sqlload`:True / False. When you don't want to load the sql files into the database, you can set it to False.
 * `zabbix_server_database_timescaledb`:False / True. When you want to use timescaledb extension into the database, you can set it to True (this option only works for postgreSQL database).
 * `zabbix_server_database_schemas`: List of schemas to load, can be overridden for a non-supported/custom setup.

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -137,7 +137,8 @@ Selinux changes will be installed based on the status of selinux running on the 
 * `zabbix_server_dbport`: The database port which is used by the Zabbix Server.
 * `zabbix_server_dbpassword_hash_method`: Default: `md5`. Allow switching postgresql user password creation to `scram-sha-256`, when anything other than `md5` is used then ansible won't hash the password with `md5`.
 * `zabbix_server_database_creation`: Default: `True`. When you don't want to create the database including user, you can set it to False.
-* `zabbix_server_install_database_client`: Default: `True`. False does not install database client. Default true
+* `zabbix_server_install_database_client`: Default: `True`. False does not install database client.
+* `zabbix_server_database_install_dependencies`: Default: `True`. False does not install database and depenencies.
 * `zabbix_server_database_sqlload`:True / False. When you don't want to load the sql files into the database, you can set it to False.
 * `zabbix_server_database_timescaledb`:False / True. When you want to use timescaledb extension into the database, you can set it to True (this option only works for postgreSQL database).
 * `zabbix_server_database_schemas`: List of schemas to load, can be overridden for a non-supported/custom setup.

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -26,7 +26,7 @@ zabbix_server_dbhost_run_install: true
 zabbix_server_database: pgsql
 zabbix_server_database_creation: true
 zabbix_server_install_database_client: true
-zabbix_server_database_install_dependencies: true
+zabbix_server_install_dependencies: true
 zabbix_server_database_schemas: "{{ _zabbix_server_database_schemas[zabbix_server_database] }}"
 
 # SELinux specific

--- a/roles/zabbix_server/defaults/main.yml
+++ b/roles/zabbix_server/defaults/main.yml
@@ -26,6 +26,7 @@ zabbix_server_dbhost_run_install: true
 zabbix_server_database: pgsql
 zabbix_server_database_creation: true
 zabbix_server_install_database_client: true
+zabbix_server_database_install_dependencies: true
 zabbix_server_database_schemas: "{{ _zabbix_server_database_schemas[zabbix_server_database] }}"
 
 # SELinux specific

--- a/roles/zabbix_server/tasks/initialize-mysql.yml
+++ b/roles/zabbix_server/tasks/initialize-mysql.yml
@@ -1,7 +1,7 @@
 ---
 # task file for mysql
 - name: "Install MySQL dependencies"
-  when: zabbix_server_database_install_dependencies
+  when: zabbix_server_install_dependencies
   ansible.builtin.package:
     name: "{{ _zabbix_server_mysql_dependencies | select | list }}"
   environment:

--- a/roles/zabbix_server/tasks/initialize-mysql.yml
+++ b/roles/zabbix_server/tasks/initialize-mysql.yml
@@ -1,6 +1,7 @@
 ---
 # task file for mysql
 - name: "Install MySQL dependencies"
+  when: zabbix_server_database_install_dependencies
   ansible.builtin.package:
     name: "{{ _zabbix_server_mysql_dependencies | select | list }}"
   environment:

--- a/roles/zabbix_server/tasks/initialize-pgsql.yml
+++ b/roles/zabbix_server/tasks/initialize-pgsql.yml
@@ -1,7 +1,7 @@
 ---
 # task file for postgresql
 - name: "Install PostgreSQL dependencies"
-  when: zabbix_server_database_install_dependencies
+  when: zabbix_server_install_dependencies
   ansible.builtin.package:
     name: "{{ _zabbix_server_pgsql_dependencies | select | list }}"
   environment:

--- a/roles/zabbix_server/tasks/initialize-pgsql.yml
+++ b/roles/zabbix_server/tasks/initialize-pgsql.yml
@@ -1,6 +1,7 @@
 ---
 # task file for postgresql
 - name: "Install PostgreSQL dependencies"
+  when: zabbix_server_database_install_dependencies
   ansible.builtin.package:
     name: "{{ _zabbix_server_pgsql_dependencies | select | list }}"
   environment:


### PR DESCRIPTION
##### SUMMARY
Adding a feature to turn off installing dependencies and database client. This options is focused for when someone use:
```yaml
- ansible.builtin.include_role:
    name: community.zabbix.zabbix_server
    tasks_from: initialize-pgsql.yml
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
role/zabbix_server
