### PR TITLE
Fix configuration module to import host and some resource

### DIFF
--- a/changelogs/fragments/1727-fix-configuration-module.yaml
+++ b/changelogs/fragments/1727-fix-configuration-module.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_configuration - Fix configuration module to import host and some resource

--- a/plugins/modules/zabbix_configuration.py
+++ b/plugins/modules/zabbix_configuration.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2025, ONODERA Masaru <masaru-onodera@ieee.org>
+# Copyright: (c) 2025, ONODERA Masaru <masa-orca>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -45,6 +45,7 @@ options:
         description:
             - The rules for importing the configuration.
             - Please refer to rules of the Zabbix configuration.import API documentation for more details.
+            - If you set C(hosts), C(images), C(maps) or C(mediaTypes) in this parameter, this module import configuration without compare.
             - https://www.zabbix.com/documentation/current/en/manual/api/reference/configuration/import
         required: false
         type: dict
@@ -183,7 +184,11 @@ def main():
         format = "yaml"
         content = content_yaml
 
-    changed = configuration.import_compare(content, format, rules)
+    uncomparable_rules = ["hosts", "images", "maps", "mediaTypes"]
+    if set(rules.keys()).isdisjoint(uncomparable_rules):
+        changed = configuration.import_compare(content, format, rules)
+    else:
+        changed = True
 
     if not changed:
         module.exit_json(changed=changed, result="Configuration is up-to date")

--- a/tests/integration/targets/test_zabbix_configuration/files/host.yaml
+++ b/tests/integration/targets/test_zabbix_configuration/files/host.yaml
@@ -1,0 +1,18 @@
+zabbix_export:
+  version: '6.0'
+  date: '2023-05-03T11:24:04Z'
+  groups:
+    - uuid: dc579cd7a1a34222933f24f52a68bcd8
+      name: 'Linux servers'
+  hosts:
+    - host: Imported_host
+      name: Imported_host
+      templates:
+        - name: 'Zabbix server health'
+      groups:
+        - name: 'Linux servers'
+      items:
+        - name: Test_item1
+          type: ZABBIX_ACTIVE
+          key: kernel.maxproc
+      inventory_mode: DISABLED

--- a/tests/integration/targets/test_zabbix_configuration/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_configuration/tasks/main.yml
@@ -169,3 +169,124 @@
     - ExampleTemplateXML
     - ExampleTemplateYAML
     - FTP Service
+
+- name: test - import Zabbix host from YAML
+  community.zabbix.zabbix_configuration:
+    content_yaml: "{{ lookup('file', 'host.yaml') }}"
+    rules:
+      hosts:
+        createMissing: true
+        updateExisting: true
+      items:
+        createMissing: true
+        updateExisting: true
+        deleteMissing: true
+      triggers:
+        createMissing: true
+        updateExisting: true
+        deleteMissing: true
+      valueMaps:
+        createMissing: true
+        updateExisting: false
+  register: zbxconfiguration_import
+
+- name: assert that configuration was imported
+  ansible.builtin.assert:
+    that:
+      - zbxconfiguration_import.changed is sameas True
+
+- name: Test for Zabbix version < 7.0
+  when: zabbix_version is version("7.0", "<")
+  block:
+    - name: get imported host
+      ansible.builtin.uri:
+        url: "{{ zabbix_api_server_url }}/api_jsonrpc.php"
+        method: POST
+        body:
+          jsonrpc: "2.0"
+          method: "host.get"
+          params: 
+            output: "extend"
+            filter: 
+              host:
+                - "Imported_host"
+          id: "1"
+          auth: "{{ check_login_under64_result.json.result }}"
+        body_format: json
+        status_code: 200
+      retries: 5
+      delay: 5
+      until: zabbix_get_host_result is defined and 'json' in zabbix_get_host_result and 'result' in zabbix_get_host_result.json
+      register: zabbix_get_host_result
+
+    - name: assert that host was imported
+      ansible.builtin.assert:
+        that:
+          - zabbix_get_host_result.json.result[0].host == 'Imported_host'
+
+    - name: delete imported host
+      ansible.builtin.uri:
+        url: "{{ zabbix_api_server_url }}/api_jsonrpc.php"
+        method: POST
+        body:
+          jsonrpc: "2.0"
+          method: "host.delete"
+          params: 
+            - "{{ zabbix_get_host_result.json.result[0].hostid }}"
+          id: "1"
+          auth: "{{ check_login_under64_result.json.result }}"
+        body_format: json
+        status_code: 200
+      retries: 5
+      delay: 5
+      until: zabbix_delete_host_result is defined and 'json' in zabbix_delete_host_result and 'result' in zabbix_delete_host_result.json
+      register: zabbix_delete_host_result
+
+- name: Test for Zabbix version >= 7.0
+  when: zabbix_version is version("7.0", ">=")
+  block:
+    - name: get imported host
+      ansible.builtin.uri:
+        url: "{{ zabbix_api_server_url }}/api_jsonrpc.php"
+        method: POST
+        headers: 
+          Authorization: "Bearer {{ check_login_result.json.result }}"
+        body:
+          jsonrpc: "2.0"
+          method: "host.get"
+          params: 
+            output: "extend"
+            filter: 
+              host:
+                - "Imported_host"
+          id: "1"
+        body_format: json
+        status_code: 200
+      retries: 5
+      delay: 5
+      until: zabbix_get_host_result is defined and 'json' in zabbix_get_host_result and 'result' in zabbix_get_host_result.json
+      register: zabbix_get_host_result
+
+    - name: assert that host was imported
+      ansible.builtin.assert:
+        that:
+          - zabbix_get_host_result.json.result[0].host == 'Imported_host'
+
+    - name: delete imported host
+      ansible.builtin.uri:
+        url: "{{ zabbix_api_server_url }}/api_jsonrpc.php"
+        method: POST
+        headers: 
+          Authorization: "Bearer {{ check_login_result.json.result }}"
+        body:
+          jsonrpc: "2.0"
+          method: "host.delete"
+          params: 
+            - "{{ zabbix_get_host_result.json.result[0].hostid }}"
+          id: "1"
+        body_format: json
+        status_code: 200
+      retries: 5
+      delay: 5
+      until: zabbix_delete_host_result is defined and 'json' in zabbix_delete_host_result and 'result' in zabbix_delete_host_result.json
+      register: zabbix_delete_host_result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix configuration module to import host and some resource
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- zabbix_configuration module
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This module uses the `configuration.importcompare` API to determine whether an update is necessary.

However, this API cannot compare certain resources. Therefore, these resources must be imported without performing a comparison.

The official Zabbix documentation states the following:

> This parameter will make no difference to the output. It is allowed only for consistency with `configuration.import`.

in https://www.zabbix.com/documentation/current/en/manual/api/reference/configuration/importcompare