### PR TITLE
Fix issue 1668: nginx vhost template does not support http2

### DIFF
--- a/changelogs/fragments/1668-nginx-http2-config.yaml
+++ b/changelogs/fragments/1668-nginx-http2-config.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_web - nginx vhost template did not support http2 configuration (https://github.com/ansible-collections/community.zabbix/issues/1668).

--- a/roles/zabbix_web/templates/nginx_vhost.conf.j2
+++ b/roles/zabbix_web/templates/nginx_vhost.conf.j2
@@ -76,8 +76,10 @@ server {
 
 {% if zabbix_web_tls|default(false) %}
 server {
-    listen {{ zabbix_web_vhost_tls_port }} ssl {{ 'http2' if zabbix_web_ssl_http2 else '' }};
-    listen [::]:{{ zabbix_web_vhost_tls_port }} ssl {{ 'http2' if zabbix_web_ssl_http2 else '' }};
+    listen {{ zabbix_web_vhost_tls_port }} ssl;
+    {{ 'http2 on;' if zabbix_web_ssl_http2 else '' }}
+    listen [::]:{{ zabbix_web_vhost_tls_port }} ssl
+    {{ 'http2 on;' if zabbix_web_ssl_http2 else '' }};
     server_tokens off;
     server_name {{ zabbix_api_server_url }} {% for alias in zabbix_url_aliases -%}{{ alias -}} {% endfor %};
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change resolve issue #1668 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- Zabbix web


The syntax suggested by @nlvw is correct and respect the NGNIX documentation

https://nginx.org/en/CHANGES
```
Changes with nginx 1.25.1 - 13 Jun 2023

    *) Feature: the "http2" directive, which enables HTTP/2 on a per-server
       basis; the "http2" parameter of the "listen" directive is now
       deprecated.
```
https://nginx.org/en/CHANGES
