### PR TITLE
request trigger dependencies and tags for comparison

### DIFF
--- a/changelogs/fragments/1641-fix-zabbix-trigger-module.yaml
+++ b/changelogs/fragments/1641-fix-zabbix-trigger-module.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - zabbix_trigger - add selectDependencies and selectTags when requesting triggers to detect changes to those values (https://github.com/ansible-collections/community.zabbix/pull/1641)
+  - zabbix_trigger - add selectDependencies and selectTags when requesting triggers to detect changes to those values

--- a/changelogs/fragments/1641-fix-zabbix-trigger-module.yaml
+++ b/changelogs/fragments/1641-fix-zabbix-trigger-module.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_trigger - add selectDependencies and selectTags when requesting triggers to detect changes to those values (https://github.com/ansible-collections/community.zabbix/pull/1641)

--- a/plugins/modules/zabbix_trigger.py
+++ b/plugins/modules/zabbix_trigger.py
@@ -295,7 +295,7 @@ class Trigger(ZabbixBase):
             host = template_name
         triggers = []
         try:
-            triggers = self._zapi.trigger.get({'filter': {'description': trigger_name, 'host': host}})
+            triggers = self._zapi.trigger.get({'filter': {'description': trigger_name, 'host': host}, "selectDependencies": "extend", "selectTags": "extend"})
         except Exception as e:
             self._module.fail_json(msg="Failed to get trigger: %s" % e)
         return triggers
@@ -383,7 +383,7 @@ class Trigger(ZabbixBase):
 
     def check_trigger_changed(self, old_trigger):
         try:
-            new_trigger = self._zapi.trigger.get({"triggerids": "%s" % old_trigger['triggerid']})[0]
+            new_trigger = self._zapi.trigger.get({"triggerids": "%s" % old_trigger['triggerid'], "selectDependencies": "extend", "selectTags": "extend"})[0]
         except Exception as e:
             self._module.fail_json(msg="Failed to get trigger: %s" % e)
         return old_trigger != new_trigger


### PR DESCRIPTION
Change comparison fails for dependency and tag changes if we have not selected them.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When setting dependencies or tags, comparison cannot be made to determine change status if trigger.get hasn't requested the data.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_trigger

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Sorry for the random PR drop, but it was a simple modification. The only other data that MIGHT be of use was functions, as I don't know if it's possible to change the function without the ID in the expression (which does get compared) changing. I have not tested function parameter changes to see if they would get missed. It's only extra data, so it might not be a bad idea to add selectFunctions: extend.

All 3 selects do show up in Zabbix 3.4 api specs. I didn't go further back than that.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
