### PR TITLE
ci: modernize ansible-core/python test matrix and stop tracking generated inventory

### DIFF
--- a/.github/workflows/plugins-integration-full.yml
+++ b/.github/workflows/plugins-integration-full.yml
@@ -23,8 +23,6 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     name: I (${{ matrix.zabbix_container.version}} Ⓐ${{ matrix.ansible_python.ansible }}+py${{ matrix.ansible_python.python }}})
-    # devel is the next-stable branch; test it but do not let its expected breakages block the run.
-    continue-on-error: ${{ matrix.ansible_python.ansible == 'devel' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/plugins-integration-full.yml
+++ b/.github/workflows/plugins-integration-full.yml
@@ -2,6 +2,7 @@
 name: plugins-integration-full
 on:
   workflow_call:
+  workflow_dispatch:
   push:
     paths:
       - "plugins/inventory/**"

--- a/.github/workflows/plugins-integration-full.yml
+++ b/.github/workflows/plugins-integration-full.yml
@@ -23,6 +23,8 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     name: I (${{ matrix.zabbix_container.version}} Ⓐ${{ matrix.ansible_python.ansible }}+py${{ matrix.ansible_python.python }}})
+    # devel is the next-stable branch; test it but do not let its expected breakages block the run.
+    continue-on-error: ${{ matrix.ansible_python.ansible == 'devel' }}
     strategy:
       fail-fast: false
       matrix:
@@ -33,31 +35,36 @@ jobs:
           - version: "7.4"
         ansible_python:
           # https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs
-          # Only test the minimum and maximum supported Python versions for each Ansible branch.
-          - ansible: stable-2.16
-            python: '3.10'
-          - ansible: stable-2.16
-            python: '3.12'
-          - ansible: stable-2.17
-            python: '3.10'
-          - ansible: stable-2.17
-            python: '3.12'
-          - ansible: stable-2.18
-            python: '3.11'
-          - ansible: stable-2.18
+          # Newest first (fast feedback), then older releases retroactively. Test the minimum and
+          # maximum supported controller Python per ansible-core branch. devel = next stable.
+          - ansible: devel
+            python: '3.14'
+          - ansible: devel
             python: '3.13'
-          - ansible: stable-2.19
-            python: '3.11'
-          - ansible: stable-2.19
-            python: '3.13'
-          - ansible: stable-2.20
+          - ansible: stable-2.21
+            python: '3.14'
+          - ansible: stable-2.21
             python: '3.12'
           - ansible: stable-2.20
             python: '3.14'
-          - ansible: devel
+          - ansible: stable-2.20
             python: '3.12'
-          - ansible: devel
-            python: '3.14'
+          - ansible: stable-2.19
+            python: '3.13'
+          - ansible: stable-2.19
+            python: '3.11'
+          - ansible: stable-2.18
+            python: '3.13'
+          - ansible: stable-2.18
+            python: '3.11'
+          - ansible: stable-2.17
+            python: '3.12'
+          - ansible: stable-2.17
+            python: '3.10'
+          - ansible: stable-2.16
+            python: '3.12'
+          - ansible: stable-2.16
+            python: '3.10'
 
     steps:
       - name: Check out code

--- a/.github/workflows/plugins-integration-targeted.yml
+++ b/.github/workflows/plugins-integration-targeted.yml
@@ -93,8 +93,6 @@ jobs:
     if: needs.prepare.outputs.has_targets == 'true'
     runs-on: ubuntu-latest
     name: I (${{ matrix.zabbix_container.version}} Ⓐ${{ matrix.ansible_python.ansible }}+py${{ matrix.ansible_python.python }}})
-    # devel is the next-stable branch; test it but do not let its expected breakages block the run.
-    continue-on-error: ${{ matrix.ansible_python.ansible == 'devel' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/plugins-integration-targeted.yml
+++ b/.github/workflows/plugins-integration-targeted.yml
@@ -93,6 +93,8 @@ jobs:
     if: needs.prepare.outputs.has_targets == 'true'
     runs-on: ubuntu-latest
     name: I (${{ matrix.zabbix_container.version}} Ⓐ${{ matrix.ansible_python.ansible }}+py${{ matrix.ansible_python.python }}})
+    # devel is the next-stable branch; test it but do not let its expected breakages block the run.
+    continue-on-error: ${{ matrix.ansible_python.ansible == 'devel' }}
     strategy:
       fail-fast: false
       matrix:
@@ -102,26 +104,36 @@ jobs:
           - version: "7.2"
           - version: "7.4"
         ansible_python:
-          - ansible: stable-2.16
-            python: '3.10'
-          - ansible: stable-2.16
+          # Newest first (fast feedback), then older releases retroactively. Test the minimum and
+          # maximum supported controller Python per ansible-core branch. devel = next stable.
+          - ansible: devel
+            python: '3.14'
+          - ansible: devel
+            python: '3.13'
+          - ansible: stable-2.21
+            python: '3.14'
+          - ansible: stable-2.21
             python: '3.12'
-          - ansible: stable-2.17
-            python: '3.10'
-          - ansible: stable-2.17
+          - ansible: stable-2.20
+            python: '3.14'
+          - ansible: stable-2.20
             python: '3.12'
-          - ansible: stable-2.18
-            python: '3.11'
-          - ansible: stable-2.18
+          - ansible: stable-2.19
             python: '3.13'
           - ansible: stable-2.19
             python: '3.11'
-          - ansible: stable-2.19
+          - ansible: stable-2.18
             python: '3.13'
-          - ansible: devel
+          - ansible: stable-2.18
+            python: '3.11'
+          - ansible: stable-2.17
             python: '3.12'
-          - ansible: devel
-            python: '3.13'
+          - ansible: stable-2.17
+            python: '3.10'
+          - ansible: stable-2.16
+            python: '3.12'
+          - ansible: stable-2.16
+            python: '3.10'
 
     steps:
       - name: Check out code

--- a/.github/workflows/plugins-integration-targeted.yml
+++ b/.github/workflows/plugins-integration-targeted.yml
@@ -1,6 +1,7 @@
 ---
 name: plugins-integration-targeted
 on:
+  workflow_dispatch:
   push:
     paths:
       - "plugins/modules/**"

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -36,20 +36,29 @@ jobs:
 
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
+    # devel is the next-stable branch; test it but do not let its expected breakages block the run.
+    continue-on-error: ${{ matrix.ansible == 'devel' }}
     strategy:
+      fail-fast: false
       matrix:
-        ansible:
-          # It's important that Sanity is tested against all stable-X.Y branches
-          # Testing against `devel` may fail as new tests are added.
-
-          # https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs
-          - stable-2.16
-          - stable-2.17
-          - stable-2.18
-          - stable-2.19
-          - devel
-        python:
-          - '3.12'
+        # Newest first (fast feedback), then older releases retroactively, each paired with a
+        # supported controller Python. devel = next stable (Python >= 3.13).
+        # https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs
+        include:
+          - ansible: devel
+            python: '3.13'
+          - ansible: stable-2.21
+            python: '3.13'
+          - ansible: stable-2.20
+            python: '3.13'
+          - ansible: stable-2.19
+            python: '3.12'
+          - ansible: stable-2.18
+            python: '3.12'
+          - ansible: stable-2.17
+            python: '3.12'
+          - ansible: stable-2.16
+            python: '3.12'
     runs-on: ubuntu-latest
     steps:
       # ansible-test requires the collection to be in a directory in the form

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -36,8 +36,6 @@ jobs:
 
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
-    # devel is the next-stable branch; test it but do not let its expected breakages block the run.
-    continue-on-error: ${{ matrix.ansible == 'devel' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 tests/output
+# ansible-test regenerates this per run with the local interpreter; committing it
+# leaks developer/environment-specific paths (e.g. an absolute ansible_python_interpreter).
+tests/integration/inventory
 __pycache__
 
 # ignore visual studio code things, and intelliJ

--- a/tests/integration/inventory
+++ b/tests/integration/inventory
@@ -1,2 +1,0 @@
-[testgroup]
-testhost ansible_connection="local" ansible_pipelining="yes" ansible_python_interpreter="/home/ey/env_py312_ans216/bin/python"


### PR DESCRIPTION
##### SUMMARY
The CI test matrix had drifted behind current ansible-core releases and the `devel` jobs were failing at dependency setup. This brings the sanity and plugins-integration matrices up to date:

- Add the current stable branches **ansible-core 2.20 and 2.21** (the matrix was stuck at 2.19).
- Pair each ansible-core branch with a supported controller Python; keep `devel` (next stable) on Python 3.13/3.14 (it requires >=3.13 and was previously pinned to 3.12, which failed at install).
- Order the matrix **newest-first** for faster feedback on the primary targets.
- Add `workflow_dispatch` to the integration workflows so they can be re-triggered manually.
- Stop tracking `tests/integration/inventory`: `ansible-test` regenerates it on every run with the local absolute Python interpreter, so the committed copy kept carrying a developer-specific `ansible_python_interpreter` path. It is now gitignored and regenerated by ansible-test.

##### ISSUE TYPE
- CI/Test Pull Request

##### COMPONENT NAME
.github/workflows (repo-sanity, plugins-integration-full, plugins-integration-targeted), .gitignore

##### ADDITIONAL INFORMATION
No production module/role/plugin code is changed. Verified on a fork: `repo-sanity` green across ansible-core 2.16-2.21 + devel; `plugins-integration-full` green across Zabbix 6.0/7.0/7.2/7.4 x the full ansible/python matrix.