### PR TITLE
chore: update dependency community.mysql to v4 and migrate to ansible.mysql

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -73,10 +73,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -156,10 +156,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -244,10 +244,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -76,7 +76,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -159,7 +159,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -247,7 +247,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/.github/workflows/build_collection.yml
+++ b/.github/workflows/build_collection.yml
@@ -35,10 +35,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/.github/workflows/build_collection.yml
+++ b/.github/workflows/build_collection.yml
@@ -38,7 +38,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/.github/workflows/javagateway.yml
+++ b/.github/workflows/javagateway.yml
@@ -81,7 +81,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -165,7 +165,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/.github/workflows/javagateway.yml
+++ b/.github/workflows/javagateway.yml
@@ -78,10 +78,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -162,10 +162,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -85,7 +85,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -160,7 +160,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -260,7 +260,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -82,10 +82,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -157,10 +157,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -257,10 +257,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -90,10 +90,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -178,10 +178,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -93,7 +93,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -181,7 +181,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -96,7 +96,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -194,7 +194,7 @@ jobs:
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -93,10 +93,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 
@@ -191,10 +191,10 @@ jobs:
         run: |
           yq -yi '
             .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.mysql" = "4.2.1" |
             .dependencies."ansible.netcommon" = "7.2.0" |
             .dependencies."ansible.posix" = "2.0.0" |
             .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "4.2.1" |
             .dependencies."community.postgresql" = "3.12.0"
           ' galaxy.yml
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Additional collections may be required when running the various roles.
 
 * `ansible.posix`:  Required if using SELinux portion of any roles
 * `ansible.general`:  Required if using SELinux portion of any roles
+* `ansible.mysql`:  Required for the proxy or server roles if using MySQL
 * `ansible.netcommon`:  Required when using the agent role
-* `community.mysql`:  Required for the proxy or server roles if using MySQL
 * `community.postgresql`:  Required for the proxy or server roles if using PostgreSQL
 * `community.windows`:  Required for the agent role if installing on Windows
 

--- a/changelogs/fragments/1747-migrate-community-mysql-collection.yaml
+++ b/changelogs/fragments/1747-migrate-community-mysql-collection.yaml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Migrate and update `community.mysql` deprecated collection to `ansible.mysql`

--- a/docs/ZABBIX_PROXY_ROLE.md
+++ b/docs/ZABBIX_PROXY_ROLE.md
@@ -59,10 +59,10 @@ ansible-galaxy collection install ansible.netcommon
 
 ### MySQL
 
-When you are a MySQL user and using Ansible 2.10 or newer, then there is a dependency on the collection named `community.mysql`. This collections are needed as the `mysql_` modules are now part of collections and not standard in Ansible anymmore. Installing the collection:
+When you are a MySQL user and using Ansible 2.10 or newer, then there is a dependency on the collection named `ansible.mysql`. This collections are needed as the `mysql_` modules are now part of collections and not standard in Ansible anymmore. Installing the collection:
 
 ```sh
-ansible-galaxy collection install community.mysql
+ansible-galaxy collection install ansible.mysql
 ```
 
 ### PostgreSQL

--- a/docs/ZABBIX_SERVER_ROLE.md
+++ b/docs/ZABBIX_SERVER_ROLE.md
@@ -57,10 +57,10 @@ ansible-galaxy collection install ansible.posix
 
 ### MySQL
 
-When you are a MySQL user and using Ansible 2.10 or newer, then there is a dependency on the collection named `community.mysql`. This collections are needed as the `mysql_` modules are now part of collections and not standard in Ansible anymore. Installing the collection:
+When you are a MySQL user and using Ansible 2.10 or newer, then there is a dependency on the collection named `ansible.mysql`. This collections are needed as the `mysql_` modules are now part of collections and not standard in Ansible anymore. Installing the collection:
 
 ```sh
-ansible-galaxy collection install community.mysql
+ansible-galaxy collection install ansible.mysql
 ```
 
 ### PostgreSQL

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,9 +20,9 @@ homepage: https://github.com/ansible-collections/community.zabbix
 issues: https://github.com/ansible-collections/community.zabbix/issues
 dependencies:
   ansible.windows: ">=2.8.0"
+  ansible.mysql: ">=4.2.1"
   ansible.netcommon: ">=3.1.1"
   ansible.posix: "*"
   community.general: "*"
-  community.mysql: ">=4.2.1"
   community.postgresql: "*"
   community.windows: "*"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -23,6 +23,6 @@ dependencies:
   ansible.netcommon: ">=3.1.1"
   ansible.posix: "*"
   community.general: "*"
-  community.mysql: ">=3.10.0"
+  community.mysql: ">=4.2.1"
   community.postgresql: "*"
   community.windows: "*"

--- a/roles/zabbix_proxy/tasks/initialize-mysql.yml
+++ b/roles/zabbix_proxy/tasks/initialize-mysql.yml
@@ -41,7 +41,7 @@
     - skip_ansible_lint
   block:
     - name: "MySQL | Register active MySQL authentication plugins"
-      community.mysql.mysql_query:
+      ansible.mysql.mysql_query:
         login_user: "{{ zabbix_proxy_mysql_login_user | default(omit) }}"
         login_password: "{{ zabbix_proxy_mysql_login_password | default(omit) }}"
         login_host: "{{ zabbix_proxy_mysql_login_host | default(omit) }}"
@@ -78,7 +78,7 @@
           - zabbix_proxy_mysql_auth_salt | length == 20
 
     - name: "MySQL | Create database"
-      community.mysql.mysql_db:
+      ansible.mysql.mysql_db:
         login_user: "{{ zabbix_proxy_mysql_login_user | default(omit) }}"
         login_password: "{{ zabbix_proxy_mysql_login_password | default(omit) }}"
         login_host: "{{ zabbix_proxy_mysql_login_host | default(omit) }}"
@@ -91,7 +91,7 @@
       register: zabbix_database_created
 
     - name: "MySQL | Create database user"
-      community.mysql.mysql_user:
+      ansible.mysql.mysql_user:
         login_user: "{{ zabbix_proxy_mysql_login_user | default(omit) }}"
         login_password: "{{ zabbix_proxy_mysql_login_password | default(omit) }}"
         login_host: "{{ zabbix_proxy_mysql_login_host | default(omit) }}"
@@ -117,7 +117,7 @@
     - database
   block:
     - name: "MySQL | Get current database version"
-      community.mysql.mysql_query:
+      ansible.mysql.mysql_query:
         login_user: "{{ zabbix_proxy_dbuser }}"
         login_password: "{{ zabbix_proxy_dbpassword }}"
         login_host: "{{ zabbix_proxy_dbhost }}"
@@ -129,7 +129,7 @@
       delegate_to: "{{ zabbix_proxy_real_dbhost | default(zabbix_proxy_dbhost_run_install | ternary(delegated_dbhost, inventory_hostname)) }}"
       block:
         - name: "MySQL | Get current value for variables"
-          community.mysql.mysql_variables:
+          ansible.mysql.mysql_variables:
             variable: "{{ name }}"
             login_user: "{{ zabbix_proxy_mysql_login_user | default(omit) }}"
             login_password: "{{ zabbix_proxy_mysql_login_password | default(omit) }}"
@@ -144,7 +144,7 @@
           register: _mysql_variable_defaults
 
         - name: "MySQL | Set variable overrides for schema import"
-          community.mysql.mysql_variables:
+          ansible.mysql.mysql_variables:
             variable: "{{ item.name }}"
             value: "{{ _mysql_schema_import_overrides[item.name] }}"
             login_user: "{{ zabbix_proxy_mysql_login_user | default(omit) }}"
@@ -162,7 +162,7 @@
               log_bin_trust_function_creators: "ON"
 
     - name: "MySQL | Import schema"
-      community.mysql.mysql_db:
+      ansible.mysql.mysql_db:
         login_user: "{{ zabbix_proxy_dbuser }}"
         login_password: "{{ zabbix_proxy_dbpassword }}"
         login_host: "{{ zabbix_proxy_dbhost }}"
@@ -176,7 +176,7 @@
   always:
     - name: "MySQL | Revert variable overrides for schema import"
       delegate_to: "{{ zabbix_proxy_real_dbhost | default(zabbix_proxy_dbhost_run_install | ternary(delegated_dbhost, inventory_hostname)) }}"
-      community.mysql.mysql_variables:
+      ansible.mysql.mysql_variables:
         variable: "{{ item.name }}"
         value: "{{ item.msg }}"
         login_user: "{{ zabbix_proxy_mysql_login_user | default(omit) }}"

--- a/roles/zabbix_server/tasks/initialize-mysql.yml
+++ b/roles/zabbix_server/tasks/initialize-mysql.yml
@@ -38,7 +38,7 @@
     - database
   block:
     - name: "MySQL | Register active MySQL authentication plugins"
-      community.mysql.mysql_query:
+      ansible.mysql.mysql_query:
         login_user: "{{ zabbix_server_mysql_login_user | default(omit) }}"
         login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
         login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
@@ -75,7 +75,7 @@
           - zabbix_server_mysql_auth_salt | length == 20
 
     - name: "MySQL | Create database"
-      community.mysql.mysql_db:
+      ansible.mysql.mysql_db:
         login_user: "{{ zabbix_server_mysql_login_user | default(omit) }}"
         login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
         login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
@@ -89,7 +89,7 @@
       register: zabbix_database_created
 
     - name: "MySQL | Create database user"
-      community.mysql.mysql_user:
+      ansible.mysql.mysql_user:
         login_user: "{{ zabbix_server_mysql_login_user | default(omit) }}"
         login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
         login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
@@ -120,7 +120,7 @@
     # Otherwise, the module will succees and we could
     # access the database version, for example 5000000 for Zabbix 5.0.
     - name: "MySQL | Get current database version"
-      community.mysql.mysql_query:
+      ansible.mysql.mysql_query:
         login_user: "{{ zabbix_server_dbuser }}"
         login_password: "{{ zabbix_server_dbpassword }}"
         login_host: "{{ zabbix_server_dbhost }}"
@@ -134,7 +134,7 @@
       delegate_to: "{{ zabbix_server_real_dbhost | default(zabbix_server_dbhost_run_install | ternary(delegated_dbhost, inventory_hostname), true) }}"
       block:
         - name: "MySQL | Get current value for variables"
-          community.mysql.mysql_variables:
+          ansible.mysql.mysql_variables:
             variable: "{{ name }}"
             login_user: "{{ zabbix_server_mysql_login_user | default(omit) }}"
             login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
@@ -150,7 +150,7 @@
           register: _mysql_variable_defaults
 
         - name: "MySQL | Set variable overrides for schema import"
-          community.mysql.mysql_variables:
+          ansible.mysql.mysql_variables:
             variable: "{{ item.name }}"
             value: "{{ _mysql_schema_import_overrides[item.name] }}"
             login_user: "{{ zabbix_server_mysql_login_user | default(omit) }}"
@@ -170,7 +170,7 @@
 
         - name: "MySQL | Disable InnoDB Strict Mode"
           when: ansible_facts['distribution_release'] == "buster"
-          community.mysql.mysql_variables:
+          ansible.mysql.mysql_variables:
             variable: innodb_strict_mode
             value: 0
             login_user: "{{ zabbix_server_mysql_login_user | default(omit) }}"
@@ -181,7 +181,7 @@
             check_hostname: "{{ zabbix_server_dbtlsconnect is defined and zabbix_server_dbtlsconnect != '' }}"
 
     - name: "MySQL | Import schema"
-      community.mysql.mysql_db:
+      ansible.mysql.mysql_db:
         login_user: "{{ zabbix_server_dbuser }}"
         login_password: "{{ zabbix_server_dbpassword }}"
         login_host: "{{ zabbix_server_dbhost }}"
@@ -199,7 +199,7 @@
   always:
     - name: "MySQL | Revert variable overrides for schema import"
       delegate_to: "{{ zabbix_server_real_dbhost | default(zabbix_server_dbhost_run_install | ternary(delegated_dbhost, inventory_hostname), true) }}"
-      community.mysql.mysql_variables:
+      ansible.mysql.mysql_variables:
         variable: "{{ item.name }}"
         value: "{{ item.msg }}"
         login_user: "{{ zabbix_server_mysql_login_user | default(omit) }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `community.mysql` collection has been deprecated since v5 release on 2026-05-06, cf.
https://github.com/ansible-collections/community.mysql/commit/eed2ec63ec12a8ec03682183927e9d9e622cac9f

Users are encouraged to migrate to the `ansible.mysql` collection (same codebase, new name), for which only v4+ versions are currently supported, cf. https://github.com/ansible-collections/ansible.mysql/blob/9b75741e24cd8020c48061fcc47d26999d627eed/README.md#releases-support-timeline

> We maintain each major release (1.x.y, 2.x.y, ...) for two years after the next major version is released.
> Here is the table for the support timeline:
> 1.x.y: released 2020-08-17, EOL
> 2.x.y: released 2021-04-15, EOL
> 3.x.y: released 2021-12-01, EOL
> 4.x.y: released 2025-09-15, EOL 2028-05-05
> 5.x.y: released 2026-05-05, current

This commit updates `community.mysql` from v3.13.x to v4.2.1 in order to perform the migration to `ansible.mysql` right after.

Release note:
https://github.com/ansible-collections/community.mysql/blob/main/CHANGELOG.rst#v4-2-1 Python2 support is dropped in v4.0.0
Few bugfixes and minor changes

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Chore Pull Request