### PR TITLE
fix: zabbix_trigger/triggerprototype idempotence - compare only managed fields

### DIFF
--- a/changelogs/fragments/zabbix_trigger-idempotence.yml
+++ b/changelogs/fragments/zabbix_trigger-idempotence.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_trigger, zabbix_triggerprototype - fix idempotence. The modules compared the whole trigger object before and after calling ``trigger.update``; when Zabbix auto-populates an unmanaged field (for example ``event_name``) during the update, that comparison reported a spurious ``changed=true``. They now compare only the fields the module manages.

--- a/plugins/modules/zabbix_trigger.py
+++ b/plugins/modules/zabbix_trigger.py
@@ -381,12 +381,16 @@ class Trigger(ZabbixBase):
             self._module.fail_json(msg="Failed to update trigger: %s" % e)
         return results
 
-    def check_trigger_changed(self, old_trigger):
+    def check_trigger_changed(self, old_trigger, keys):
         try:
             new_trigger = self._zapi.trigger.get({"triggerids": "%s" % old_trigger['triggerid'], "selectDependencies": "extend", "selectTags": "extend"})[0]
         except Exception as e:
             self._module.fail_json(msg="Failed to get trigger: %s" % e)
-        return old_trigger != new_trigger
+        # Compare only the fields this module manages. Zabbix auto-populates some unmanaged fields
+        # (e.g. event_name/url_name) during trigger.update, which flipped the old != new full-dict
+        # compare and broke idempotence. Both dicts come from trigger.get, so there is no int/str or
+        # expression-normalization skew.
+        return any(old_trigger.get(k) != new_trigger.get(k) for k in keys)
 
     def delete_trigger(self, trigger_id):
         if self._module.check_mode:
@@ -466,7 +470,7 @@ def main():
                     params['description'] = params['new_name']
                     params.pop("new_name")
                 results.append(trigger.update_trigger(params))
-                changed_trigger = trigger.check_trigger_changed(t)
+                changed_trigger = trigger.check_trigger_changed(t, params.keys())
                 if changed_trigger:
                     changed = True
             module.exit_json(changed=changed, result=results)

--- a/plugins/modules/zabbix_triggerprototype.py
+++ b/plugins/modules/zabbix_triggerprototype.py
@@ -393,12 +393,14 @@ class Triggerprototype(ZabbixBase):
             self._module.fail_json(msg="Failed to update triggerprototype: %s" % e)
         return results
 
-    def check_triggerprototype_changed(self, old_triggerprototype):
+    def check_triggerprototype_changed(self, old_triggerprototype, keys):
         try:
             new_triggerprototype = self._zapi.triggerprototype.get({'triggerids': '%s' % old_triggerprototype['triggerid']})[0]
         except Exception as e:
             self._module.fail_json(msg="Failed to get triggerprototype: %s" % e)
-        return old_triggerprototype != new_triggerprototype
+        # Compare only managed fields (see zabbix_trigger) so unmanaged fields Zabbix auto-populates
+        # during update don't break idempotence.
+        return any(old_triggerprototype.get(k) != new_triggerprototype.get(k) for k in keys)
 
     def delete_triggerprototype(self, trigger_id):
         if self._module.check_mode:
@@ -478,7 +480,7 @@ def main():
                     params['description'] = params['new_name']
                     params.pop("new_name")
                 results.append(triggerprototype.update_triggerprototype(params))
-                changed_trigger = triggerprototype.check_triggerprototype_changed(t)
+                changed_trigger = triggerprototype.check_triggerprototype_changed(t, params.keys())
                 if changed_trigger:
                     changed = True
             module.exit_json(changed=changed, result=results)


### PR DESCRIPTION
##### SUMMARY
`check_trigger_changed` compared the full old vs new trigger dict returned by `trigger.get`. Zabbix auto-populates some fields the module does not manage (for example `event_name`, `url_name`) during `trigger.update`, so the full-dict comparison always reported a change and the module was never idempotent. This compares only the keys the task manages instead. The same fix is applied to `zabbix_triggerprototype`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/zabbix_trigger.py, plugins/modules/zabbix_triggerprototype.py

##### ADDITIONAL INFORMATION
Both dicts being compared come from `trigger.get`, so narrowing the comparison to the managed keys introduces no int/str or expression-normalization skew; it only stops the unmanaged, server-populated fields from producing a spurious `changed`. The modules are exercised by the `plugins-integration` suite, and sanity is green (see the validation note in the comments).
