### PR TITLE
fix(zabbix_agent): Windows install hangs when MSI properties contain spaces

### DIFF
--- a/changelogs/fragments/1717-fix-windows-msiexec-property-quoting.yaml
+++ b/changelogs/fragments/1717-fix-windows-msiexec-property-quoting.yaml
@@ -1,2 +1,3 @@
 bugfixes:
   - zabbix_agent - fix Windows agent installation hanging indefinitely when MSI public properties contain spaces; switch ``win_command`` from ``argv:`` to ``cmd:`` form so values can use the ``PROPERTY="value"`` quoting msiexec requires (https://github.com/ansible-collections/community.zabbix/issues/1717).
+  - zabbix_agent - fix Windows agent ``Include`` paths in ``zabbix_agent2.conf`` reverting to Linux defaults (``/etc/zabbix/zabbix_agent2.d``); ``_zabbix_agent_include_dirs`` referenced the now-deprecated ``zabbix_agent_win_install_dir_conf`` without a fallback, which made it evaluate as undefined and ``default(_includes)`` fall through to the Linux paths. Same regression as previously reported in #1378 and #1580.

--- a/changelogs/fragments/1717-fix-windows-msiexec-property-quoting.yaml
+++ b/changelogs/fragments/1717-fix-windows-msiexec-property-quoting.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_agent - fix Windows agent installation hanging indefinitely when MSI public properties contain spaces; switch ``win_command`` from ``argv:`` to ``cmd:`` form so values can use the ``PROPERTY="value"`` quoting msiexec requires (https://github.com/ansible-collections/community.zabbix/issues/1717).

--- a/roles/zabbix_agent/tasks/install-Windows.yml
+++ b/roles/zabbix_agent/tasks/install-Windows.yml
@@ -87,14 +87,12 @@
     #  register: _res
 
     # https://www.zabbix.com/documentation/current/en/manual/installation/install_from_packages/win_msi
+    # cmd: form needed so MSI public properties with spaces can use the
+    # PROPERTY="value" quoting msiexec requires.
     - name: Install Zabbix Agent
       ansible.windows.win_command:
         chdir: "{{ _zabbix_agent_win_userprofile_path.stdout | trim }}/Downloads"
-        argv:
-          - msiexec
-          - /i
-          #- "/l*v zabbix-install.log"
-          - "{{ zabbix_agent_win_package }}"
-          - /qn
-          - "SERVER={{ zabbix_agent_server }}"
-          - "INSTALLFOLDER={{ zabbix_agent_win_install_dir }}"
+        cmd: >-
+          msiexec /i "{{ zabbix_agent_win_package }}" /qn
+          SERVER="{{ zabbix_agent_server }}"
+          INSTALLFOLDER="{{ zabbix_agent_win_install_dir | replace('/', '\\') }}"

--- a/roles/zabbix_agent/vars/Windows.yml
+++ b/roles/zabbix_agent/vars/Windows.yml
@@ -1,7 +1,7 @@
 ---
 _zabbix_agent_logfile: "{{ zabbix_agent_win_install_dir }}\\{{ zabbix_agent2 | ternary('zabbix_agent2.log', 'zabbix_agentd.log') }}"
 _zabbix_agent_include_dirs:
-  - "{{ zabbix_agent_win_install_dir_conf }}\\{{ zabbix_agent2 | ternary('zabbix_agent2.d', 'zabbix_agent.d') }}"
+  - "{{ zabbix_agent_win_install_dir_conf | default(zabbix_agent_win_install_dir) }}\\{{ zabbix_agent2 | ternary('zabbix_agent2.d', 'zabbix_agent.d') }}"
 _zabbix_agent_controlsocket: "\\\\.\\pipe\\agent.sock"
 _zabbix_agent_pluginsocket: "\\\\.\\pipe\\agent.plugin.sock"
 _zabbix_agent_conf_dir: "{{ zabbix_agent_win_install_dir_conf | default(zabbix_agent_win_install_dir) }}"


### PR DESCRIPTION
Fixes #1717. Also fixes a closely-related regression of #1378 / #1580 (Windows `Include` paths) that surfaced while testing this PR.

### Summary

Two bugs that together prevent Windows agent installs from succeeding:

1. **MSI property quoting causes msiexec to hang silently (#1717).**
2. **`Include=` paths in `zabbix_agent2.conf` revert to Linux defaults (#1378, #1580 regression).**

### Bug 1 — msiexec hangs

`roles/zabbix_agent/tasks/install-Windows.yml` invokes `msiexec /i ... /qn` via `ansible.windows.win_command` with `argv:` form. When any MSI public property value contains a space (which `INSTALLFOLDER` always does given the role's default of `C:/Program Files/Zabbix Agent 2`, and `SERVER` may when the user lists multiple servers), the install hangs indefinitely on every Windows host.

#### Root cause

`argv:` form quotes any element containing whitespace as a single token. So this argv element:

```yaml
- "INSTALLFOLDER={{ zabbix_agent_win_install_dir }}"
```

ends up on the command line as:

```
"INSTALLFOLDER=C:/Program Files/Zabbix Agent 2"
```

…with the quotes wrapping the whole `PROPERTY=VALUE` token. msiexec rejects this — it requires `PROPERTY="VALUE"` (quotes around the **value** only). Normally, rejected arguments cause msiexec to display its help dialog. Combined with `/qn` there's no UI session to render that dialog, but msiexec **doesn't exit either** — it sits forever in an unrecoverable parse-error state. Confirmed by running the same command interactively on the host: the help dialog appears instead of the install proceeding.

A misleading downstream symptom: the Windows Installer service (`msiserver`) self-terminates at 5-minute intervals because msiexec never actually submits a transaction to it, so it sees no work and idle-times-out. That looked like a service-lifecycle issue at first, but it's just a consequence of the parse failure.

#### Fix

Switch from `argv:` to `cmd:` (string) form so the command line can include the canonical msiexec property syntax `PROPERTY="value"`. Also normalize forward slashes in `zabbix_agent_win_install_dir` to backslashes — without quotes, msiexec would interpret an unquoted `/Program` as a switch; with quotes it's tolerated, but matching Windows Installer conventions is cleaner.

Quoting all three potentially-spacy values for robustness:

- `"{{ zabbix_agent_win_package }}"` (filenames could contain spaces if overridden)
- `SERVER="{{ zabbix_agent_server }}"` (multi-server configs commonly use `host1, host2` formatting)
- `INSTALLFOLDER="{{ zabbix_agent_win_install_dir | replace('/', '\\') }}"` (default has spaces and forward slashes)

### Bug 2 — Include paths revert to Linux defaults

After the msiexec fix landed and the install actually completed, the agent service still refused to start. The Windows event log showed:

```
ERROR: Cannot read configuration: cannot include
"C:\Program Files\Zabbix Agent 2\etc\zabbix\zabbix_agent2.d\*.conf":
The system cannot find the path specified.
```

The conf had Linux-style Include paths even though `vars/Windows.yml` is loaded correctly (`LogFile` resolved to the proper Windows path).

#### Root cause

[`vars/Windows.yml:4`](https://github.com/ansible-collections/community.zabbix/blob/main/roles/zabbix_agent/vars/Windows.yml#L4) references `zabbix_agent_win_install_dir_conf` bare:

```yaml
_zabbix_agent_include_dirs:
  - "{{ zabbix_agent_win_install_dir_conf }}\\..."
```

That variable is the **deprecated** name (per `tasks/deprecation_checks.yml`) and is undefined by design unless the user opted into the legacy spelling. When `_zabbix_agent_include_dirs` is lazily evaluated, the inner `{{ zabbix_agent_win_install_dir_conf }}` is undefined, which makes the whole list reduce to undefined. Then the role default

```yaml
zabbix_agent_include_dirs: "{{ _zabbix_agent_include_dirs | default(_includes) }}"
```

falls through to `_includes` (the Linux paths from `vars/agent2_vars.yml`), and the conf gets `Include=/etc/zabbix/zabbix_agent2.d/*.conf`.

The line directly below in the same file (`_zabbix_agent_conf_dir`) handles the deprecation correctly with `default(zabbix_agent_win_install_dir)` — it was just missed on `_zabbix_agent_include_dirs`. Bisect points to commit e246ff4 (2026-04-10, "roles/agent/defaults: zabbix_agent_conf_dir") which introduced the deprecation but didn't propagate the fallback to all references.

This is the same symptom as #1378 (closed 2024-08-23) and #1580 (closed 2025-07-15), regressed by the deprecation refactor.

#### Fix

Add `| default(zabbix_agent_win_install_dir)` to `_zabbix_agent_include_dirs`, matching the pattern already in use for `_zabbix_agent_conf_dir` on the next line.

### Testing

- Reproduced both bugs on Windows Server 2022 with stock 4.2.0.
- Verified the `msiexec` command line generated by the patched task succeeds when run by hand on the same host.
- Verified the patched playbook completes the install end-to-end via `ansible-playbook ... -v` for both:
  - the in-place upgrade path (existing 6.0.x agent → newer version)
  - the fresh install path (manually uninstalled the existing agent first)
- Verified `zabbix_agent2.conf` after the run contains `Include=C:\Program Files\Zabbix Agent 2\zabbix_agent2.d/*.conf` (Windows path) and the service starts cleanly.

Changelog fragment included covering both bugs.
