### PR TITLE
fix: zabbix-web configuration directory group

### DIFF
--- a/changelogs/fragments/1671-fix-web-ownership.yaml
+++ b/changelogs/fragments/1671-fix-web-ownership.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - web role - Fixed ownership of `/etc/zabbix/web` directory to match Debian distributions packages

--- a/roles/zabbix_web/tasks/main.yml
+++ b/roles/zabbix_web/tasks/main.yml
@@ -95,7 +95,7 @@
   ansible.builtin.file:
     path: /etc/zabbix/web
     owner: "{{ zabbix_php_fpm_conf_user }}"
-    group: "{{ zabbix_php_fpm_conf_group }}"
+    group: root
     state: directory
     mode: 0755
   become: true


### PR DESCRIPTION
##### SUMMARY

Zabbix-frontend-php packages for various distros include the `/etc/zabbix/web` directory with a root:root mode.

Having "{{ zabbix_php_fpm_conf_group }}" as the group of this directory is overwritten at package update time, causing unnecessary changes in ansible, breaking the idempotency principle.

This commit changes the group to `root` (gid 0) to fix the idempotency issue.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

zabbix-web

##### ADDITIONAL INFORMATION

* Using nginx as frontend.
* Deploy the zabbix stack using the collection
* Run `apt install zabbix-frontend-php --reinstall` or whatever the command to reinstall the frontend package
* Re-deploy the zabbix stack using the collection

Before :

```
TASK [community.zabbix.zabbix_web : Create zabbix-web directory] *******************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
-    "group": 0,
+    "group": 33,
     "path": "/etc/zabbix/web"
 }
-changed: [[MY_ZABBIX_SERVER]]
```

After :

```
TASK [community.zabbix.zabbix_web : Create zabbix-web directory] *******************************************************
ok: [[MY_ZABBIX_SERVER]]
```