### PR TITLE
feat: Add Ubuntu 26 (Resolute) support

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -32,6 +32,7 @@ jobs:
         container:
           - image: rockylinux10
           - image: rockylinux9
+          - image: ubuntu2604
           - image: ubuntu2404
           - image: ubuntu2204
           - image: debian13
@@ -52,6 +53,12 @@ jobs:
           - container:
               image: rockylinux10
             version: v72
+          - container:
+              image: ubuntu2604
+            version: v72
+          - container:
+              image: ubuntu2604
+            version: v60
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -115,6 +122,7 @@ jobs:
         container:
           - image: rockylinux10
           - image: rockylinux9
+          - image: ubuntu2604
           - image: ubuntu2404
           - image: ubuntu2204
           - image: debian13
@@ -135,6 +143,12 @@ jobs:
           - container:
               image: rockylinux10
             version: v72
+          - container:
+              image: ubuntu2604
+            version: v72
+          - container:
+              image: ubuntu2604
+            version: v60
     steps:
       - name: Check out code
         uses: actions/checkout@v6

--- a/changelogs/fragments/1748-ubuntu-26-support.yaml
+++ b/changelogs/fragments/1748-ubuntu-26-support.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zabbix_agent - add support for Ubuntu 26 (Resolute), which only ships Zabbix 7.0, 7.4 and 8.0 repositories.
+  - zabbix_repo - Zabbix 8.0 moved the Debian/Ubuntu repository path from ``stable/`` to ``release/``; ``zabbix_repo_deb_url`` now selects the correct path based on ``zabbix_repo_version``.

--- a/roles/zabbix_agent/vars/main.yml
+++ b/roles/zabbix_agent/vars/main.yml
@@ -52,6 +52,7 @@ _zabbix_agent_valid_versions:
   Ubuntu-26:
     - "8.0"
     - "7.4"
+    - "7.0"
   Ubuntu-24:
     - "7.4"
     - "7.2"

--- a/roles/zabbix_agent/vars/main.yml
+++ b/roles/zabbix_agent/vars/main.yml
@@ -49,6 +49,9 @@ _zabbix_agent_valid_versions:
     - "7.2"
     - "7.0"
     - "6.0"
+  Ubuntu-26:
+    - "8.0"
+    - "7.4"
   Ubuntu-24:
     - "7.4"
     - "7.2"

--- a/roles/zabbix_repo/defaults/main.yml
+++ b/roles/zabbix_repo/defaults/main.yml
@@ -4,7 +4,7 @@ zabbix_repo_version: "7.4"
 zabbix_repo_yum_gpgcheck: 1
 zabbix_repo_yum_schema: https
 zabbix_repo_deb_schema: https
-zabbix_repo_deb_url: "{{ zabbix_repo_version is version('8.0', '>=') | ternary(_80_plus_deb_repo, zabbix_repo_version is version('7.0', '>') | ternary(_post_72_deb_repo, _pre_72_deb_repo)) }}"
+zabbix_repo_deb_url: "{{ zabbix_repo_version is version('7.2', '>=') | ternary(_zabbix_repo_deb_repo, _pre_72_deb_repo) }}"
 zabbix_repo_deb_arch: "{{ _zabbix_repo_deb_arch_map[ansible_facts['architecture']] }}"
 zabbix_repo_deb_component: main
 zabbix_repo_yum:

--- a/roles/zabbix_repo/defaults/main.yml
+++ b/roles/zabbix_repo/defaults/main.yml
@@ -4,7 +4,7 @@ zabbix_repo_version: "7.4"
 zabbix_repo_yum_gpgcheck: 1
 zabbix_repo_yum_schema: https
 zabbix_repo_deb_schema: https
-zabbix_repo_deb_url: "{{ zabbix_repo_version is version('7.0', '>') | ternary(_post_72_deb_repo, _pre_72_deb_repo) }}"
+zabbix_repo_deb_url: "{{ zabbix_repo_version is version('8.0', '>=') | ternary(_80_plus_deb_repo, zabbix_repo_version is version('7.0', '>') | ternary(_post_72_deb_repo, _pre_72_deb_repo)) }}"
 zabbix_repo_deb_arch: "{{ _zabbix_repo_deb_arch_map[ansible_facts['architecture']] }}"
 zabbix_repo_deb_component: main
 zabbix_repo_yum:

--- a/roles/zabbix_repo/vars/main.yml
+++ b/roles/zabbix_repo/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 _pre_72_deb_repo: "{{ zabbix_repo_deb_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
 _post_72_deb_repo: "{{ zabbix_repo_deb_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/stable/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}"
+_80_plus_deb_repo: "{{ zabbix_repo_deb_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/release/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}"
 
 _pre_72_yum_repo: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/rhel/{{ ansible_facts['distribution_major_version'] }}/$basearch/"
 _post_72_yum_repo: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/stable/rhel/{{ ansible_facts['distribution_major_version'] }}/$basearch/"

--- a/roles/zabbix_repo/vars/main.yml
+++ b/roles/zabbix_repo/vars/main.yml
@@ -1,7 +1,6 @@
 ---
 _pre_72_deb_repo: "{{ zabbix_repo_deb_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}{% if ansible_facts['architecture'] == 'aarch64' and ansible_facts.lsb.id | default(ansible_facts['distribution']) in ['Debian', 'Ubuntu'] %}-arm64{% endif %}"
-_post_72_deb_repo: "{{ zabbix_repo_deb_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/stable/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}"
-_80_plus_deb_repo: "{{ zabbix_repo_deb_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/release/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}"
+_zabbix_repo_deb_repo: "{{ zabbix_repo_deb_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version }}/{{ zabbix_repo_version is version('8.0', '>=') | ternary('release', 'stable') }}/{{ ansible_facts.lsb.id | default(ansible_facts['distribution']) | lower }}"
 
 _pre_72_yum_repo: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/rhel/{{ ansible_facts['distribution_major_version'] }}/$basearch/"
 _post_72_yum_repo: "{{ zabbix_repo_yum_schema }}://repo.zabbix.com/zabbix/{{ zabbix_repo_version | regex_search('^[0-9]+.[0-9]+') }}/stable/rhel/{{ ansible_facts['distribution_major_version'] }}/$basearch/"


### PR DESCRIPTION
##### SUMMARY
Add support for Ubuntu 26 (Resolute Ringtail) to the zabbix_agent role.

Ubuntu 26 only supports Zabbix 8.0 and 7.4, as earlier versions are not available for this release.

Additionally, Zabbix 8.0 changed the Debian repository URL path from `stable/` to `release/`, so this PR adds a new repo URL variable `_80_plus_deb_repo` and updates `zabbix_repo_deb_url` to select the correct path based on the Zabbix version.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_agent, zabbix_repo

##### ADDITIONAL INFORMATION
- Ubuntu 26 codename: Resolute Ringtail
- Zabbix 8.0+ Debian repo URL uses `release/` path: `https://repo.zabbix.com/zabbix/<version>/release/<distro>`
- Previous versions (7.2–7.4) continue to use `stable/` path