### PR TITLE
Fix http(s)_proxy statements

### DIFF
--- a/roles/zabbix_agent/tasks/configure-Docker.yml
+++ b/roles/zabbix_agent/tasks/configure-Docker.yml
@@ -46,6 +46,6 @@
     volumes: "{{ zabbix_agent_docker_volumes }}"
     env: "{{ zabbix_agent_docker_env }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   become: true

--- a/roles/zabbix_agent/tasks/install-Windows.yml
+++ b/roles/zabbix_agent/tasks/install-Windows.yml
@@ -70,7 +70,7 @@
         url_password: "{{ zabbix_download_pass | default(omit) }}"
         force: false
         follow_redirects: all
-        proxy_url: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+        proxy_url: "{{ zabbix_https_proxy | default(omit) }}"
         validate_certs: "{{ zabbix_download_validate_certs | default(false) | bool }}"
         timeout: "{{ zabbix_download_timeout | default(120) | int }}"
       register: _zabbix_agent_win_download

--- a/roles/zabbix_agent/tasks/install.yml
+++ b/roles/zabbix_agent/tasks/install.yml
@@ -7,8 +7,8 @@
     disablerepo: "{{ zabbix_agent_disable_repo | default(_zabbix_agent_disable_repo | default(omit)) }}"
     install_recommends: "{{ zabbix_apt_install_recommends | default(_zabbix_agent_install_recommends | default(omit)) }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: _zabbix_agent_packages_installed
   until: _zabbix_agent_packages_installed is succeeded
   become: true

--- a/roles/zabbix_agent/tasks/selinux.yml
+++ b/roles/zabbix_agent/tasks/selinux.yml
@@ -6,8 +6,8 @@
     update_cache: true
     install_recommends: "{{ zabbix_apt_install_recommends | default(_zabbix_agent_install_recommends | default(omit)) }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: zabbix_agent_selinux_installed
   until: zabbix_agent_selinux_installed is succeeded
   become: true
@@ -22,8 +22,8 @@
       - python3-policycoreutils
       - zabbix-selinux-policy
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: zabbix_agent_selinux_installed
   until: zabbix_agent_selinux_installed is succeeded
   when: ansible_facts['os_family'] == "RedHat"

--- a/roles/zabbix_javagateway/tasks/main.yml
+++ b/roles/zabbix_javagateway/tasks/main.yml
@@ -38,8 +38,8 @@
       - java-{{ zabbix_javagateway_openjdk_version }}-openjdk
     state: "{{ zabbix_javagateway_package_state }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: _zabbix_javagateway_openjdk
   until: _zabbix_javagateway_openjdk is succeeded
   become: true
@@ -54,8 +54,8 @@
     disablerepo: "{{ zabbix_javagateway_disable_repo | default(_zabbix_javagateway_disable_repo | default(omit)) }}"
     install_recommends: "{{ zabbix_javagateway_install_recommends | default(_zabbix_javagateway_install_recommends | default(omit)) }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: _zabbix_javagateway_install
   until: _zabbix_javagateway_install is succeeded
   become: true

--- a/roles/zabbix_proxy/tasks/initialize-mysql.yml
+++ b/roles/zabbix_proxy/tasks/initialize-mysql.yml
@@ -5,8 +5,8 @@
   ansible.builtin.package:
     name: "{{ _zabbix_proxy_mysql_dependencies }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   become: true
   register: _zabbix_proxy_dependencies_installed
   until: _zabbix_proxy_dependencies_installed is succeeded

--- a/roles/zabbix_proxy/tasks/initialize-pgsql.yml
+++ b/roles/zabbix_proxy/tasks/initialize-pgsql.yml
@@ -5,8 +5,8 @@
   ansible.builtin.package:
     name: "{{ _zabbix_proxy_pgsql_dependencies | select | list }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   become: true
   register: _zabbix_proxy_pgsql_packages_installed
   until: _zabbix_proxy_pgsql_packages_installed is succeeded

--- a/roles/zabbix_proxy/tasks/initialize-sqlite3.yml
+++ b/roles/zabbix_proxy/tasks/initialize-sqlite3.yml
@@ -5,8 +5,8 @@
   ansible.builtin.package:
     name: "{{ _zabbix_proxy_sqlite3_dependencies }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   become: true
   register: _zabbix_proxy_sqlite3_packages_installed
   until: _zabbix_proxy_sqlite3_packages_installed is succeeded

--- a/roles/zabbix_proxy/tasks/main.yml
+++ b/roles/zabbix_proxy/tasks/main.yml
@@ -59,8 +59,8 @@
     update_cache: true
     disablerepo: "{{ zabbix_proxy_disable_repo | default(_zabbix_proxy_disable_repo | default(omit)) }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: _zabbix_proxy_package_installed
   until: _zabbix_proxy_package_installed is succeeded
   become: true

--- a/roles/zabbix_proxy/tasks/selinux.yml
+++ b/roles/zabbix_proxy/tasks/selinux.yml
@@ -6,8 +6,8 @@
       - python3-policycoreutils
       - zabbix-selinux-policy
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: zabbix_proxy_dependencies_installed
   until: zabbix_proxy_dependencies_installed is succeeded
   become: true

--- a/roles/zabbix_repo/tasks/Debian.yml
+++ b/roles/zabbix_repo/tasks/Debian.yml
@@ -7,8 +7,8 @@
     force: true
     state: present
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: gnupg_installed
   until: gnupg_installed is succeeded
   become: true
@@ -36,8 +36,8 @@
     mode: "0644"
     force: true
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: zabbix_repo_files_installed
   until: zabbix_repo_files_installed is succeeded
   become: true

--- a/roles/zabbix_repo/tasks/RedHat.yml
+++ b/roles/zabbix_repo/tasks/RedHat.yml
@@ -14,8 +14,8 @@
     url: "{{ item }}"
     dest: "/etc/pki/rpm-gpg/{{ item | basename }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   become: true
   loop:
     - "{{ zabbix_repo_rpm_gpg_key_url }}"

--- a/roles/zabbix_server/tasks/initialize-mysql.yml
+++ b/roles/zabbix_server/tasks/initialize-mysql.yml
@@ -4,8 +4,8 @@
   ansible.builtin.package:
     name: "{{ _zabbix_server_mysql_dependencies | select | list }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: _zabbix_server_dependencies_installed
   until: _zabbix_server_dependencies_installed is succeeded
   become: true

--- a/roles/zabbix_server/tasks/initialize-pgsql.yml
+++ b/roles/zabbix_server/tasks/initialize-pgsql.yml
@@ -4,8 +4,8 @@
   ansible.builtin.package:
     name: "{{ _zabbix_server_pgsql_dependencies | select | list }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: _zabbix_server_dependencies_installed
   until: _zabbix_server_dependencies_installed is succeeded
   become: true

--- a/roles/zabbix_server/tasks/main.yml
+++ b/roles/zabbix_server/tasks/main.yml
@@ -40,8 +40,8 @@
     disablerepo: "{{ zabbix_server_disable_repo | default(_zabbix_server_disable_repo | default(omit)) }}"
     install_recommends: "{{ zabbix_server_install_recommends | default(_zabbix_server_install_recommends | default(omit)) }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: _zabbix_server_package_installed
   until: _zabbix_server_package_installed is succeeded
   become: true

--- a/roles/zabbix_server/tasks/selinux.yml
+++ b/roles/zabbix_server/tasks/selinux.yml
@@ -6,8 +6,8 @@
       - python3-policycoreutils
       - zabbix-selinux-policy
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: zabbix_server_dependencies_installed
   until: zabbix_server_dependencies_installed is succeeded
   become: true

--- a/roles/zabbix_web/tasks/apache.yml
+++ b/roles/zabbix_web/tasks/apache.yml
@@ -14,8 +14,8 @@
     update_cache: true
     disablerepo: "{{ zabbix_web_disable_repo | default(_zabbix_web_disable_repo | default(omit)) }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: zabbix_apache_conf_install
   until: zabbix_apache_conf_install is succeeded
   become: true

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -68,8 +68,8 @@
     update_cache: true
     disablerepo: "{{ zabbix_web_disable_repo | default(_zabbix_web_disable_repo | default(omit)) }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: _zabbix_web_package_installed
   until: _zabbix_web_package_installed is succeeded
   become: true

--- a/roles/zabbix_web/tasks/nginx.yml
+++ b/roles/zabbix_web/tasks/nginx.yml
@@ -17,8 +17,8 @@
     update_cache: true
     disablerepo: "{{ zabbix_web_disable_repo | default(_zabbix_web_disable_repo | default(omit)) }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: zabbix_nginx_conf_install
   until: zabbix_nginx_conf_install is succeeded
   become: true

--- a/roles/zabbix_web/tasks/selinux.yml
+++ b/roles/zabbix_web/tasks/selinux.yml
@@ -5,8 +5,8 @@
       - python3-libsemanage
       - python3-policycoreutils
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default(None) | default(omit) }}"
-    https_proxy: "{{ zabbix_https_proxy | default(None) | default(omit) }}"
+    http_proxy: "{{ zabbix_http_proxy | default('') }}"
+    https_proxy: "{{ zabbix_https_proxy | default('') }}"
   register: zabbix_web_dependencies_installed
   until: zabbix_web_dependencies_installed is succeeded
   become: true


### PR DESCRIPTION
##### SUMMARY
Fixes #1619

An empty string seems to be the way to not set environment variables.

`| default(omit)` doesn't work as one might assume outside of module parameters. It injects a placeholder for the module to remove, but when omit is used on other areas it doesn't quite work that way.

This little playbook should verify it;
(the http_proxy variable is intentionally commented out)

```yaml
  - hosts: localhost
    vars:
      #http_proxy: "http://example.com:3218"
    tasks:
      - shell: 'echo "http_proxy: (${http_proxy:-not set})"'
        environment:
          http_proxy: "{{ http_proxy | default(omit) }}"
        register: _res
      - debug:
          var: _res
      - shell: 'echo "http_proxy: (${http_proxy:-not set})"'
        environment:
          http_proxy: "{{ http_proxy | default('') }}"
        register: _res
      - debug:
          var: _res
      - shell: 'echo "http_proxy: (${http_proxy:-not set})"'
        environment:
          http_proxy: "http://example.com:3218"
        register: _res
      - debug:
          var: _res
```

```shell
TASK [debug]
ok: [localhost] => {
    "_res": {
        ...
        "stdout_lines": [
            "http_proxy: (__omit_place_holder__a822cc0b2fd200e020aba364968565842cf642bd)"
        ]
    }
}
TASK [debug]
ok: [localhost] => {
    "_res": {
        ...
        "stdout_lines": [
            "http_proxy: (not set)"
        ]
    }
}
TASK [debug]
ok: [localhost] => {
    "_res": {
        ...
        "stdout_lines": [
            "http_proxy: (http://example.com:3218)"
        ]
    }
}

```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
More or less all the roles