### PR TITLE
roles/agent/windows: uri => win_uri

### DIFF
--- a/changelogs/fragments/1628.yml
+++ b/changelogs/fragments/1628.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - roles/agent, swap uri with win_uri
+  - roles/agent, check to see if zabbix_agent_version_long is already supplied

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -223,7 +223,6 @@ Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
 * `zabbix_win_firewall_management`: Enable Windows firewall management (add service and port to allow rules). Default: `True`
 * `zabbix_agent_win_install_dir`: The directory where Zabbix needs to be installed. Default: `C:\Program Files\Zabbix Agent 2` when variable `zabbix_agent2` is true, `C:\Program Files\Zabbix Agent` when `zabbix_agent2` is false.
 * `zabbix_agent_win_install_dir_conf`: The directory where Zabbix configuration file needs to be installed. Default: `zabbix_agent_win_install_dir`
-* `zabbix_win_install_dir_bin`: The directory where Zabbix binary file needs to be installed.
 * `zabbix_win_package`: file name pattern (zip only). This will be used to generate the `zabbix_win_download_link` variable.
 
 ### Tweaking the windows service

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -218,7 +218,7 @@ Otherwise it just for the Zabbix Agent or for the Zabbix Agent 2.
 
 * `zabbix_agent_win_include`: The directory in which the Zabbix Agent specific configuration files are stored.
 * `zabbix_agent_win_logfile`: The full path to the logfile for the Zabbix Agent.
-* `zabbix_version_long`: The long (major.minor.patch) version of the Zabbix Agent. This will be used to generate the `zabbix_win_package` and `zabbix_win_download_link` variables. This takes precedence over `zabbix_agent_version`.
+* `zabbix_agent_version_long`: The long (major.minor.patch) version of the Zabbix Agent. This will be used to generate the `zabbix_win_package` and `zabbix_win_download_link` variables. This takes precedence over `zabbix_agent_version`.
 * `zabbix_win_download_link`: The download url to the `win.zip` file.
 * `zabbix_win_firewall_management`: Enable Windows firewall management (add service and port to allow rules). Default: `True`
 * `zabbix_agent_win_install_dir`: The directory where Zabbix needs to be installed. Default: `C:\Program Files\Zabbix Agent 2` when variable `zabbix_agent2` is true, `C:\Program Files\Zabbix Agent` when `zabbix_agent2` is false.
@@ -253,8 +253,8 @@ _Supporting macOS is a best effort (We don't have the possibility to either test
 
 * `zabbix_mac_download_link`: The download url to the `pkg` file.
 * `zabbix_mac_download_url`: The download url.  Default `https://cdn.zabbix.com/zabbix/binaries/stable`
-* `zabbix_mac_package`: The name of the mac install package.  Default `zabbix_agent-{{ zabbix_version_long }}-macos-amd64-openssl.pkg`
-* `zabbix_version_long`: The long (major.minor.patch) version of the Zabbix Agent. This will be used to generate the `zabbix_mac_download_link` link.
+* `zabbix_mac_package`: The name of the mac install package.  Default `zabbix_agent-{{ zabbix_agent_version_long }}-macos-amd64-openssl.pkg`
+* `zabbix_agent_version_long`: The long (major.minor.patch) version of the Zabbix Agent. This will be used to generate the `zabbix_mac_download_link` link.
 
 ## Docker Variables
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,7 +19,7 @@ documentation: https://github.com/ansible-collections/community.zabbix.git
 homepage: https://github.com/ansible-collections/community.zabbix
 issues: https://github.com/ansible-collections/community.zabbix/issues
 dependencies:
-  ansible.windows: "*"
+  ansible.windows: ">=2.8.0"
   ansible.netcommon: ">=3.1.1"
   ansible.posix: "*"
   community.general: "*"

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -5,6 +5,7 @@ zabbix_agent_version_check: true
 
 zabbix_agent2: false
 zabbix_agent_version_minor: "*"
+#zabbix_agent_version_long: 7.4.2
 zabbix_agent_package_remove: false
 zabbix_agent_package: "{{ _zabbix_agent_package | default(zabbix_agent2 | ternary('zabbix-agent2', 'zabbix-agent')) }}"
 zabbix_agent_package_state: present
@@ -120,9 +121,8 @@ zabbix_agent_win_service: "{{ zabbix_agent2 | ternary('Zabbix Agent 2', 'Zabbix 
 zabbix_win_firewall_management: true
 
 # macOS Related
-zabbix_version_long: 5.2.4
-zabbix_mac_package: zabbix_agent-{{ zabbix_version_long }}-macos-amd64-openssl.pkg
-zabbix_mac_download_link: "{{ zabbix_agent_download_base_url }}/{{ zabbix_agent_version }}/{{ zabbix_version_long }}/{{ zabbix_mac_package }}"
+zabbix_mac_package: "zabbix_agent-{{ zabbix_agent_version_long }}-macos-amd64-openssl.pkg"
+zabbix_mac_download_link: "{{ zabbix_agent_download_base_url }}/{{ zabbix_agent_version }}/{{ zabbix_agent_version_long }}/{{ zabbix_mac_package }}"
 
 # Zabbix Agent Docker facts
 zabbix_agent_docker: false

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -5,7 +5,6 @@ zabbix_agent_version_check: true
 
 zabbix_agent2: false
 zabbix_agent_version_minor: "*"
-zabbix_version_patch: 0
 zabbix_agent_package_remove: false
 zabbix_agent_package: "{{ _zabbix_agent_package | default(zabbix_agent2 | ternary('zabbix-agent2', 'zabbix-agent')) }}"
 zabbix_agent_package_state: present

--- a/roles/zabbix_agent/tasks/install-Windows.yml
+++ b/roles/zabbix_agent/tasks/install-Windows.yml
@@ -1,13 +1,12 @@
 ---
 - name: Get latest zabbix releases
-  delegate_to: localhost
-  uri:
+  win_uri:
     url: https://services.zabbix.com/updates/v1
     return_content: true
   register: _zabbix_versions
   run_once: true
 
-- name: Set zabbix_version_long
+- name: Set zabbix_agent_version_long
   set_fact:
     zabbix_agent_version_long: "{{ _zabbix_versions.json | json_query(_latest_release) }}"
   vars:

--- a/roles/zabbix_agent/tasks/install-Windows.yml
+++ b/roles/zabbix_agent/tasks/install-Windows.yml
@@ -1,17 +1,19 @@
 ---
-- name: Get latest zabbix releases
-  win_uri:
-    url: https://services.zabbix.com/updates/v1
-    return_content: true
-  register: _zabbix_versions
-  run_once: true
+- name: Get version if not set
+  when: zabbix_agent_version_long is not defined
+  block:
+    - name: Get latest zabbix releases
+      win_uri:
+        url: https://services.zabbix.com/updates/v1
+        return_content: true
+      register: _zabbix_versions
+      run_once: true
 
-- name: Set zabbix_agent_version_long
-  set_fact:
-    zabbix_agent_version_long: "{{ _zabbix_versions.json | json_query(_latest_release) }}"
-  vars:
-    _latest_release: "versions[?version=='{{ zabbix_agent_version }}'].latest_release.release | [0]"
-  when: zabbix_agent_version_long is undefined
+    - name: Set zabbix_agent_version_long
+      set_fact:
+        zabbix_agent_version_long: "{{ _zabbix_versions.json | json_query(_latest_release) }}"
+      vars:
+        _latest_release: "versions[?version=='{{ zabbix_agent_version }}'].latest_release.release | [0]"
 
 - name: Check for and uninstall old agent
   when: work_not_in_progress_anymore | default(false)


### PR DESCRIPTION
##### SUMMARY
Swap out uri for win_uri and some minor cleanups related to the change.
`zabbix_agent_version_long` check suggested by @patrik-plastik in #1589 
Fixes #1621
Fixes #1627

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles/zabbix_agent

##### ADDITIONAL INFORMATION
Requires `ansible.windows: ">=2.8.0"`