### PR TITLE
Added options to allow for custom content in zabbix.conf.php

### DIFF
--- a/changelogs/fragments/1740-web-custom-zabbix-conf-php.yaml
+++ b/changelogs/fragments/1740-web-custom-zabbix-conf-php.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_web - add `zabbix_web_custom_zabbix_conf_php` variable to allow for the addition of custom raw PHP config in zabbix.conf.php

--- a/docs/ZABBIX_WEB_ROLE.md
+++ b/docs/ZABBIX_WEB_ROLE.md
@@ -111,6 +111,7 @@ The following is an overview of all available configuration defaults for this ro
 * `zabbix_saml_idp_crt`: (Optional) The path to the certificate of the Identity Provider used for SAML authentication
 * `zabbix_saml_sp_crt`: (Optional) The path to the public certificate of Zabbix as Service Provider
 * `zabbix_saml_sp_key`: (Optional) The path to the private certificate of Zabbix as Service Provider
+* `zabbix_web_custom_zabbix_conf_php`: (Optional) Any custom php options appended to zabbix.conf.php
 
 #### Apache/Nginx Configuration
 

--- a/roles/zabbix_web/defaults/main.yml
+++ b/roles/zabbix_web/defaults/main.yml
@@ -46,7 +46,7 @@ zabbix_web_php_fpm_max_childs: 50
 zabbix_web_php_fpm_start_servers: 5
 zabbix_web_php_fpm_min_spare_servers: 5
 zabbix_web_php_fpm_max_spare_servers: 35
-
+zabbix_web_custom_zabbix_conf_php: ""
 
 # Database
 zabbix_server_database: pgsql

--- a/roles/zabbix_web/templates/zabbix.conf.php.j2
+++ b/roles/zabbix_web/templates/zabbix.conf.php.j2
@@ -65,7 +65,7 @@ $SSO['SP_KEY'] = '{{ zabbix_saml_sp_key }}';
 {% endif %}
 {% endif %}
 
-{% if zabbix_web_custom_zabbix_conf_php | default('') | length > 0 %}
+{% if zabbix_web_custom_zabbix_conf_php | length > 0 %}
 {{ zabbix_web_custom_zabbix_conf_php }}
 {% endif %}
 ?>

--- a/roles/zabbix_web/templates/zabbix.conf.php.j2
+++ b/roles/zabbix_web/templates/zabbix.conf.php.j2
@@ -64,4 +64,8 @@ $SSO['SP_KEY'] = '{{ zabbix_saml_sp_key }}';
 {{ (zabbix_server_tls_certificate_subject is defined and zabbix_server_tls_certificate_subject is not none) | ternary('', '// ') }}$ZBX_SERVER_TLS['CERTIFICATE_SUBJECT'] = '{{ zabbix_server_tls_certificate_subject | default('') }}';
 {% endif %}
 {% endif %}
+
+{% if zabbix_web_custom_zabbix_conf_php | default('') | length > 0 %}
+{{ zabbix_web_custom_zabbix_conf_php }}
+{% endif %}
 ?>


### PR DESCRIPTION
##### SUMMARY
Added option to allow for the addition of raw PHP config in zabbix.conf.php.
Usage example:
```yaml
zabbix_web_custom_zabbix_conf_php: |
  $SSO['SETTINGS'] = [
      'use_proxy_headers'  => true,
      'security' => [
          'requestedAuthnContext' => [
              'urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified',
          ],
      ]
  ];
```
Actually fixes #1563 because #1570 did not.

##### ISSUE TYPE
- Bugfix/Feature Pull Request

##### COMPONENT NAME
Web role

##### ADDITIONAL INFORMATION
There may be a need for very specific options that is not worth/possible to add using mapped variables directly. I.e. in the case of SSO.
