### PR TITLE
Debian 13: add zabbix_agent support

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -28,6 +28,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
           - image: opensuseleap15
@@ -107,6 +108,7 @@ jobs:
             ansible_core: ansible-core<2.17
           - image: ubuntu2404
           - image: ubuntu2204
+          - image: debian13
           - image: debian12
           - image: debian11
           - image: opensuseleap15

--- a/changelogs/fragments/1687-debian13-support.yaml
+++ b/changelogs/fragments/1687-debian13-support.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - zabbix_agent - add Debian 13 to supported versions.

--- a/roles/zabbix_agent/handlers/main.yml
+++ b/roles/zabbix_agent/handlers/main.yml
@@ -1,13 +1,16 @@
 ---
 - name: restart zabbix-agent
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: "{{ zabbix_agent_service }}"
     state: restarted
     enabled: true
+    daemon_reload: true
   become: true
   when:
     - not zabbix_agent_docker
-    - ansible_facts.os_family != "Windows" and ansible_facts.os_family != "Darwin"
+    - ansible_facts.os_family != "Windows"
+    - ansible_facts.os_family != "Darwin"
+    - ansible_facts.os_family != "FreeBSD"
 
 - name: firewalld-reload
   ansible.builtin.command: "firewall-cmd --reload"

--- a/roles/zabbix_agent/vars/Debian.yml
+++ b/roles/zabbix_agent/vars/Debian.yml
@@ -7,6 +7,12 @@ _zabbix_agent_install_recommends: false
 
 zabbix_valid_agent_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.2
+    - 7.0
+    - 6.0
+
   "12":
     - 7.4
     - 7.2


### PR DESCRIPTION
### Summary
This PR adds Debian 13 support for the `zabbix_agent` role and ensures repository setup works on Debian 13.

### Changes
- **zabbix_agent**
  - Add Debian 13 to the supported versions matrix.
  - On Debian 13+, prefer **zabbix-agent2** by default (legacy `zabbix-agent` package may be incompatible due to missing dependencies).
- **zabbix_repo**
  - On Debian 13+, default the Zabbix APT repository suite to **bookworm** when the repository does not provide a matching Debian suite.
- **Changelog**
  - Add a changelog fragment for these bugfixes.
- **CI (Molecule)**
  - Add Debian 13 to the test matrix.
  - Exclude Debian 13 from `default` and `autopsk` scenarios (Debian 13 uses Agent2 by default), while keeping coverage via `agent2` and `agent2autopsk`.

### Testing
- Local Debian 13 (trixie) verification: role installs **zabbix-agent2** and service runs.
- Molecule on Debian 13:
  - `agent2` ✅
  - `agent2autopsk` ✅