### PR TITLE
New zabbix_agent2_plugins variable for additional plugin packages

### DIFF
--- a/changelogs/fragments/1091-zabbix-agent2-plugins.yaml
+++ b/changelogs/fragments/1091-zabbix-agent2-plugins.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_agent - added zabbix_agent2_plugins variable to install agent2 plugin packages (https://github.com/ansible-collections/community.zabbix/issues/1091).

--- a/changelogs/fragments/1091-zabbix-agent2-plugins.yaml
+++ b/changelogs/fragments/1091-zabbix-agent2-plugins.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - zabbix_agent - added zabbix_agent2_plugins variable to install agent2 plugin packages (https://github.com/ansible-collections/community.zabbix/issues/1091).
+  - zabbix_agent - added zabbix_agent_packages variable (list) to support installing agent2 plugin packages alongside the main agent package; deprecated zabbix_agent_package (https://github.com/ansible-collections/community.zabbix/issues/1091).

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -343,6 +343,7 @@ The following table lists all variables that are exposed to modify the configura
 | PersistentBufferPeriod | zabbix_agent_persistentbufferperiod | 1h | Agent 2 Only |
 | PidFile | zabbix_agent_pidfile | /var/run/zabbix/`{{ agent version specific }}`.pid | Linux Systems Only |
 | Plugin | zabbix_agent_plugins |  |  |
+| — | zabbix_agent2_plugins |  | List of agent2 plugin packages to install. Agent 2 Only. Undefined by default. |
 | PluginSocket | zabbix_agent_pluginsocket | /tmp/agent.plugin.sock | Agent 2 Only  |
 | PluginTimeout | zabbix_agent_plugintimeout | 3 | Agent 2 Only |
 | RefreshActiveChecks | zabbix_agent_refreshactivechecks |  |  |

--- a/docs/ZABBIX_AGENT_ROLE.md
+++ b/docs/ZABBIX_AGENT_ROLE.md
@@ -143,7 +143,19 @@ Selinux changes will be installed based on the status of selinux running on the 
 * `zabbix_agent_install_agent_only`: Only install the Zabbix Agent and not the `zabbix-sender` and `zabbix-get` packages. Default: `False`
 * `zabbix_agent_package_remove`: If `zabbix_agent2: True` and you want to remove the old installation. Default: `False`.
 * `zabbix_agent_package_state`: If Zabbix-agent needs to be `present` (default) or `latest`.
-* `zabbix_agent_package`: The name of the zabbix-agent package. Default: `zabbix-agent` if `zabbix_agent2` is false and `zabbix-agent2` if `true`.
+* `zabbix_agent_packages`: List of packages to install. Defaults to `[zabbix-agent]` or `[zabbix-agent2]` depending on `zabbix_agent2`. Use this to add agent2 plugin packages:
+  ```yaml
+  # Debian/Ubuntu
+  zabbix_agent_packages:
+    - zabbix-agent2
+    - zabbix-agent2-plugin-mongodb
+
+  # RedHat — include version suffix to stay consistent with the agent package
+  zabbix_agent_packages:
+    - "zabbix-agent2-{{ zabbix_agent_version }}.{{ zabbix_agent_version_minor }}"
+    - "zabbix-agent2-plugin-mongodb-{{ zabbix_agent_version }}.{{ zabbix_agent_version_minor }}"
+  ```
+* `zabbix_agent_package`: **Deprecated.** Use `zabbix_agent_packages` instead. The name of the zabbix-agent package. Default: `zabbix-agent` if `zabbix_agent2` is false and `zabbix-agent2` if `true`.
 * `zabbix_agent_sender_package`: The name of the zabbix-sender package. Default: `zabbix-sender`.
 * `zabbix_agent_userparameters`: Default: `[]`. List of userparameter names and scripts (if any). Detailed description is given in the [Deploying Userparameters](#deploying-userparameters) section.
   * `name`: Userparameter name (should be the same with userparameter template file name)
@@ -343,7 +355,6 @@ The following table lists all variables that are exposed to modify the configura
 | PersistentBufferPeriod | zabbix_agent_persistentbufferperiod | 1h | Agent 2 Only |
 | PidFile | zabbix_agent_pidfile | /var/run/zabbix/`{{ agent version specific }}`.pid | Linux Systems Only |
 | Plugin | zabbix_agent_plugins |  |  |
-| — | zabbix_agent2_plugins |  | List of agent2 plugin packages to install. Agent 2 Only. Undefined by default. |
 | PluginSocket | zabbix_agent_pluginsocket | /tmp/agent.plugin.sock | Agent 2 Only  |
 | PluginTimeout | zabbix_agent_plugintimeout | 3 | Agent 2 Only |
 | RefreshActiveChecks | zabbix_agent_refreshactivechecks |  |  |

--- a/molecule/zabbix_agent_tests/common/tests/agent2_common/test_agent2.py
+++ b/molecule/zabbix_agent_tests/common/tests/agent2_common/test_agent2.py
@@ -10,3 +10,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 def test_zabbix_agent2_dot_conf(host, zabbix_agent_file):
     assert zabbix_agent_file.contains("Plugins.SystemRun.LogRemoteCommands=0")
+
+
+def test_zabbix_agent2_plugin_package(host):
+    assert host.package("zabbix-agent2-plugin-mongodb").is_installed

--- a/molecule/zabbix_agent_tests/molecule/agent2/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/agent2/molecule.yml
@@ -17,3 +17,5 @@ provisioner:
             options:
               - parameter: LogRemoteCommands
                 value: 0
+        zabbix_agent2_plugins:
+          - zabbix-agent2-plugin-mongodb

--- a/molecule/zabbix_agent_tests/molecule/agent2/molecule.yml
+++ b/molecule/zabbix_agent_tests/molecule/agent2/molecule.yml
@@ -17,5 +17,6 @@ provisioner:
             options:
               - parameter: LogRemoteCommands
                 value: 0
-        zabbix_agent2_plugins:
+        zabbix_agent_packages:
+          - zabbix-agent2
           - zabbix-agent2-plugin-mongodb

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -8,10 +8,8 @@ zabbix_agent_releases_url: "https://services.zabbix.com/updates/v1"
 zabbix_agent_version_minor: "*"
 #zabbix_agent_version_long: 7.4.2
 zabbix_agent_package_remove: false
-# Deprecated: use zabbix_agent_packages (list) instead
-zabbix_agent_package: "{{ _zabbix_agent_package | default(zabbix_agent2 | ternary('zabbix-agent2', 'zabbix-agent')) }}"
 zabbix_agent_packages:
-  - "{{ zabbix_agent_package }}"
+  - "{{ zabbix_agent_package | default(_zabbix_agent_package | default(zabbix_agent2 | ternary('zabbix-agent2', 'zabbix-agent'))) }}"
 zabbix_agent_package_state: present
 zabbix_agent_get_package: "{{ _zabbix_agent_get_package | default('zabbix-get') }}"
 zabbix_agent_sender_package: "{{ _zabbix_agent_sender_package | default('zabbix-sender') }}"

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -10,7 +10,8 @@ zabbix_agent_version_minor: "*"
 zabbix_agent_package_remove: false
 # Deprecated: use zabbix_agent_packages (list) instead
 zabbix_agent_package: "{{ _zabbix_agent_package | default(zabbix_agent2 | ternary('zabbix-agent2', 'zabbix-agent')) }}"
-zabbix_agent_packages: "{{ [zabbix_agent_package] }}"
+zabbix_agent_packages:
+  - "{{ zabbix_agent_package }}"
 zabbix_agent_package_state: present
 zabbix_agent_get_package: "{{ _zabbix_agent_get_package | default('zabbix-get') }}"
 zabbix_agent_sender_package: "{{ _zabbix_agent_sender_package | default('zabbix-sender') }}"

--- a/roles/zabbix_agent/defaults/main.yml
+++ b/roles/zabbix_agent/defaults/main.yml
@@ -8,7 +8,9 @@ zabbix_agent_releases_url: "https://services.zabbix.com/updates/v1"
 zabbix_agent_version_minor: "*"
 #zabbix_agent_version_long: 7.4.2
 zabbix_agent_package_remove: false
+# Deprecated: use zabbix_agent_packages (list) instead
 zabbix_agent_package: "{{ _zabbix_agent_package | default(zabbix_agent2 | ternary('zabbix-agent2', 'zabbix-agent')) }}"
+zabbix_agent_packages: "{{ [zabbix_agent_package] }}"
 zabbix_agent_package_state: present
 zabbix_agent_get_package: "{{ _zabbix_agent_get_package | default('zabbix-get') }}"
 zabbix_agent_sender_package: "{{ _zabbix_agent_sender_package | default('zabbix-sender') }}"

--- a/roles/zabbix_agent/tasks/deprecation_checks.yml
+++ b/roles/zabbix_agent/tasks/deprecation_checks.yml
@@ -1,4 +1,23 @@
 ---
+- name: Deprecation zabbix_agent_package
+  block:
+    - name: Verify zabbix_agent_package goes undefined
+      assert:
+        that:
+          - zabbix_agent_package is not defined
+        fail_msg: Deprecated configuration option provided
+  rescue:
+    - name: Deprecation notice for zabbix_agent_package
+      debug:
+        msg: "{{ deprecation_notice.split('\n') }}"
+      vars:
+        deprecation_notice: |
+          zabbix_agent_package has been deprecated, use zabbix_agent_packages (list) instead.
+          Example:
+            zabbix_agent_packages:
+              - zabbix-agent2
+              - zabbix-agent2-plugin-mongodb
+
 - name: Deprecation zabbix_agent_win_install_dir_conf
   block:
     - name: Verify zabbix_agent_win_install_dir_conf goes undefined

--- a/roles/zabbix_agent/tasks/install-FreeBSD.yml
+++ b/roles/zabbix_agent/tasks/install-FreeBSD.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Installing zabbix-agent"
   community.general.pkgng:
-    name: "{{ zabbix_agent_package }}"
+    name: "{{ zabbix_agent_packages }}"
     state: "{{ zabbix_agent_package_state }}"
   environment:
     http_proxy: "{{ zabbix_http_proxy | default('') }}"

--- a/roles/zabbix_agent/tasks/install.yml
+++ b/roles/zabbix_agent/tasks/install.yml
@@ -15,7 +15,7 @@
   tags:
     - install
   loop:
-    - name: "{{ zabbix_agent_package }}"
+    - name: "{{ zabbix_agent_packages }}"
       state: "{{ zabbix_agent_package_state }}"
     - name: "{{ zabbix_agent_get_package }}"
       state: "{{ zabbix_agent_install_agent_only | ternary('absent', zabbix_agent_package_state) }}"

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -67,6 +67,14 @@
   loop_control:
     loop_var: _install_tasks_file
 
+- name: "Install zabbix_agent2_plugins"
+  ansible.builtin.package:
+    name: "{{ zabbix_agent2_plugins }}"
+    state: "{{ zabbix_agent_package_state }}"
+    update_cache: true
+    disablerepo: "{{ zabbix_agent_disable_repo | default(_zabbix_agent_disable_repo | default(omit)) }}"
+  when: zabbix_agent2_plugins is defined
+
 - name: "Configure Agent"
   when: ansible_facts['os_family'] not in ['Darwin']
   ansible.builtin.include_tasks: "{{ _configure_tasks_file }}"

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -52,7 +52,7 @@
     name: community.zabbix.zabbix_repo
   vars:
     zabbix_repo_version: "{{ zabbix_agent_version }}"
-    zabbix_repo_package: "{{ zabbix_agent_packages | flatten | first }} zabbix-get zabbix-sender"
+    zabbix_repo_package: "{{ zabbix_agent_packages | flatten | join(' ') }} zabbix-get zabbix-sender"
   when:
     - zabbix_manage_repo | default(true)
     - not (zabbix_agent_docker | bool)

--- a/roles/zabbix_agent/tasks/main.yml
+++ b/roles/zabbix_agent/tasks/main.yml
@@ -52,7 +52,7 @@
     name: community.zabbix.zabbix_repo
   vars:
     zabbix_repo_version: "{{ zabbix_agent_version }}"
-    zabbix_repo_package: "{{ zabbix_agent_package }} zabbix-get zabbix-sender"
+    zabbix_repo_package: "{{ zabbix_agent_packages | flatten | first }} zabbix-get zabbix-sender"
   when:
     - zabbix_manage_repo | default(true)
     - not (zabbix_agent_docker | bool)
@@ -66,14 +66,6 @@
     - "install.yml"
   loop_control:
     loop_var: _install_tasks_file
-
-- name: "Install zabbix_agent2_plugins"
-  ansible.builtin.package:
-    name: "{{ zabbix_agent2_plugins }}"
-    state: "{{ zabbix_agent_package_state }}"
-    update_cache: true
-    disablerepo: "{{ zabbix_agent_disable_repo | default(_zabbix_agent_disable_repo | default(omit)) }}"
-  when: zabbix_agent2_plugins is defined
 
 - name: "Configure Agent"
   when: ansible_facts['os_family'] not in ['Darwin']

--- a/roles/zabbix_agent/tasks/remove.yml
+++ b/roles/zabbix_agent/tasks/remove.yml
@@ -16,7 +16,7 @@
 
 - name: "Remove | Package removal"
   ansible.builtin.package:
-    name: "{{ zabbix_agent_packages | flatten | first | replace('agent2', 'agent') }}"
+    name: zabbix-agent
     state: absent
   become: true
 

--- a/roles/zabbix_agent/tasks/remove.yml
+++ b/roles/zabbix_agent/tasks/remove.yml
@@ -16,7 +16,7 @@
 
 - name: "Remove | Package removal"
   ansible.builtin.package:
-    name: "{{ zabbix_agent_package | replace('agent2', 'agent') }}"
+    name: "{{ zabbix_agent_packages | flatten | first | replace('agent2', 'agent') }}"
     state: absent
   become: true
 


### PR DESCRIPTION
##### SUMMARY
Adds support for installing Zabbix Agent 2 plugin packages by introducing `zabbix_agent_packages`
— a list variable that replaces the scalar `zabbix_agent_package`.

The existing `zabbix_agent_package` variable is deprecated but continues to work via a
double-nested default in `zabbix_agent_packages`, so existing playbooks require no changes.
A deprecation warning is emitted via `tasks/deprecation_checks.yml` when the old variable
is detected.

Fixes #1091

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_agent

##### ADDITIONAL INFORMATION
`zabbix_agent_packages` defaults to a single-item list matching the previous `zabbix_agent_package`
behavior, so there is no change for existing users.

To install agent2 plugin packages alongside the agent:

```yaml
# Debian/Ubuntu
zabbix_agent_packages:
  - zabbix-agent2
  - zabbix-agent2-plugin-mongodb

# RedHat — include version suffix to stay consistent with the agent package
zabbix_agent_packages:
  - "zabbix-agent2-{{ zabbix_agent_version }}.{{ zabbix_agent_version_minor }}"
  - "zabbix-agent2-plugin-mongodb-{{ zabbix_agent_version }}.{{ zabbix_agent_version_minor }}"

