### PR TITLE
Debian 13 (Trixie) Support

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -28,6 +28,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
           - image: opensuseleap15
@@ -50,6 +51,12 @@ jobs:
           - container:
               image: rockylinux10
             version: v60
+          - container:
+              image: debian13
+            version: v60
+          - container:
+              image: debian13
+            version: v72
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/javagateway.yml
+++ b/.github/workflows/javagateway.yml
@@ -28,6 +28,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
           - image: opensuseleap15
@@ -49,6 +50,12 @@ jobs:
           - container:
               image: rockylinux10
             version: v60
+          - container:
+              image: debian13
+            version: v60
+          - container:
+              image: debian13
+            version: v72
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -28,6 +28,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
           - image: opensuseleap15
@@ -53,6 +54,12 @@ jobs:
           - container:
               image: rockylinux10
             version: v60
+          - container:
+              image: debian13
+            version: v60
+          - container:
+              image: debian13
+            version: v72
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -28,6 +28,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
           - image: opensuseleap15
@@ -61,6 +62,12 @@ jobs:
           - container:
               image: debian11
             version: v70
+          - container:
+              image: debian13
+            version: v60            
+          - container:
+              image: debian13
+            version: v72
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -28,6 +28,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
         collection_role:
@@ -62,6 +63,12 @@ jobs:
           - container:
               image: debian11
             version: v70
+          - container:
+              image: debian13
+            version: v60
+          - container:
+              image: debian13
+            version: v72
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/molecule/zabbix_web/prepare.yml
+++ b/molecule/zabbix_web/prepare.yml
@@ -88,6 +88,7 @@
               - php{{ __php_default_version_debian }}-curl
               - php{{ __php_default_version_debian }}-imap
               - php-json
+              - default-mysql-client
               - php{{ __php_default_version_debian }}-opcache
               - php{{ __php_default_version_debian }}-xml
               - php{{ __php_default_version_debian }}-mbstring

--- a/molecule/zabbix_web/prepare.yml
+++ b/molecule/zabbix_web/prepare.yml
@@ -44,6 +44,29 @@
           - php-xml
       when: ansible_facts['os_family'] == 'RedHat'
 
+    - name: Workaround for geerlingguy.php Debian 13 support
+      when:
+        - ansible_facts['distribution'] == "Debian"
+        - ansible_facts['distribution_major_version'] >= '13'
+      block:
+        - name: Set PHP Version
+          ansible.builtin.set_fact:
+            __php_default_version_debian: "8.4"
+        - name: Set PHP packages
+          ansible.builtin.set_fact:
+            __php_packages:
+              - php{{ __php_default_version_debian }}-common
+              - php{{ __php_default_version_debian }}-cli
+              - php{{ __php_default_version_debian }}-dev
+              - php{{ __php_default_version_debian }}-fpm
+              - php{{ __php_default_version_debian }}-gd
+              - php{{ __php_default_version_debian }}-curl
+              - php-json
+              - php{{ __php_default_version_debian }}-opcache
+              - php{{ __php_default_version_debian }}-xml
+              - php{{ __php_default_version_debian }}-mbstring
+              - php{{ __php_default_version_debian }}-apcu
+              - php{{ __php_default_version_debian }}-sqlite3
     - name: Workaround for geerlingguy.php missing ubuntu-24.04 support
       when:
         - ansible_facts['distribution'] == "Ubuntu"

--- a/roles/zabbix_agent/vars/Debian.yml
+++ b/roles/zabbix_agent/vars/Debian.yml
@@ -7,6 +7,9 @@ _zabbix_agent_install_recommends: false
 
 zabbix_valid_agent_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2

--- a/roles/zabbix_javagateway/vars/Debian.yml
+++ b/roles/zabbix_javagateway/vars/Debian.yml
@@ -1,5 +1,8 @@
 zabbix_valid_javagateway_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2

--- a/roles/zabbix_proxy/vars/Debian.yml
+++ b/roles/zabbix_proxy/vars/Debian.yml
@@ -1,5 +1,8 @@
 zabbix_valid_proxy_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2

--- a/roles/zabbix_server/vars/Debian.yml
+++ b/roles/zabbix_server/vars/Debian.yml
@@ -7,6 +7,9 @@ mysql_create_dir: ""
 
 zabbix_valid_server_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2

--- a/roles/zabbix_web/vars/Debian.yml
+++ b/roles/zabbix_web/vars/Debian.yml
@@ -23,6 +23,9 @@ _nginx_tls_dhparam: /etc/ssl/private/dhparams.pem
 
 zabbix_valid_web_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2


### PR DESCRIPTION
##### SUMMARY
Tries to replace #1640 
This PR brings support for Debian 13 (Trixie) now that Zabbix is [publishing](https://repo.zabbix.com/zabbix/7.0/debian/dists/trixie/main/binary-amd64/) apt packages in their repo.

This also updates the Github Actions workflows to test the Zabbix packages on Debian 13.

##### ISSUE TYPE
* Feature Pull Request

##### COMPONENT NAME
`zabbix-server` `zabbix-agent` `zabbix-javagateway` `zabbix-web` `zabbix-proxy`
