### PR TITLE
Make molecule work behind a proxy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ pip install -r requirements.txt
 Note that Docker is required when testing roles as Molecule is configured to use it. Once everything is installed, validate your role changes with:
 
 ```bash
-molecule test
+molecule test --all
 ```
 
 ### Testing Zabbix modules

--- a/molecule/zabbix_agent_tests/common/molecule.yml
+++ b/molecule/zabbix_agent_tests/common/molecule.yml
@@ -25,6 +25,9 @@ platforms:
 
 provisioner:
   name: ansible
+  config_options:
+    privilege_escalation:
+      become_method: ansible.builtin.su
   playbooks:
     create: ../../common/playbooks/create.yml
     prepare: ../../common/playbooks/prepare.yml
@@ -37,6 +40,9 @@ provisioner:
   inventory:
     group_vars:
       all:
+        zabbix_http_proxy: ${HTTP_PROXY}
+        zabbix_https_proxy: ${HTTPS_PROXY}
+        zabbix_no_proxy: ${NO_PROXY}
         ansible_connection: community.docker.docker
         zabbix_agent_server: 192.168.3.33
         zabbix_agent_serveractive: 192.168.3.33

--- a/molecule/zabbix_agent_tests/common/molecule.yml
+++ b/molecule/zabbix_agent_tests/common/molecule.yml
@@ -34,18 +34,18 @@ provisioner:
     ANSIBLE_REMOTE_TMP: /tmp/
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../../../roles
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:
-        zabbix_http_proxy: ${HTTP_PROXY}
-        zabbix_https_proxy: ${HTTPS_PROXY}
-        zabbix_no_proxy: ${NO_PROXY}
+        zabbix_http_proxy: ${http_proxy}
+        zabbix_https_proxy: ${https_proxy}
+        zabbix_no_proxy: ${no_proxy}
         ansible_connection: community.docker.docker
         zabbix_agent_server: 192.168.3.33
         zabbix_agent_serveractive: 192.168.3.33

--- a/molecule/zabbix_agent_tests/common/molecule.yml
+++ b/molecule/zabbix_agent_tests/common/molecule.yml
@@ -25,9 +25,6 @@ platforms:
 
 provisioner:
   name: ansible
-  config_options:
-    privilege_escalation:
-      become_method: ansible.builtin.su
   playbooks:
     create: ../../common/playbooks/create.yml
     prepare: ../../common/playbooks/prepare.yml
@@ -37,6 +34,12 @@ provisioner:
     ANSIBLE_REMOTE_TMP: /tmp/
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../../../roles
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_agent_tests/common/playbooks/converge.yml
+++ b/molecule/zabbix_agent_tests/common/playbooks/converge.yml
@@ -1,5 +1,9 @@
 ---
 - name: Converge
   hosts: all
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
   roles:
     - role: zabbix_agent

--- a/molecule/zabbix_agent_tests/common/playbooks/prepare.yml
+++ b/molecule/zabbix_agent_tests/common/playbooks/prepare.yml
@@ -2,6 +2,50 @@
 - name: Prepare
   hosts: all
   tasks:
+    # before anything else, put optional proxy configs in important parts of the os
+    - name: "bash proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/profile.d/proxy.sh
+      when:
+        - zabbix_http_proxy is defined
+    - name: "apt proxy"
+      ansible.builtin.copy:
+        content: |
+          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
+          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
+        dest: /etc/apt/apt.conf.d/99proxy
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - zabbix_http_proxy is defined
+    - name: "dnf proxy"
+      ansible.builtin.lineinfile:
+        regexp: '^proxy='
+        line: 'proxy={{ zabbix_http_proxy }}'
+        path: /etc/dnf/dnf.conf
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - zabbix_http_proxy is defined
+    - name: "suse proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/sysconfig/proxy
+      when:
+        - ansible_facts['os_family'] == 'Suse'
+        - zabbix_http_proxy is defined
+
     - block:
       - name: 'Create zabbix group'
         ansible.builtin.group:

--- a/molecule/zabbix_agent_tests/common/playbooks/prepare.yml
+++ b/molecule/zabbix_agent_tests/common/playbooks/prepare.yml
@@ -1,51 +1,11 @@
 ---
 - name: Prepare
   hosts: all
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
   tasks:
-    # before anything else, put optional proxy configs in important parts of the os
-    - name: "bash proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/profile.d/proxy.sh
-      when:
-        - zabbix_http_proxy is defined
-    - name: "apt proxy"
-      ansible.builtin.copy:
-        content: |
-          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
-          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
-        dest: /etc/apt/apt.conf.d/99proxy
-      when:
-        - ansible_facts['os_family'] == 'Debian'
-        - zabbix_http_proxy is defined
-    - name: "dnf proxy"
-      ansible.builtin.lineinfile:
-        regexp: '^proxy='
-        line: 'proxy={{ zabbix_http_proxy }}'
-        path: /etc/dnf/dnf.conf
-      when:
-        - ansible_facts['os_family'] == 'RedHat'
-        - zabbix_http_proxy is defined
-    - name: "suse proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/sysconfig/proxy
-      when:
-        - ansible_facts['os_family'] == 'Suse'
-        - zabbix_http_proxy is defined
-
     - block:
       - name: 'Create zabbix group'
         ansible.builtin.group:

--- a/molecule/zabbix_agent_tests/molecule/agent2/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/agent2/molecule.yml
@@ -3,9 +3,15 @@ scenario:
   name: agent2
 provisioner:
   name: ansible
+  config_options:
+    privilege_escalation:
+      become_method: ansible.builtin.su
   inventory:
     group_vars:
       all:
+        zabbix_http_proxy: ${HTTP_PROXY}
+        zabbix_https_proxy: ${HTTPS_PROXY}
+        zabbix_no_proxy: ${NO_PROXY}
         zabbix_agent2: true
         zabbix_agent_tlspsk_auto: False
         zabbix_agent_tlspskidentity: my_Identity

--- a/molecule/zabbix_agent_tests/molecule/agent2/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/agent2/molecule.yml
@@ -3,9 +3,13 @@ scenario:
   name: agent2
 provisioner:
   name: ansible
-  config_options:
-    privilege_escalation:
-      become_method: ansible.builtin.su
+  env:
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_agent_tests/molecule/agent2/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/agent2/molecule.yml
@@ -4,18 +4,18 @@ scenario:
 provisioner:
   name: ansible
   env:
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:
-        zabbix_http_proxy: ${HTTP_PROXY}
-        zabbix_https_proxy: ${HTTPS_PROXY}
-        zabbix_no_proxy: ${NO_PROXY}
+        zabbix_http_proxy: ${http_proxy}
+        zabbix_https_proxy: ${https_proxy}
+        zabbix_no_proxy: ${no_proxy}
         zabbix_agent2: true
         zabbix_agent_tlspsk_auto: False
         zabbix_agent_tlspskidentity: my_Identity

--- a/molecule/zabbix_agent_tests/molecule/agent2autopsk/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/agent2autopsk/molecule.yml
@@ -3,9 +3,13 @@ scenario:
   name: agent2autopsk
 provisioner:
   name: ansible
-  config_options:
-    privilege_escalation:
-      become_method: ansible.builtin.su
+  env:
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_agent_tests/molecule/agent2autopsk/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/agent2autopsk/molecule.yml
@@ -4,18 +4,18 @@ scenario:
 provisioner:
   name: ansible
   env:
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:
-        zabbix_http_proxy: ${HTTP_PROXY}
-        zabbix_https_proxy: ${HTTPS_PROXY}
-        zabbix_no_proxy: ${NO_PROXY}
+        zabbix_http_proxy: ${http_proxy}
+        zabbix_https_proxy: ${https_proxy}
+        zabbix_no_proxy: ${no_proxy}
         zabbix_agent2: true
         zabbix_agent_tlspsk_auto: True
         zabbix_agent_plugins:

--- a/molecule/zabbix_agent_tests/molecule/agent2autopsk/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/agent2autopsk/molecule.yml
@@ -3,9 +3,15 @@ scenario:
   name: agent2autopsk
 provisioner:
   name: ansible
+  config_options:
+    privilege_escalation:
+      become_method: ansible.builtin.su
   inventory:
     group_vars:
       all:
+        zabbix_http_proxy: ${HTTP_PROXY}
+        zabbix_https_proxy: ${HTTPS_PROXY}
+        zabbix_no_proxy: ${NO_PROXY}
         zabbix_agent2: true
         zabbix_agent_tlspsk_auto: True
         zabbix_agent_plugins:

--- a/molecule/zabbix_agent_tests/molecule/autopsk/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/autopsk/molecule.yml
@@ -3,9 +3,13 @@ scenario:
   name: autopsk
 provisioner:
   name: ansible
-  config_options:
-    privilege_escalation:
-      become_method: ansible.builtin.su
+  env:
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_agent_tests/molecule/autopsk/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/autopsk/molecule.yml
@@ -4,16 +4,16 @@ scenario:
 provisioner:
   name: ansible
   env:
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:
-        zabbix_http_proxy: ${HTTP_PROXY}
-        zabbix_https_proxy: ${HTTPS_PROXY}
-        zabbix_no_proxy: ${NO_PROXY}
+        zabbix_http_proxy: ${http_proxy}
+        zabbix_https_proxy: ${https_proxy}
+        zabbix_no_proxy: ${no_proxy}
         zabbix_agent_tlspsk_auto: True

--- a/molecule/zabbix_agent_tests/molecule/autopsk/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/autopsk/molecule.yml
@@ -3,7 +3,13 @@ scenario:
   name: autopsk
 provisioner:
   name: ansible
+  config_options:
+    privilege_escalation:
+      become_method: ansible.builtin.su
   inventory:
     group_vars:
       all:
+        zabbix_http_proxy: ${HTTP_PROXY}
+        zabbix_https_proxy: ${HTTPS_PROXY}
+        zabbix_no_proxy: ${NO_PROXY}
         zabbix_agent_tlspsk_auto: True

--- a/molecule/zabbix_agent_tests/molecule/default/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/default/molecule.yml
@@ -3,9 +3,15 @@ scenario:
   name: default
 provisioner:
   name: ansible
+  config_options:
+    privilege_escalation:
+      become_method: ansible.builtin.su
   inventory:
     group_vars:
       all:
+        zabbix_http_proxy: ${HTTP_PROXY}
+        zabbix_https_proxy: ${HTTPS_PROXY}
+        zabbix_no_proxy: ${NO_PROXY}
         zabbix_agent_tlspskidentity: my_Identity
         zabbix_agent_tlspskfile: /data/certs/zabbix.psk
         zabbix_agent_tlspsk_secret: 97defd6bd126d5ba7fa5f296595f82eac905d5eda270207a580ab7c0cb9e8eab

--- a/molecule/zabbix_agent_tests/molecule/default/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/default/molecule.yml
@@ -4,18 +4,18 @@ scenario:
 provisioner:
   name: ansible
   env:
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:
-        zabbix_http_proxy: ${HTTP_PROXY}
-        zabbix_https_proxy: ${HTTPS_PROXY}
-        zabbix_no_proxy: ${NO_PROXY}
+        zabbix_http_proxy: ${http_proxy}
+        zabbix_https_proxy: ${https_proxy}
+        zabbix_no_proxy: ${no_proxy}
         zabbix_agent_tlspskidentity: my_Identity
         zabbix_agent_tlspskfile: /data/certs/zabbix.psk
         zabbix_agent_tlspsk_secret: 97defd6bd126d5ba7fa5f296595f82eac905d5eda270207a580ab7c0cb9e8eab

--- a/molecule/zabbix_agent_tests/molecule/default/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/default/molecule.yml
@@ -3,9 +3,13 @@ scenario:
   name: default
 provisioner:
   name: ansible
-  config_options:
-    privilege_escalation:
-      become_method: ansible.builtin.su
+  env:
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_javagateway/converge.yml
+++ b/molecule/zabbix_javagateway/converge.yml
@@ -1,6 +1,10 @@
 ---
 - name: Converge
   hosts: all
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
   roles:
     - role: zabbix_javagateway
       javagateway_pidfile: /tmp/zabbix_java.pid

--- a/molecule/zabbix_javagateway/molecule.yml
+++ b/molecule/zabbix_javagateway/molecule.yml
@@ -31,9 +31,12 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
-  config_options:
-    privilege_escalation:
-      become_method: ansible.builtin.su
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_javagateway/molecule.yml
+++ b/molecule/zabbix_javagateway/molecule.yml
@@ -31,9 +31,15 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
+  config_options:
+    privilege_escalation:
+      become_method: ansible.builtin.su
   inventory:
     group_vars:
       all:
+        zabbix_http_proxy: ${HTTP_PROXY}
+        zabbix_https_proxy: ${HTTPS_PROXY}
+        zabbix_no_proxy: ${NO_PROXY}
         ansible_connection: community.docker.docker
       v74:
         zabbix_javagateway_version: 7.4

--- a/molecule/zabbix_javagateway/molecule.yml
+++ b/molecule/zabbix_javagateway/molecule.yml
@@ -31,18 +31,18 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:
-        zabbix_http_proxy: ${HTTP_PROXY}
-        zabbix_https_proxy: ${HTTPS_PROXY}
-        zabbix_no_proxy: ${NO_PROXY}
+        zabbix_http_proxy: ${http_proxy}
+        zabbix_https_proxy: ${https_proxy}
+        zabbix_no_proxy: ${no_proxy}
         ansible_connection: community.docker.docker
       v74:
         zabbix_javagateway_version: 7.4

--- a/molecule/zabbix_javagateway/prepare.yml
+++ b/molecule/zabbix_javagateway/prepare.yml
@@ -2,51 +2,12 @@
 - name: Prepare
   hosts: all
 
-  pre_tasks:
-    # before anything else, put optional proxy configs in important parts of the os
-    - name: "bash proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/profile.d/proxy.sh
-      when:
-        - zabbix_http_proxy is defined
-    - name: "apt proxy"
-      ansible.builtin.copy:
-        content: |
-          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
-          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
-        dest: /etc/apt/apt.conf.d/99proxy
-      when:
-        - ansible_facts['os_family'] == 'Debian'
-        - zabbix_http_proxy is defined
-    - name: "dnf proxy"
-      ansible.builtin.lineinfile:
-        regexp: '^proxy='
-        line: 'proxy={{ zabbix_http_proxy }}'
-        path: /etc/dnf/dnf.conf
-      when:
-        - ansible_facts['os_family'] == 'RedHat'
-        - zabbix_http_proxy is defined
-    - name: "suse proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/sysconfig/proxy
-      when:
-        - ansible_facts['os_family'] == 'Suse'
-        - zabbix_http_proxy is defined
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
 
+  pre_tasks:
     - name: "Installing packages"
       ansible.builtin.package:
         name:
@@ -54,6 +15,10 @@
         state: present
       register: installation_dependencies
       until: installation_dependencies is succeeded
+
+    # workaround for "Authentication service cannot retrieve authentication info"
+    - name: "SUDO permissions workaround"
+      ansible.builtin.command: chmod 0400 /etc/shadow
 
     # https://github.com/geerlingguy/ansible-role-java/issues/64
     - name: "Workaround Java issue for Debian"

--- a/molecule/zabbix_javagateway/prepare.yml
+++ b/molecule/zabbix_javagateway/prepare.yml
@@ -3,6 +3,50 @@
   hosts: all
 
   pre_tasks:
+    # before anything else, put optional proxy configs in important parts of the os
+    - name: "bash proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/profile.d/proxy.sh
+      when:
+        - zabbix_http_proxy is defined
+    - name: "apt proxy"
+      ansible.builtin.copy:
+        content: |
+          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
+          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
+        dest: /etc/apt/apt.conf.d/99proxy
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - zabbix_http_proxy is defined
+    - name: "dnf proxy"
+      ansible.builtin.lineinfile:
+        regexp: '^proxy='
+        line: 'proxy={{ zabbix_http_proxy }}'
+        path: /etc/dnf/dnf.conf
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - zabbix_http_proxy is defined
+    - name: "suse proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/sysconfig/proxy
+      when:
+        - ansible_facts['os_family'] == 'Suse'
+        - zabbix_http_proxy is defined
+
     - name: "Installing packages"
       ansible.builtin.package:
         name:

--- a/molecule/zabbix_proxy/converge.yml
+++ b/molecule/zabbix_proxy/converge.yml
@@ -1,5 +1,9 @@
 ---
 - hosts: all
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
   roles:
     - role: zabbix_proxy
   tasks:

--- a/molecule/zabbix_proxy/molecule.yml
+++ b/molecule/zabbix_proxy/molecule.yml
@@ -33,9 +33,12 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
-  config_options:
-    privilege_escalation:
-      become_method: ansible.builtin.su
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_proxy/molecule.yml
+++ b/molecule/zabbix_proxy/molecule.yml
@@ -33,9 +33,15 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
+  config_options:
+    privilege_escalation:
+      become_method: ansible.builtin.su
   inventory:
     group_vars:
       all:
+        zabbix_http_proxy: ${HTTP_PROXY}
+        zabbix_https_proxy: ${HTTPS_PROXY}
+        zabbix_no_proxy: ${NO_PROXY}
         ansible_connection: community.docker.docker
         zabbix_api_create_proxy: true
         zabbix_proxy_hostname: proxy1

--- a/molecule/zabbix_proxy/molecule.yml
+++ b/molecule/zabbix_proxy/molecule.yml
@@ -33,18 +33,18 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:
-        zabbix_http_proxy: ${HTTP_PROXY}
-        zabbix_https_proxy: ${HTTPS_PROXY}
-        zabbix_no_proxy: ${NO_PROXY}
+        zabbix_http_proxy: ${http_proxy}
+        zabbix_https_proxy: ${https_proxy}
+        zabbix_no_proxy: ${no_proxy}
         ansible_connection: community.docker.docker
         zabbix_api_create_proxy: true
         zabbix_proxy_hostname: proxy1

--- a/molecule/zabbix_proxy/prepare.yml
+++ b/molecule/zabbix_proxy/prepare.yml
@@ -3,6 +3,50 @@
   hosts: all
 
   tasks:
+    # before anything else, put optional proxy configs in important parts of the os
+    - name: "bash proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/profile.d/proxy.sh
+      when:
+        - zabbix_http_proxy is defined
+    - name: "apt proxy"
+      ansible.builtin.copy:
+        content: |
+          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
+          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
+        dest: /etc/apt/apt.conf.d/99proxy
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - zabbix_http_proxy is defined
+    - name: "dnf proxy"
+      ansible.builtin.lineinfile:
+        regexp: '^proxy='
+        line: 'proxy={{ zabbix_http_proxy }}'
+        path: /etc/dnf/dnf.conf
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - zabbix_http_proxy is defined
+    - name: "suse proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/sysconfig/proxy
+      when:
+        - ansible_facts['os_family'] == 'Suse'
+        - zabbix_http_proxy is defined
+
     # To prevent services from starting during package installations on a docker build,
     # images normally come with this set to exit 101.
     - name: "Allow services to start on install"

--- a/molecule/zabbix_proxy/prepare.yml
+++ b/molecule/zabbix_proxy/prepare.yml
@@ -2,51 +2,12 @@
 - name: Prepare
   hosts: all
 
-  tasks:
-    # before anything else, put optional proxy configs in important parts of the os
-    - name: "bash proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/profile.d/proxy.sh
-      when:
-        - zabbix_http_proxy is defined
-    - name: "apt proxy"
-      ansible.builtin.copy:
-        content: |
-          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
-          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
-        dest: /etc/apt/apt.conf.d/99proxy
-      when:
-        - ansible_facts['os_family'] == 'Debian'
-        - zabbix_http_proxy is defined
-    - name: "dnf proxy"
-      ansible.builtin.lineinfile:
-        regexp: '^proxy='
-        line: 'proxy={{ zabbix_http_proxy }}'
-        path: /etc/dnf/dnf.conf
-      when:
-        - ansible_facts['os_family'] == 'RedHat'
-        - zabbix_http_proxy is defined
-    - name: "suse proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/sysconfig/proxy
-      when:
-        - ansible_facts['os_family'] == 'Suse'
-        - zabbix_http_proxy is defined
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
 
+  tasks:
     # To prevent services from starting during package installations on a docker build,
     # images normally come with this set to exit 101.
     - name: "Allow services to start on install"
@@ -63,6 +24,10 @@
         update_cache: "{{ (ansible_facts['os_family'] in ['Debian', 'Suse']) | ternary(true, omit) }}"
       register: installation_dependencies
       until: installation_dependencies is succeeded
+
+    # workaround for "Authentication service cannot retrieve authentication info"
+    - name: "SUDO permissions workaround"
+      ansible.builtin.command: chmod 0400 /etc/shadow
 
     - name: "Configure SUDO."
       ansible.builtin.lineinfile:

--- a/molecule/zabbix_proxy_psk/molecule.yml
+++ b/molecule/zabbix_proxy_psk/molecule.yml
@@ -34,9 +34,15 @@ provisioner:
   env:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
+  config_options:
+    privilege_escalation:
+      become_method: ansible.builtin.su
   inventory:
     group_vars:
       all:
+        zabbix_http_proxy: ${HTTP_PROXY}
+        zabbix_https_proxy: ${HTTPS_PROXY}
+        zabbix_no_proxy: ${NO_PROXY}
         ansible_connection: community.docker.docker
         zabbix_api_create_proxy: true
         zabbix_proxy_hostname: proxy1

--- a/molecule/zabbix_proxy_psk/molecule.yml
+++ b/molecule/zabbix_proxy_psk/molecule.yml
@@ -34,9 +34,12 @@ provisioner:
   env:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
-  config_options:
-    privilege_escalation:
-      become_method: ansible.builtin.su
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_proxy_psk/molecule.yml
+++ b/molecule/zabbix_proxy_psk/molecule.yml
@@ -34,18 +34,18 @@ provisioner:
   env:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:
-        zabbix_http_proxy: ${HTTP_PROXY}
-        zabbix_https_proxy: ${HTTPS_PROXY}
-        zabbix_no_proxy: ${NO_PROXY}
+        zabbix_http_proxy: ${http_proxy}
+        zabbix_https_proxy: ${https_proxy}
+        zabbix_no_proxy: ${no_proxy}
         ansible_connection: community.docker.docker
         zabbix_api_create_proxy: true
         zabbix_proxy_hostname: proxy1

--- a/molecule/zabbix_proxy_psk_active/molecule.yml
+++ b/molecule/zabbix_proxy_psk_active/molecule.yml
@@ -34,9 +34,15 @@ provisioner:
   env:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
+  config_options:
+    privilege_escalation:
+      become_method: ansible.builtin.su
   inventory:
     group_vars:
       all:
+        zabbix_http_proxy: ${HTTP_PROXY}
+        zabbix_https_proxy: ${HTTPS_PROXY}
+        zabbix_no_proxy: ${NO_PROXY}
         ansible_connection: community.docker.docker
         zabbix_api_create_proxy: true
         zabbix_proxy_hostname: proxy1

--- a/molecule/zabbix_proxy_psk_active/molecule.yml
+++ b/molecule/zabbix_proxy_psk_active/molecule.yml
@@ -34,9 +34,12 @@ provisioner:
   env:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
-  config_options:
-    privilege_escalation:
-      become_method: ansible.builtin.su
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_proxy_psk_active/molecule.yml
+++ b/molecule/zabbix_proxy_psk_active/molecule.yml
@@ -34,18 +34,18 @@ provisioner:
   env:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:
-        zabbix_http_proxy: ${HTTP_PROXY}
-        zabbix_https_proxy: ${HTTPS_PROXY}
-        zabbix_no_proxy: ${NO_PROXY}
+        zabbix_http_proxy: ${http_proxy}
+        zabbix_https_proxy: ${https_proxy}
+        zabbix_no_proxy: ${no_proxy}
         ansible_connection: community.docker.docker
         zabbix_api_create_proxy: true
         zabbix_proxy_hostname: proxy1

--- a/molecule/zabbix_repo/converge.yml
+++ b/molecule/zabbix_repo/converge.yml
@@ -1,4 +1,8 @@
 ---
 - hosts: all
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
   roles:
     - role: zabbix_repo

--- a/molecule/zabbix_repo/molecule.yml
+++ b/molecule/zabbix_repo/molecule.yml
@@ -31,12 +31,12 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_repo/molecule.yml
+++ b/molecule/zabbix_repo/molecule.yml
@@ -31,6 +31,12 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_repo/prepare.yml
+++ b/molecule/zabbix_repo/prepare.yml
@@ -2,51 +2,12 @@
 - name: Prepare
   hosts: all
 
-  tasks:
-    # before anything else, put optional proxy configs in important parts of the os
-    - name: "bash proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/profile.d/proxy.sh
-      when:
-        - zabbix_http_proxy is defined
-    - name: "apt proxy"
-      ansible.builtin.copy:
-        content: |
-          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
-          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
-        dest: /etc/apt/apt.conf.d/99proxy
-      when:
-        - ansible_facts['os_family'] == 'Debian'
-        - zabbix_http_proxy is defined
-    - name: "dnf proxy"
-      ansible.builtin.lineinfile:
-        regexp: '^proxy='
-        line: 'proxy={{ zabbix_http_proxy }}'
-        path: /etc/dnf/dnf.conf
-      when:
-        - ansible_facts['os_family'] == 'RedHat'
-        - zabbix_http_proxy is defined
-    - name: "suse proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/sysconfig/proxy
-      when:
-        - ansible_facts['os_family'] == 'Suse'
-        - zabbix_http_proxy is defined
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
 
+  tasks:
     - name: "Configure SUDO."
       ansible.builtin.lineinfile:
         dest: /etc/sudoers

--- a/molecule/zabbix_repo/prepare.yml
+++ b/molecule/zabbix_repo/prepare.yml
@@ -3,6 +3,50 @@
   hosts: all
 
   tasks:
+    # before anything else, put optional proxy configs in important parts of the os
+    - name: "bash proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/profile.d/proxy.sh
+      when:
+        - zabbix_http_proxy is defined
+    - name: "apt proxy"
+      ansible.builtin.copy:
+        content: |
+          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
+          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
+        dest: /etc/apt/apt.conf.d/99proxy
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - zabbix_http_proxy is defined
+    - name: "dnf proxy"
+      ansible.builtin.lineinfile:
+        regexp: '^proxy='
+        line: 'proxy={{ zabbix_http_proxy }}'
+        path: /etc/dnf/dnf.conf
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - zabbix_http_proxy is defined
+    - name: "suse proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/sysconfig/proxy
+      when:
+        - ansible_facts['os_family'] == 'Suse'
+        - zabbix_http_proxy is defined
+
     - name: "Configure SUDO."
       ansible.builtin.lineinfile:
         dest: /etc/sudoers

--- a/molecule/zabbix_server/converge.yml
+++ b/molecule/zabbix_server/converge.yml
@@ -1,5 +1,9 @@
 ---
 - hosts: all
   become: true
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
   roles:
     - role: zabbix_server

--- a/molecule/zabbix_server/molecule.yml
+++ b/molecule/zabbix_server/molecule.yml
@@ -32,9 +32,12 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
-  config_options:
-    privilege_escalation:
-      become_method: ansible.builtin.su
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_server/molecule.yml
+++ b/molecule/zabbix_server/molecule.yml
@@ -32,18 +32,18 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:
-        zabbix_http_proxy: ${HTTP_PROXY}
-        zabbix_https_proxy: ${HTTPS_PROXY}
-        zabbix_no_proxy: ${NO_PROXY}
+        zabbix_http_proxy: ${http_proxy}
+        zabbix_https_proxy: ${https_proxy}
+        zabbix_no_proxy: ${no_proxy}
         ansible_connection: community.docker.docker
       v74:
         zabbix_server_version: 7.4

--- a/molecule/zabbix_server/molecule.yml
+++ b/molecule/zabbix_server/molecule.yml
@@ -32,9 +32,15 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
+  config_options:
+    privilege_escalation:
+      become_method: ansible.builtin.su
   inventory:
     group_vars:
       all:
+        zabbix_http_proxy: ${HTTP_PROXY}
+        zabbix_https_proxy: ${HTTPS_PROXY}
+        zabbix_no_proxy: ${NO_PROXY}
         ansible_connection: community.docker.docker
       v74:
         zabbix_server_version: 7.4

--- a/molecule/zabbix_server/prepare.yml
+++ b/molecule/zabbix_server/prepare.yml
@@ -3,6 +3,50 @@
   hosts: all
 
   tasks:
+    # before anything else, put optional proxy configs in important parts of the os
+    - name: "bash proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/profile.d/proxy.sh
+      when:
+        - zabbix_http_proxy is defined
+    - name: "apt proxy"
+      ansible.builtin.copy:
+        content: |
+          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
+          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
+        dest: /etc/apt/apt.conf.d/99proxy
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - zabbix_http_proxy is defined
+    - name: "dnf proxy"
+      ansible.builtin.lineinfile:
+        regexp: '^proxy='
+        line: 'proxy={{ zabbix_http_proxy }}'
+        path: /etc/dnf/dnf.conf
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - zabbix_http_proxy is defined
+    - name: "suse proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/sysconfig/proxy
+      when:
+        - ansible_facts['os_family'] == 'Suse'
+        - zabbix_http_proxy is defined
+
     # To prevent services from starting during package installations on a docker build,
     # images normally come with this set to exit 101.
     - name: "Allow services to start on install"

--- a/molecule/zabbix_server/prepare.yml
+++ b/molecule/zabbix_server/prepare.yml
@@ -2,51 +2,12 @@
 - name: Prepare
   hosts: all
 
-  tasks:
-    # before anything else, put optional proxy configs in important parts of the os
-    - name: "bash proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/profile.d/proxy.sh
-      when:
-        - zabbix_http_proxy is defined
-    - name: "apt proxy"
-      ansible.builtin.copy:
-        content: |
-          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
-          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
-        dest: /etc/apt/apt.conf.d/99proxy
-      when:
-        - ansible_facts['os_family'] == 'Debian'
-        - zabbix_http_proxy is defined
-    - name: "dnf proxy"
-      ansible.builtin.lineinfile:
-        regexp: '^proxy='
-        line: 'proxy={{ zabbix_http_proxy }}'
-        path: /etc/dnf/dnf.conf
-      when:
-        - ansible_facts['os_family'] == 'RedHat'
-        - zabbix_http_proxy is defined
-    - name: "suse proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/sysconfig/proxy
-      when:
-        - ansible_facts['os_family'] == 'Suse'
-        - zabbix_http_proxy is defined
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
 
+  tasks:
     # To prevent services from starting during package installations on a docker build,
     # images normally come with this set to exit 101.
     - name: "Allow services to start on install"
@@ -63,6 +24,10 @@
         update_cache: "{{ (ansible_facts['os_family'] in ['Debian', 'Suse']) | ternary(true, omit) }}"
       register: installation_dependencies
       until: installation_dependencies is succeeded
+
+    # workaround for "Authentication service cannot retrieve authentication info"
+    - name: "SUDO permissions workaround"
+      ansible.builtin.command: chmod 0400 /etc/shadow
 
     - name: "Configure SUDO."
       ansible.builtin.lineinfile:

--- a/molecule/zabbix_web/converge.yml
+++ b/molecule/zabbix_web/converge.yml
@@ -1,5 +1,9 @@
 ---
 - name: Converge
   hosts: all
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
   roles:
     - role: zabbix_web

--- a/molecule/zabbix_web/molecule.yml
+++ b/molecule/zabbix_web/molecule.yml
@@ -34,9 +34,12 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
-  config_options:
-    privilege_escalation:
-      become_method: ansible.builtin.su
+    HTTP_PROXY: "${HTTP_PROXY}"
+    HTTPS_PROXY: "${HTTPS_PROXY}"
+    NO_PROXY: "${NO_PROXY}"
+    http_proxy: "${HTTP_PROXY}"
+    https_proxy: "${HTTPS_PROXY}"
+    no_proxy: "${NO_PROXY}"
   inventory:
     group_vars:
       all:

--- a/molecule/zabbix_web/molecule.yml
+++ b/molecule/zabbix_web/molecule.yml
@@ -34,9 +34,15 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
+  config_options:
+    privilege_escalation:
+      become_method: ansible.builtin.su
   inventory:
     group_vars:
       all:
+        zabbix_http_proxy: ${HTTP_PROXY}
+        zabbix_https_proxy: ${HTTPS_PROXY}
+        zabbix_no_proxy: ${NO_PROXY}
         ansible_connection: community.docker.docker
         zabbix_api_server_url: zabbix-web-${MY_MOLECULE_VERSION:-v74}-${MY_MOLECULE_DATABASE:-mysql}-${MY_MOLECULE_CONTAINER:-rockylinux10}
       v74:

--- a/molecule/zabbix_web/molecule.yml
+++ b/molecule/zabbix_web/molecule.yml
@@ -34,18 +34,18 @@ provisioner:
     # https://github.com/ansible/molecule/issues/4015#issuecomment-1680859724
     ANSIBLE_ROLES_PATH: ../../roles
     ANSIBLE_INJECT_FACT_VARS: "False"
-    HTTP_PROXY: "${HTTP_PROXY}"
-    HTTPS_PROXY: "${HTTPS_PROXY}"
-    NO_PROXY: "${NO_PROXY}"
-    http_proxy: "${HTTP_PROXY}"
-    https_proxy: "${HTTPS_PROXY}"
-    no_proxy: "${NO_PROXY}"
+    HTTP_PROXY: "${http_proxy}"
+    HTTPS_PROXY: "${https_proxy}"
+    NO_PROXY: "${no_proxy}"
+    http_proxy: "${http_proxy}"
+    https_proxy: "${https_proxy}"
+    no_proxy: "${no_proxy}"
   inventory:
     group_vars:
       all:
-        zabbix_http_proxy: ${HTTP_PROXY}
-        zabbix_https_proxy: ${HTTPS_PROXY}
-        zabbix_no_proxy: ${NO_PROXY}
+        zabbix_http_proxy: ${http_proxy}
+        zabbix_https_proxy: ${https_proxy}
+        zabbix_no_proxy: ${no_proxy}
         ansible_connection: community.docker.docker
         zabbix_api_server_url: zabbix-web-${MY_MOLECULE_VERSION:-v74}-${MY_MOLECULE_DATABASE:-mysql}-${MY_MOLECULE_CONTAINER:-rockylinux10}
       v74:

--- a/molecule/zabbix_web/prepare.yml
+++ b/molecule/zabbix_web/prepare.yml
@@ -3,6 +3,50 @@
   hosts: all
 
   pre_tasks:
+    # before anything else, put optional proxy configs in important parts of the os
+    - name: "bash proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/profile.d/proxy.sh
+      when:
+        - zabbix_http_proxy is defined
+    - name: "apt proxy"
+      ansible.builtin.copy:
+        content: |
+          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
+          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
+        dest: /etc/apt/apt.conf.d/99proxy
+      when:
+        - ansible_facts['os_family'] == 'Debian'
+        - zabbix_http_proxy is defined
+    - name: "dnf proxy"
+      ansible.builtin.lineinfile:
+        regexp: '^proxy='
+        line: 'proxy={{ zabbix_http_proxy }}'
+        path: /etc/dnf/dnf.conf
+      when:
+        - ansible_facts['os_family'] == 'RedHat'
+        - zabbix_http_proxy is defined
+    - name: "suse proxy"
+      ansible.builtin.copy:
+        content: |
+          export HTTP_PROXY="{{ zabbix_http_proxy }}"
+          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
+          export http_proxy="{{ zabbix_http_proxy }}"
+          export https_proxy="{{ zabbix_https_proxy }}"
+          export no_proxy="{{ zabbix_no_proxy }}"
+          export NO_PROXY="{{ zabbix_no_proxy }}"
+        dest: /etc/sysconfig/proxy
+      when:
+        - ansible_facts['os_family'] == 'Suse'
+        - zabbix_http_proxy is defined
+
     # issues on redhat with curl, so install curl-minimal.
     - name: "Installing packages"
       ansible.builtin.package:

--- a/molecule/zabbix_web/prepare.yml
+++ b/molecule/zabbix_web/prepare.yml
@@ -2,51 +2,12 @@
 - name: Prepare
   hosts: all
 
-  pre_tasks:
-    # before anything else, put optional proxy configs in important parts of the os
-    - name: "bash proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/profile.d/proxy.sh
-      when:
-        - zabbix_http_proxy is defined
-    - name: "apt proxy"
-      ansible.builtin.copy:
-        content: |
-          Acquire::http::Proxy "{{ zabbix_http_proxy }}";
-          Acquire::https::Proxy "{{ zabbix_https_proxy }}";
-        dest: /etc/apt/apt.conf.d/99proxy
-      when:
-        - ansible_facts['os_family'] == 'Debian'
-        - zabbix_http_proxy is defined
-    - name: "dnf proxy"
-      ansible.builtin.lineinfile:
-        regexp: '^proxy='
-        line: 'proxy={{ zabbix_http_proxy }}'
-        path: /etc/dnf/dnf.conf
-      when:
-        - ansible_facts['os_family'] == 'RedHat'
-        - zabbix_http_proxy is defined
-    - name: "suse proxy"
-      ansible.builtin.copy:
-        content: |
-          export HTTP_PROXY="{{ zabbix_http_proxy }}"
-          export HTTPS_PROXY="{{ zabbix_https_proxy }}"
-          export http_proxy="{{ zabbix_http_proxy }}"
-          export https_proxy="{{ zabbix_https_proxy }}"
-          export no_proxy="{{ zabbix_no_proxy }}"
-          export NO_PROXY="{{ zabbix_no_proxy }}"
-        dest: /etc/sysconfig/proxy
-      when:
-        - ansible_facts['os_family'] == 'Suse'
-        - zabbix_http_proxy is defined
+  environment:
+    http_proxy: "{{ zabbix_http_proxy }}"
+    https_proxy: "{{ zabbix_https_proxy }}"
+    no_proxy: "{{ zabbix_no_proxy }}"
 
+  pre_tasks:
     # issues on redhat with curl, so install curl-minimal.
     - name: "Installing packages"
       ansible.builtin.package:
@@ -62,6 +23,10 @@
         dest: /etc/sudoers
         line: "Defaults    !requiretty"
         state: present
+
+    # workaround for "Authentication service cannot retrieve authentication info"
+    - name: "SUDO permissions workaround"
+      ansible.builtin.command: chmod 0400 /etc/shadow
 
     - name: Enabling PHP 8.0
       ansible.builtin.dnf:


### PR DESCRIPTION
##### SUMMARY
This makes ``molecule test --all`` run to completion when behind a web proxy. To test, put yourself behind a squid proxy without any other internet access, and run something like:
```
HTTP_PROXY=http://10.10.10.10:3128 HTTPS_PROXY=http://10.10.10.10:3128 NO_PROXY=localhost molecule test --all
```

Without these changes, molecule fails during preparare on the task to install sudo.

This also includes a ``become`` change I ran into, where ``sudo`` always failed due to reasons I think are PAM-related. Rather than debug that further, I switched to ``su`` and included it in this PR to make it testable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Test automation

##### ADDITIONAL INFORMATION
The changes in this PR are the same in every scenario:
* Change the become provider to ``su``
* Pass ``zabbix_*_proxy`` into ansible runs from the environment
* Configure OS tools that are not affected by ``zabbix_*_proxy`` but still need internet access

```paste below
HTTP_PROXY=http://10.10.10.10:3128 HTTPS_PROXY=http://10.10.10.10:3128 NO_PROXY=localhost molecule test --all
```