### PR TITLE
Debian 13 (Trixie) Support

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -28,6 +28,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
           - image: opensuseleap15
@@ -50,6 +51,12 @@ jobs:
           - container:
               image: rockylinux10
             version: v60
+          - container:
+              image: debian13
+            version: v60
+          - container:
+              image: debian13
+            version: v72
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/javagateway.yml
+++ b/.github/workflows/javagateway.yml
@@ -28,6 +28,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
           - image: opensuseleap15
@@ -49,6 +50,12 @@ jobs:
           - container:
               image: rockylinux10
             version: v60
+          - container:
+              image: debian13
+            version: v60
+          - container:
+              image: debian13
+            version: v72
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -28,6 +28,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
           - image: opensuseleap15
@@ -53,6 +54,12 @@ jobs:
           - container:
               image: rockylinux10
             version: v60
+          - container:
+              image: debian13
+            version: v60
+          - container:
+              image: debian13
+            version: v72
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -28,6 +28,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
           - image: opensuseleap15
@@ -61,6 +62,12 @@ jobs:
           - container:
               image: debian11
             version: v70
+          - container:
+              image: debian13
+            version: v60            
+          - container:
+              image: debian13
+            version: v72
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -28,6 +28,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
         collection_role:
@@ -62,6 +63,12 @@ jobs:
           - container:
               image: debian11
             version: v70
+          - container:
+              image: debian13
+            version: v60
+          - container:
+              image: debian13
+            version: v72
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/roles/zabbix_agent/vars/Debian.yml
+++ b/roles/zabbix_agent/vars/Debian.yml
@@ -7,6 +7,9 @@ _zabbix_agent_install_recommends: false
 
 zabbix_valid_agent_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2

--- a/roles/zabbix_javagateway/vars/Debian.yml
+++ b/roles/zabbix_javagateway/vars/Debian.yml
@@ -1,5 +1,8 @@
 zabbix_valid_javagateway_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2

--- a/roles/zabbix_proxy/vars/Debian.yml
+++ b/roles/zabbix_proxy/vars/Debian.yml
@@ -1,5 +1,8 @@
 zabbix_valid_proxy_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2

--- a/roles/zabbix_server/vars/Debian.yml
+++ b/roles/zabbix_server/vars/Debian.yml
@@ -7,6 +7,9 @@ mysql_create_dir: ""
 
 zabbix_valid_server_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2

--- a/roles/zabbix_web/vars/Debian.yml
+++ b/roles/zabbix_web/vars/Debian.yml
@@ -23,6 +23,9 @@ _nginx_tls_dhparam: /etc/ssl/private/dhparams.pem
 
 zabbix_valid_web_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR brings support for Debian 13 (Trixie) now that Zabbix is [publishing](https://repo.zabbix.com/zabbix/7.0/debian/dists/trixie/main/binary-amd64/) apt packages in their repo. 

This also updates the Github Actions workflows to test the Zabbix packages on Debian 13.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`zabbix-server`
`zabbix-agent`
`zabbix-javagateway`
`zabbix-web`
`zabbix-proxy`

