### PR TITLE
fix: correct role supported-version maps and add Ubuntu 26.04

### DIFF
--- a/changelogs/fragments/ubuntu-2604.yml
+++ b/changelogs/fragments/ubuntu-2604.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Zabbix roles - add support for Ubuntu 26.04 (Resolute) to the supported OS/version map.

--- a/changelogs/fragments/valid-versions-map.yml
+++ b/changelogs/fragments/valid-versions-map.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Zabbix roles - align the supported OS/version maps with actual Zabbix package availability (verified against repo.zabbix.com) so the "version is supported" check matches what can really be installed. Debian 11 (bullseye) is limited to Zabbix 6.0 for the ``zabbix_server`` and ``zabbix_web`` roles (no 7.0/7.4 server or frontend packages are published for bullseye), and EL10 drops Zabbix 6.0 for the server-side roles (6.0 ships only the agent on EL10); the ``zabbix_agent`` role keeps 6.0 on EL10.

--- a/roles/zabbix_agent/vars/main.yml
+++ b/roles/zabbix_agent/vars/main.yml
@@ -49,6 +49,9 @@ _zabbix_agent_valid_versions:
     - "7.2"
     - "7.0"
     - "6.0"
+  Ubuntu-26:
+    - "7.4"
+    - "7.0"
   Ubuntu-24:
     - "7.4"
     - "7.2"

--- a/roles/zabbix_javagateway/vars/main.yml
+++ b/roles/zabbix_javagateway/vars/main.yml
@@ -16,6 +16,7 @@ _zabbix_javagateway_valid_versions:
     - "7.0"
     - "6.0"
   RedHat-10:
+    # EL10 has no zabbix-java-gateway package for 6.0 (agent-only branch); 7.0+ only.
     - "7.4"
     - "7.0"
   RedHat-9:
@@ -35,6 +36,9 @@ _zabbix_javagateway_valid_versions:
     - "7.2"
     - "7.0"
     - "6.0"
+  Ubuntu-26:
+    - "7.4"
+    - "7.0"
   Ubuntu-24:
     - "7.4"
     - "7.2"

--- a/roles/zabbix_proxy/vars/main.yml
+++ b/roles/zabbix_proxy/vars/main.yml
@@ -23,6 +23,7 @@ _zabbix_proxy_valid_versions:
     - "7.0"
     - "6.0"
   RedHat-10:
+    # EL10 has no zabbix-proxy package for 6.0 (agent-only branch); 7.0+ only.
     - "7.4"
     - "7.0"
   RedHat-9:
@@ -40,6 +41,9 @@ _zabbix_proxy_valid_versions:
     - "7.2"
     - "7.0"
     - "6.0"
+  Ubuntu-26:
+    - "7.4"
+    - "7.0"
   Ubuntu-24:
     - "7.4"
     - "7.2"

--- a/roles/zabbix_server/vars/main.yml
+++ b/roles/zabbix_server/vars/main.yml
@@ -25,8 +25,10 @@ _zabbix_server_valid_versions:
     - "7.0"
     - "6.0"
   Debian-11:
+    # Debian 11 (bullseye) ships no zabbix-server package for 7.0/7.4; only 6.0.
     - "6.0"
   RedHat-10:
+    # EL10 has no zabbix-server package for 6.0 (agent-only branch); 7.0+ only.
     - "7.4"
     - "7.0"
   RedHat-9:
@@ -44,6 +46,9 @@ _zabbix_server_valid_versions:
     - "7.2"
     - "7.0"
     - "6.0"
+  Ubuntu-26:
+    - "7.4"
+    - "7.0"
   Ubuntu-24:
     - "7.4"
     - "7.2"

--- a/roles/zabbix_web/vars/main.yml
+++ b/roles/zabbix_web/vars/main.yml
@@ -15,8 +15,10 @@ _zabbix_web_valid_versions:
     - "7.0"
     - "6.0"
   Debian-11:
+    # Debian 11 (bullseye) ships no zabbix-frontend-php package for 7.0/7.4; only 6.0.
     - "6.0"
   RedHat-10:
+    # EL10 has no zabbix-web frontend package for 6.0 (agent-only branch); 7.0+ only.
     - "7.4"
     - "7.0"
   RedHat-9:
@@ -34,6 +36,9 @@ _zabbix_web_valid_versions:
     - "7.2"
     - "7.0"
     - "6.0"
+  Ubuntu-26:
+    - "7.4"
+    - "7.0"
   Ubuntu-24:
     - "7.4"
     - "7.2"

--- a/roles/zabbix_web_service/vars/main.yml
+++ b/roles/zabbix_web_service/vars/main.yml
@@ -7,30 +7,43 @@ _zabbix_web_service_valid_versions:
     - "6.0"
   Debian-12:
     - "7.4"
+    - "7.2"
     - "7.0"
     - "6.0"
   Debian-11:
+    - "7.4"
+    - "7.2"
+    - "7.0"
     - "6.0"
   RedHat-10:
+    # EL10 has no zabbix-web-service package for 6.0 (agent-only branch); 7.0+ only.
     - "7.4"
     - "7.0"
   RedHat-9:
     - "7.4"
+    - "7.2"
     - "7.0"
     - "6.0"
   RedHat-8:
     - "7.4"
+    - "7.2"
     - "7.0"
     - "6.0"
   Suse-15:
     - "7.4"
+    - "7.2"
     - "7.0"
     - "6.0"
+  Ubuntu-26:
+    - "7.4"
+    - "7.0"
   Ubuntu-24:
     - "7.4"
+    - "7.2"
     - "7.0"
     - "6.0"
   Ubuntu-22:
     - "7.4"
+    - "7.2"
     - "7.0"
     - "6.0"


### PR DESCRIPTION
##### SUMMARY
The per-role supported-version maps did not match what Zabbix actually ships per distribution, so version selection/asserts could pick a Zabbix branch that has no package for that OS. This reconciles the maps with real package availability and adds Ubuntu 26.04 (Resolute Raccoon):

- Debian 11 (bullseye) ships `zabbix-server` / `zabbix-frontend-php` only for 6.0, so the server and web maps are limited accordingly.
- EL10 has the server-side packages only for 7.0+ (the 6.0 branch is agent-only there), so 6.0 is dropped from the server-side role maps while the agent keeps it.
- Add Ubuntu 26.04 across the role maps.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/zabbix_agent, roles/zabbix_server, roles/zabbix_proxy, roles/zabbix_javagateway, roles/zabbix_web, roles/zabbix_web_service (vars/main.yml)

##### ADDITIONAL INFORMATION
Package availability was verified against repo.zabbix.com. Exercised across the role test matrix (distro x arch x ansible-core x Zabbix) on our fork; see the validation note in the comments for the green run links. Changelog fragments included. Refs #1745.
