### PR TITLE
Add zabbix_valuemap_info module.

### DIFF
--- a/plugins/modules/zabbix_valuemap_info.py
+++ b/plugins/modules/zabbix_valuemap_info.py
@@ -1,0 +1,151 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, G.J. Doornink
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = """
+module: zabbix_valuemap_info
+short_description: Gather information about Zabbix valuemap
+author:
+    - G.J. Doornink (@gjdoornink)
+description:
+    - This module allows you to search for Zabbix valuemap entries.
+requirements:
+    - "python >= 3.9"
+options:
+    host_name:
+        type: str
+        description:
+            - Name of the Zabbix host.
+        required: true
+    name:
+        type: str
+        description:
+            - Name of the Zabbix valuemap.
+        required: false
+extends_documentation_fragment:
+- community.zabbix.zabbix
+
+"""
+
+EXAMPLES = """
+# If you want to use Username and Password to be authenticated by Zabbix Server
+- name: Set credentials to access Zabbix Server API
+  ansible.builtin.set_fact:
+    ansible_user: Admin
+    ansible_httpapi_pass: zabbix
+
+# If you want to use API token to be authenticated by Zabbix Server
+# https://www.zabbix.com/documentation/current/en/manual/web_interface/frontend_sections/administration/general#api-tokens
+- name: Set API token
+  ansible.builtin.set_fact:
+    ansible_zabbix_auth_key: 8ec0d52432c15c91fcafe9888500cf9a607f44091ab554dbee860f6b44fac895
+
+- name: Get zabbix valuemap info
+  # set task level variables as we change ansible_connection plugin here
+  vars:
+    ansible_network_os: community.zabbix.zabbix
+    ansible_connection: httpapi
+    ansible_httpapi_port: 443
+    ansible_httpapi_use_ssl: true
+    ansible_httpapi_validate_certs: false
+    ansible_zabbix_url_path: "zabbixeu"  # If Zabbix WebUI runs on non-default (zabbix) path ,e.g. http://<FQDN>/zabbixeu
+    ansible_host: zabbix-example-fqdn.org
+  community.zabbix.zabbix_valuemap_info:
+    host_name: example_host
+    name: Numbers
+"""
+
+RETURN = """
+zabbix_valuemap:
+  description: List of Zabbix valuemaps.
+  returned: always
+  type: list
+  elements: dict
+  sample: [
+    {
+      "hostid": "10771",
+      "mappings": [
+        {
+          "newvalue": "one",
+          "type": "0",
+          "value": "1"
+        },
+        {
+          "newvalue": "two",
+          "type": "0",
+          "value": "2"
+        }
+      ],
+      "name": "Numbers",
+      "uuid": "",
+      "valuemapid": "1467"
+    }
+  ]
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
+import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils
+
+
+class Valuemap(ZabbixBase):
+    def get_host_id(self, host_name):
+        try:
+            host_list = self._zapi.host.get({"filter": {"host": host_name}})
+        except Exception as e:
+            self._module.fail_json(msg="Failed to get host: %s" % e)
+
+        if len(host_list) < 1:
+            self._module.fail_json(msg="Host not found: %s" % host_name)
+        else:
+            return host_list[0]["hostid"]
+
+    def get_valuemaps(self, host_name, valuemap_name):
+        valuemap_list = []
+        try:
+            data = {"output": "extend", "selectMappings": "extend", "filter": {}}
+            data["filter"]["hostid"] = self.get_host_id(host_name)
+            if valuemap_name is not None:
+                data["filter"]["name"] = valuemap_name
+
+            valuemap_list = self._zapi.valuemap.get(data)
+        except Exception as e:
+            self._module.fail_json(msg="Failed to get valuemaps: %s" % e)
+
+        if len(valuemap_list) > 0:
+            valuemap_list = [valuemap for valuemap in valuemap_list if valuemap["uuid"] == ""]
+        if valuemap_name is not None and len(valuemap_list) < 1:
+            self._module.fail_json(msg="Valuemap not found: %s" % valuemap_name)
+
+        return valuemap_list
+
+
+def main():
+    argument_spec = zabbix_utils.zabbix_common_argument_spec()
+    argument_spec.update(dict(
+        host_name=dict(type="str", required=True),
+        name=dict(type="str", required=False)
+    ))
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    host_name = module.params["host_name"]
+    name = module.params["name"]
+
+    valuemap = Valuemap(module)
+    valuemaps = valuemap.get_valuemaps(host_name, name)
+    module.exit_json(changed=False, valuemaps=valuemaps)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/test_zabbix_valuemap_info/meta/main.yml
+++ b/tests/integration/targets/test_zabbix_valuemap_info/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_zabbix

--- a/tests/integration/targets/test_zabbix_valuemap_info/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_valuemap_info/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: test - do not run tests for Zabbix < 7.0
+  meta: end_play
+  when: zabbix_version is version('7.0', '<')
+
+# setup stuff
+- include_tasks: zabbix_setup.yml
+
+# zabbix_valuemap module tests
+- include_tasks: zabbix_tests.yml
+
+# tear down stuff set up earlier
+- include_tasks: zabbix_teardown.yml

--- a/tests/integration/targets/test_zabbix_valuemap_info/tasks/zabbix_setup.yml
+++ b/tests/integration/targets/test_zabbix_valuemap_info/tasks/zabbix_setup.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Create test host
+  community.zabbix.zabbix_host:
+    host_name: ExampleHost
+    host_groups:
+      - Linux servers
+      - Zabbix servers
+    status: enabled
+    state: present
+    interfaces:
+      - type: 1
+        main: 1
+        useip: 1
+        ip: 10.1.1.1
+        dns: ""
+        port: "10050"
+      - type: 1
+        main: 0
+        useip: 0
+        ip: ""
+        dns: "community.zabbix.ansible"
+        port: "10050"

--- a/tests/integration/targets/test_zabbix_valuemap_info/tasks/zabbix_teardown.yml
+++ b/tests/integration/targets/test_zabbix_valuemap_info/tasks/zabbix_teardown.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Remove test host
+  community.zabbix.zabbix_host:
+    host_name: ExampleHost
+    state: absent

--- a/tests/integration/targets/test_zabbix_valuemap_info/tasks/zabbix_tests.yml
+++ b/tests/integration/targets/test_zabbix_valuemap_info/tasks/zabbix_tests.yml
@@ -1,0 +1,99 @@
+---
+
+- name: test - get valuemaps without host_name
+  community.zabbix.zabbix_valuemap_info:
+  ignore_errors: true
+  register: get_valuemap_info_result
+
+- name: assert that host_name is required
+  ansible.builtin.assert:
+    that: get_valuemap_info_result.failed
+
+- name: test - get all valuemaps for host
+  community.zabbix.zabbix_valuemap_info:
+    host_name: ExampleHost
+  register: get_valuemap_info_result
+
+- name: assert that no valuemaps are present for host
+  ansible.builtin.assert:
+    that: get_valuemap_info_result | length == 0
+
+- name: test - get valuemap
+  community.zabbix.zabbix_valuemap_info:
+    host_name: ExampleHost
+    name: TestValuemap
+  ignore_errors: true
+  register: get_valuemap_info_result
+
+- name: assert that valuemap is not present
+  ansible.builtin.assert:
+    that: get_valuemap_info_result.failed
+
+- name: test - create new valuemap
+  community.zabbix.zabbix_valuemap:
+    name: TestValuemap
+    host_name: ExampleHost
+    mappings:
+      - value: 0
+        map_to: "Down"
+        type: 0
+      - value: 1
+        map_to: "Up"
+        type: 1
+    state: present
+
+- name: test - create another valuemap
+  community.zabbix.zabbix_valuemap:
+    name: AnotherTestValuemap
+    host_name: ExampleHost
+    mappings:
+      - value: 0
+        map_to: "Down"
+        type: 0
+      - value: 1
+        map_to: "Up"
+        type: 1
+    state: present
+
+- name: test - get all valuemaps for host
+  community.zabbix.zabbix_valuemap_info:
+    host_name: ExampleHost
+  register: get_valuemap_info_result
+
+- name: assert that two valuemaps are present for host
+  ansible.builtin.assert:
+    that: get_valuemap_info_result | length == 2
+
+- name: test - get valuemap
+  community.zabbix.zabbix_valuemap_info:
+    host_name: ExampleHost
+    name: TestValuemap
+  register: get_valuemap_info_result
+
+- name: assert that valuemap content is returned
+  ansible.builtin.assert:
+    that:
+      - get_valuemap_info_result.valuemaps | length == 1
+      - get_valuemap_info_result.valuemaps.0.hostid is defined
+      - get_valuemap_info_result.valuemaps.0.name == "TestValuemap"
+      - get_valuemap_info_result.valuemaps.0.uuid == ""
+      - get_valuemap_info_result.valuemaps.0.valuemapid is defined
+      - get_valuemap_info_result.valuemaps.0.mappings | length == 2
+      - get_valuemap_info_result.valuemaps.0.mappings.0.newvalue is defined
+      - get_valuemap_info_result.valuemaps.0.mappings.0.type is defined
+      - get_valuemap_info_result.valuemaps.0.mappings.0.value is defined
+      - get_valuemap_info_result.valuemaps.0.mappings.1.newvalue is defined
+      - get_valuemap_info_result.valuemaps.0.mappings.1.type is defined
+      - get_valuemap_info_result.valuemaps.0.mappings.1.value is defined
+
+- name: test - remove test valuemap
+  community.zabbix.zabbix_valuemap:
+    name: TestValuemap
+    host_name: ExampleHost
+    state: absent
+
+- name: test - remove another valuemap
+  community.zabbix.zabbix_valuemap:
+    name: AnotherTestValuemap
+    host_name: ExampleHost
+    state: absent

--- a/tests/integration/targets/test_zabbix_valuemap_info/tasks/zabbix_tests.yml
+++ b/tests/integration/targets/test_zabbix_valuemap_info/tasks/zabbix_tests.yml
@@ -16,7 +16,7 @@
 
 - name: assert that no valuemaps are present for host
   ansible.builtin.assert:
-    that: get_valuemap_info_result | length == 0
+    that: get_valuemap_info_result.valuemaps | length == 0
 
 - name: test - get valuemap
   community.zabbix.zabbix_valuemap_info:
@@ -62,7 +62,7 @@
 
 - name: assert that two valuemaps are present for host
   ansible.builtin.assert:
-    that: get_valuemap_info_result | length == 2
+    that: get_valuemap_info_result.valuemaps | length == 2
 
 - name: test - get valuemap
   community.zabbix.zabbix_valuemap_info:


### PR DESCRIPTION
##### SUMMARY

This PR adds the zabbix_valuemap_info module.

This PR implements feature #1639 

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

zabbix_valuemap_info

##### ADDITIONAL INFORMATION

The zabbix_valuemap_info module gets  valuemap information for a host.
If a valuemap name is specified it returns information about the specified valuemap or an error if the specified valuemap does not exist.
If no valuemap name is specified it returns all valuemaps or an empty list if no valuemaps are present for the host.
