### PR TITLE
ci: import Zabbix arm64 GPG key for fping on EL aarch64 in molecule prepare

### DIFF
--- a/molecule/zabbix_proxy/prepare.yml
+++ b/molecule/zabbix_proxy/prepare.yml
@@ -12,6 +12,16 @@
         dest: /usr/sbin/policy-rc.d
       when: ansible_facts['os_family'] == 'Debian'
 
+    # On EL aarch64, Zabbix signs its "non-supported" repo packages (e.g. fping, pulled in by
+    # zabbix-proxy) with a key that the zabbix_repo role does not install (the amd64 packages use
+    # a different key), so the dnf module fails GPG validation with "Public key ... is not
+    # installed". Pre-import that Zabbix key. Idempotent; RedHat only; unused where not needed.
+    - name: "Import Zabbix non-supported repo GPG key (EL aarch64 fping)"
+      ansible.builtin.rpm_key:
+        state: present
+        key: https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD
+      when: ansible_facts['os_family'] == 'RedHat'
+
     - name: "Installing packages"
       ansible.builtin.package:
         name: "{{ _packages | select | list }}"

--- a/molecule/zabbix_server/prepare.yml
+++ b/molecule/zabbix_server/prepare.yml
@@ -12,6 +12,16 @@
         dest: /usr/sbin/policy-rc.d
       when: ansible_facts['os_family'] == 'Debian'
 
+    # On EL aarch64, Zabbix signs its "non-supported" repo packages (e.g. fping, pulled in by
+    # zabbix-server) with a key that the zabbix_repo role does not install (the amd64 packages use
+    # a different key), so the dnf module fails GPG validation with "Public key ... is not
+    # installed". Pre-import that Zabbix key. Idempotent; RedHat only; unused where not needed.
+    - name: "Import Zabbix non-supported repo GPG key (EL aarch64 fping)"
+      ansible.builtin.rpm_key:
+        state: present
+        key: https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD
+      when: ansible_facts['os_family'] == 'RedHat'
+
     - name: "Installing sudo"
       ansible.builtin.package:
         name:


### PR DESCRIPTION
##### SUMMARY
On EL aarch64 the Zabbix "non-supported" repository signs packages such as `fping` (pulled in by `zabbix-server` / `zabbix-proxy`) with a different GPG key than the amd64 packages, and the `zabbix_repo` role does not install it. The dnf package step then fails GPG validation with "Public key ... is not installed". This pre-imports that key in the server/proxy molecule prepare so the aarch64 role tests can install their packages. Idempotent and RedHat-only.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
molecule/zabbix_server/prepare.yml, molecule/zabbix_proxy/prepare.yml

##### ADDITIONAL INFORMATION
Verified by installing the fping package under GPG check on an EL aarch64 container; the server/proxy role tests pass on arm64 on our fork (see the validation note in the comments). Test-only change (no user-facing role code), so no changelog fragment.
