### PR TITLE
Mysql 8.4

### DIFF
--- a/molecule/default/create.docker.yml
+++ b/molecule/default/create.docker.yml
@@ -30,6 +30,7 @@
         image: "{{ _container[_db_type].image }}"
         state: started
         recreate: true
+        command: "{{ _container[_db_type].command | default(omit) }}"
         networks:
           - name: zabbix
         env: "{{ _container[_db_type].env }}"
@@ -40,8 +41,9 @@
         _db_type: "{{ item.groups | intersect(_database_groups) | first }}"
         _container:
           mysql:
-            image: "mysql:8.0.45"
+            image: "mysql:8.4.8"
             env: { MYSQL_ROOT_PASSWORD: changeme }
+            command: --mysql-native-password=ON
           pgsql:
             image: "timescale/timescaledb:latest-pg13"
             env: { POSTGRES_PASSWORD: changeme }

--- a/molecule/zabbix_proxy/create.docker.yml
+++ b/molecule/zabbix_proxy/create.docker.yml
@@ -30,6 +30,7 @@
         image: "{{ _container[_db_type].image }}"
         state: started
         recreate: true
+        command: "{{ _container[_db_type].command | default(omit) }}"
         networks:
           - name: zabbix
         env: "{{ _container[_db_type].env }}"
@@ -40,8 +41,9 @@
         _db_type: "{{ item.groups | intersect(_database_groups) | first }}"
         _container:
           mysql:
-            image: "mysql:8.0.45"
+            image: "mysql:8.4.8"
             env: { MYSQL_ROOT_PASSWORD: changeme }
+            command: --mysql-native-password=ON
           pgsql:
             image: "timescale/timescaledb:latest-pg13"
             env: { POSTGRES_PASSWORD: changeme }

--- a/molecule/zabbix_web/create.docker.yml
+++ b/molecule/zabbix_web/create.docker.yml
@@ -21,6 +21,7 @@
             image: "{{ _container[_db_type].image }}"
             state: started
             recreate: true
+            command: "{{ _container[_db_type].command | default(omit) }}"
             networks:
               - name: zabbix
             env: "{{ _container[_db_type].env }}"
@@ -29,8 +30,9 @@
           vars:
             _container:
               mysql:
-                image: "mysql:8.0"
+                image: "mysql:8.4.8"
                 env: { MYSQL_ROOT_PASSWORD: changeme }
+                command: --mysql-native-password=ON
               pgsql:
                 image: "timescale/timescaledb:latest-pg13"
                 env:


### PR DESCRIPTION
##### SUMMARY
Fixes #1732 


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_proxy
zabbix_web

##### ADDITIONAL INFORMATION
Uses mysql 8.4.8 cause 8.4.9 has a [bug](https://bugs.mysql.com/bug.php?id=120323) that breaks db schema import
Adds command to db container creation cause [mysql_native_password is getting deprecated](https://dev.mysql.com/doc/refman/8.4/en/native-pluggable-authentication.html) and needs to be enabled for mysql 8.4 by using --mysql-native-password=ON

```
The mysql_native_password authentication plugin is deprecated as of MySQL 8.0.34, disabled by default in MySQL 8.4, and removed as of MySQL 9.0.0. 
```