### PR TITLE
zabbix_repo: Fix broken conditional 

### DIFF
--- a/roles/zabbix_repo/tasks/Debian.yml
+++ b/roles/zabbix_repo/tasks/Debian.yml
@@ -83,7 +83,7 @@
     mode: "0644"
   when:
     - zabbix_repo_package is defined
-    - zabbix_repo_package
+    - zabbix_repo_package | length > 0
   become: true
   tags:
     - install


### PR DESCRIPTION

##### SUMMARY
As per [Ansible 12 porting guide](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_12.html#example-implicit-boolean-conversion) using a `str` in conditionals to check if non-empty is no longer allowed and should be done by comparing the output of `length` filter as in `var | length > 0`.    

Contributes to fixing issue [1523](https://github.com/ansible-collections/community.zabbix/issues/1523)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Role `zabbix_repo`  
File `roles/zabbix_repo/tasks/Debian.yml`
Task "Debian | Configuring the weight for APT" 

##### ADDITIONAL INFORMATION
Debian 13 ships with Ansible 12 in its repositories, therefore it can't run the `zabbix_repo` on Debian/Ubuntu targets without explicitly allowing broken conditionals.  

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:  
```paste below
TASK [community.zabbix.zabbix_repo : Debian | Configuring the weight for APT] ***************
[ERROR]: Task failed: Conditional result was 'zabbix-agent2' of type 'str', which evaluates to True. Conditionals must have a boolean result.

Task failed.
Origin: /home/user/.ansible/collections/ansible_collections/community/zabbix/roles/zabbix_repo/tasks/Debian.yml:75:3

73     - install
74
75 - name: "Debian | Configuring the weight for APT"
     ^ column 3

<<< caused by >>>

Conditional result was 'zabbix-agent2' of type 'str', which evaluates to True. Conditionals must have a boolean result.
Origin: /home/user/.ansible/collections/ansible_collections/community/zabbix/roles/zabbix_repo/tasks/Debian.yml:86:7

84   when:
85     - zabbix_repo_package is defined
86     - zabbix_repo_package
         ^ column 7

Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.

fatal: [target_host]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result was 'zabbix-agent2' of type 'str', which evaluates to True. Conditionals must have a boolean result."}
```

After:  
```
TASK [community.zabbix.zabbix_repo : Debian | Configuring the weight for APT] ***************
--- before
+++ after: /etc/apt/preferences.d/zabbix-agent2
@@ -0,0 +1,3 @@
+Package: zabbix-agent2
+Pin: origin repo.zabbix.com
+Pin-Priority: 1001

changed: [target_host]

```