### PR TITLE
Add setting to make nginx config listen on IPv6 as well.

### DIFF
--- a/roles/zabbix_web/templates/nginx_vhost.conf.j2
+++ b/roles/zabbix_web/templates/nginx_vhost.conf.j2
@@ -2,6 +2,7 @@
 
 server {
     listen {{ zabbix_web_vhost_port }};
+    listen [::]:{{ zabbix_web_vhost_port }};
     server_tokens off;
     server_name {{ zabbix_api_server_url }} {% for alias in zabbix_url_aliases -%}{{ alias -}} {% endfor %};
 
@@ -76,6 +77,7 @@ server {
 {% if zabbix_web_tls|default(false) %}
 server {
     listen {{ zabbix_web_vhost_tls_port }} ssl {{ 'http2' if zabbix_web_ssl_http2 else '' }};
+    listen [::]:{{ zabbix_web_vhost_tls_port }} ssl {{ 'http2' if zabbix_web_ssl_http2 else '' }};
     server_tokens off;
     server_name {{ zabbix_api_server_url }} {% for alias in zabbix_url_aliases -%}{{ alias -}} {% endfor %};
 


### PR DESCRIPTION
##### SUMMARY
Adds option in nginx config to also listen on IPv6 ([::] as well as 0.0.0.0). In 2025 being natively dualstack is the way to go.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nginx_vhost.conf.j2 (zabbix_web role)

##### ADDITIONAL INFORMATION
IPv6 makes external management a breeze, with no NAT-ing to consider.