### PR TITLE
fix(zabbix-agent): zabbix-agent removal fails when the service status is "not-found"

### DIFF
--- a/changelogs/fragments/1742-fix-zabbix-agent-not-found-service-deactivation.yaml
+++ b/changelogs/fragments/1742-fix-zabbix-agent-not-found-service-deactivation.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_agent - fix `zabbix-agent.service` deactivation task when the service has a `not-found` systemd status (https://github.com/ansible-collections/community.zabbix/issues/1742).

--- a/roles/zabbix_agent/tasks/remove.yml
+++ b/roles/zabbix_agent/tasks/remove.yml
@@ -9,8 +9,10 @@
     enabled: false
   become: true
   when: |
-    ansible_facts.services["zabbix-agent.service"] is defined or
-    ansible_facts.services["zabbix-agent"] is defined
+    (ansible_facts.services["zabbix-agent.service"] is defined and
+    ansible_facts.services["zabbix-agent.service"].status != "not-found") or
+    (ansible_facts.services["zabbix-agent"] is defined and
+    ansible_facts.services["zabbix-agent"].status != "not-found")
 
 - name: "Remove | Package removal"
   ansible.builtin.package:


### PR DESCRIPTION
`ansible.builtin.service_facts` is listing systemd services loaded "in memory" with something like: `systemctl list-units --all`. This lists every "known" services with a corresponding "status", cf.
https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#list-units%20PATTERN%E2%80%A6 The `not-found` status is affected to services being referenced by other services unit files, without existing "for real" in the system. For example, a service `installed.service` coming from an installed package, stating:
```
[Unit]
[...]
Before=not-installed.service
```
If `not-installed.service` does not exist in the system, this will result in the following statuses:
* `installed.service`    : "loaded"
* `not-installed.service`: "not-found"

The zabbix-agent "remove" feature is meant to remove zabbix-agent when installing zabbix-agent2. Before package removal, it tries to disable `zabbix-agent.service`.

Before this commit, this task failed when the `zabbix-agent.service` has a `not-found` systemd status.

This commit only performs the deactivation if the `zabbix-agent.service` is present in the services list AND that it has a status different from "not-found".

Fix https://github.com/ansible-collections/community.zabbix/issues/1742

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

Zabbix-agent

##### ADDITIONAL INFORMATION

Fix https://github.com/ansible-collections/community.zabbix/issues/1742
Cf. https://github.com/ansible-collections/community.zabbix/issues/1742
