### PR TITLE
Fix opensuse-leap-15 tests

### DIFF
--- a/roles/zabbix_proxy/vars/Suse.yml
+++ b/roles/zabbix_proxy/vars/Suse.yml
@@ -9,7 +9,7 @@ zabbix_valid_proxy_versions:
 _zabbix_proxy_pgsql_dependencies:
   - "{{ zabbix_proxy_install_database_client | ternary('postgresql', '') }}"
   - gzip
-  - python3-psycopg2
+  - "python3{% if ansible_facts.python.version.minor == 11 %}11{% endif %}-psycopg2"
 
 _zabbix_proxy_mysql_dependencies:
   - "{{ zabbix_proxy_install_database_client | ternary('mysql', '') }}"

--- a/roles/zabbix_server/vars/Suse.yml
+++ b/roles/zabbix_server/vars/Suse.yml
@@ -9,7 +9,7 @@ zabbix_valid_server_versions:
 _zabbix_server_pgsql_dependencies:
   - "{{ zabbix_server_install_database_client | ternary('postgresql', '') }}"
   - gzip
-  - python3-psycopg2
+  - "python3{% if ansible_facts.python.version.minor == 11 %}11{% endif %}-psycopg2"
 
 _zabbix_server_mysql_dependencies:
   - "{{ zabbix_server_install_database_client | ternary('mysql', '') }}"


### PR DESCRIPTION
##### SUMMARY

geerlingguy/docker-opensuseleap15-ansible#5 updated leap-15 to use python3.11 in order to run more recent versions of ansible.

So we get this when using the community.postgresql modules;

```
   Failed to import the required Python library (psycopg2) on dd785066a558's
   Python /usr/bin/python3.11.
```

It's not a pretty fix, and I'm open to suggestions, but for now it gets the tests to pass.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
server and proxy roles via molecule
