### PR TITLE
Revert "Updated Testing Matrix"

### DIFF
--- a/.github/workflows/plugins-integration.yml
+++ b/.github/workflows/plugins-integration.yml
@@ -30,33 +30,19 @@ jobs:
           - stable-2.17
           - stable-2.18
           - stable-2.19
-          - stable-2.20
           - devel
         python:
           - '3.10'
           - '3.11'
           - '3.12'
           - '3.13'
-          - '3.14'
         exclude:
-          - ansible: stable-2.20
-            python: '3.11'
-          - ansible: stable-2.20
-            python: '3.10'
-          - ansible: stable-2.19
-            python: '3.14'
           - ansible: stable-2.19
             python: '3.10'
           - ansible: stable-2.18
-            python: '3.14'
-          - ansible: stable-2.18
             python: '3.10'
-          - ansible: stable-2.17
-            python: '3.14'
           - ansible: stable-2.17
             python: '3.13'
-          - ansible: stable-2.16
-            python: '3.14'
           - ansible: stable-2.16
             python: '3.13'
           - ansible: devel


### PR DESCRIPTION
Reverts ansible-collections/community.zabbix#1704

This has caused the number of tests run per PR to go from 6 to over 500, so reverting.