### PR TITLE
fix: change default value of proxy from '' to `omit` in get_url task

### DIFF
--- a/roles/zabbix_repo/tasks/Debian.yml
+++ b/roles/zabbix_repo/tasks/Debian.yml
@@ -7,8 +7,8 @@
     force: true
     state: present
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default('') }}"
-    https_proxy: "{{ zabbix_https_proxy | default('') }}"
+    http_proxy: "{{ zabbix_http_proxy | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(omit) }}"
   register: gnupg_installed
   until: gnupg_installed is succeeded
   become: true
@@ -36,8 +36,8 @@
     mode: "0644"
     force: true
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default('') }}"
-    https_proxy: "{{ zabbix_https_proxy | default('') }}"
+    http_proxy: "{{ zabbix_http_proxy | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(omit) }}"
   register: zabbix_repo_files_installed
   until: zabbix_repo_files_installed is succeeded
   become: true

--- a/roles/zabbix_repo/tasks/RedHat.yml
+++ b/roles/zabbix_repo/tasks/RedHat.yml
@@ -14,8 +14,8 @@
     url: "{{ item }}"
     dest: "/etc/pki/rpm-gpg/{{ item | basename }}"
   environment:
-    http_proxy: "{{ zabbix_http_proxy | default('') }}"
-    https_proxy: "{{ zabbix_https_proxy | default('') }}"
+    http_proxy: "{{ zabbix_http_proxy | default(omit) }}"
+    https_proxy: "{{ zabbix_https_proxy | default(omit) }}"
   become: true
   loop:
     - "{{ zabbix_repo_rpm_gpg_key_url }}"


### PR DESCRIPTION
ansible-core 2.19 fail this task in combination of empty string http[s]_proxy and get_url. in this case, the task try to use http proxy. but actually the variable is empty so it failed by name resolution error.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
