### PR TITLE
ci: modernize and instrument the collection test suite

### DIFF
--- a/.github/actions/publish-test-results/action.yml
+++ b/.github/actions/publish-test-results/action.yml
@@ -1,0 +1,41 @@
+---
+# Publish JUnit test results: upload the XML as a build artifact AND render a
+# per-cell GitHub Check via dorny/test-reporter. Caller gates with `if: always()`.
+name: Publish test results
+description: Upload JUnit XML as an artifact and publish it as a GitHub Check.
+inputs:
+  junit-path:
+    description: Glob to the JUnit XML file(s), RELATIVE to working-directory (the repo root).
+    required: true
+  artifact-name:
+    description: Unique artifact name for this matrix cell (upload-artifact@v4 rejects duplicates).
+    required: true
+  check-name:
+    description: Title of the published GitHub Check for this cell.
+    required: true
+  working-directory:
+    description: "Relative path under $GITHUB_WORKSPACE where the repo was checked out (for dorny git resolution)."
+    required: false
+    default: "."
+runs:
+  using: composite
+  steps:
+    - name: Upload JUnit XML artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        # upload-artifact resolves relative to $GITHUB_WORKSPACE, so prefix the repo root.
+        path: ${{ inputs.working-directory }}/${{ inputs.junit-path }}
+        if-no-files-found: error
+        include-hidden-files: true
+        retention-days: 14
+    - name: Publish JUnit as a Check
+      uses: dorny/test-reporter@v2
+      with:
+        name: ${{ inputs.check-name }}
+        # dorny chdir's into working-directory, so path must be relative to it.
+        path: ${{ inputs.junit-path }}
+        reporter: java-junit
+        fail-on-error: false
+        fail-on-empty: false
+        working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/report-result/action.yml
+++ b/.github/actions/report-result/action.yml
@@ -1,0 +1,71 @@
+---
+# Reusable reporter: append a one-row result table to the job's GitHub Actions step summary.
+# Keeps CI results visible at a glance without copy-pasting summary code into every job.
+# Text only (PASS/FAIL) — no emoji, per project output rules.
+name: Report result
+description: Append a single result row to the GitHub Actions step summary for this job.
+inputs:
+  outcome:
+    description: The tested step's outcome (success/failure/cancelled).
+    required: true
+  scenario:
+    description: Scenario or test target name.
+    required: false
+    default: ""
+  container:
+    description: Container image / distro.
+    required: false
+    default: ""
+  zabbix:
+    description: Zabbix version.
+    required: false
+    default: ""
+  database:
+    description: Database or web-server dimension.
+    required: false
+    default: ""
+  arch:
+    description: CPU architecture.
+    required: false
+    default: "amd64"
+  ansible:
+    description: ansible-core branch/version.
+    required: false
+    default: ""
+  python:
+    description: Python version.
+    required: false
+    default: ""
+  result-file:
+    description: Optional path to append a machine-readable "cell|...|RESULT" line for the aggregator.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Append result row to step summary
+      shell: bash
+      env:
+        OUTCOME: ${{ inputs.outcome }}
+        SCENARIO: ${{ inputs.scenario }}
+        CONTAINER: ${{ inputs.container }}
+        ZABBIX: ${{ inputs.zabbix }}
+        DATABASE: ${{ inputs.database }}
+        ARCH: ${{ inputs.arch }}
+        ANSIBLE: ${{ inputs.ansible }}
+        PYTHON: ${{ inputs.python }}
+        RESULT_FILE: ${{ inputs.result-file }}
+      run: |
+        result="FAIL"
+        if [ "${OUTCOME}" = "success" ]; then result="PASS"; fi
+        {
+          echo "### Result";
+          echo "";
+          echo "| Scenario | Container | Zabbix | DB/Web | Arch | Ansible+Py | Result |";
+          echo "|---|---|---|---|---|---|---|";
+          echo "| ${SCENARIO} | ${CONTAINER} | ${ZABBIX} | ${DATABASE} | ${ARCH} | ${ANSIBLE} ${PYTHON} | ${result} |";
+        } >> "$GITHUB_STEP_SUMMARY"
+        if [ -n "${RESULT_FILE}" ]; then
+          mkdir -p "$(dirname "${RESULT_FILE}")"
+          echo "${SCENARIO}|${CONTAINER}|${ZABBIX}|${DATABASE}|${ARCH}|${ANSIBLE}|${PYTHON}|${result}" > "${RESULT_FILE}"
+        fi

--- a/.github/actions/upload-failure-logs/action.yml
+++ b/.github/actions/upload-failure-logs/action.yml
@@ -1,0 +1,24 @@
+---
+# Upload log files that survive `molecule destroy` / test teardown, so failures are
+# debuggable from the run page without shelling into a (now-destroyed) container.
+# Caller gates with `if: failure()`.
+name: Upload failure logs
+description: Upload detailed log files as an artifact for post-mortem debugging.
+inputs:
+  artifact-name:
+    description: Unique artifact name for this matrix cell.
+    required: true
+  paths:
+    description: Newline-separated list of paths/globs to upload.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Upload failure logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.paths }}
+        if-no-files-found: ignore
+        include-hidden-files: true
+        retention-days: 14

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -2,12 +2,15 @@
 name: "community.zabbix.zabbix_agent"
 on:
   workflow_call:
+  workflow_dispatch:
   push:
     paths:
       - "roles/zabbix_agent/**"
       - "molecule/zabbix_agent/**"
       - "molecule/requirements.txt"
       - ".github/workflows/agent.yml"
+      - ".github/workflows/role-test.yml"
+      - ".github/actions/**"
       - "roles/zabbix_repo/**"
   pull_request:
     paths:
@@ -15,264 +18,61 @@ on:
       - "molecule/zabbix_agent/**"
       - "molecule/requirements.txt"
       - ".github/workflows/agent.yml"
+      - ".github/workflows/role-test.yml"
+      - ".github/actions/**"
       - "roles/zabbix_repo/**"
 concurrency:
   group: agent-${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 jobs:
   build-collection:
     uses: ./.github/workflows/build_collection.yml
 
-  base:
+  molecule:
     needs: build-collection
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        container:
-          - image: rockylinux10
-          - image: rockylinux9
-          - image: ubuntu2404
-          - image: ubuntu2204
-          - image: debian13
-          - image: debian12
-          - image: debian11
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-        scenario_name:
-          - default
-          - agent2
-        exclude:
-          - container:
-              image: debian13
-            version: v72
-          - container:
-              image: rockylinux10
-            version: v72
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-          cache: pip
-          cache-dependency-path: molecule/requirements.txt
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
-        run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        working-directory: molecule/zabbix_agent_tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule -c common/molecule.yml test -s ${{ matrix.scenario_name }}
-
-  psk:
-    needs: build-collection
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        container:
-          - image: rockylinux10
-          - image: rockylinux9
-          - image: ubuntu2404
-          - image: ubuntu2204
-          - image: debian13
-          - image: debian12
-          - image: debian11
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-        scenario_name:
-          - autopsk
-          - agent2autopsk
-        exclude:
-          - container:
-              image: debian13
-            version: v72
-          - container:
-              image: rockylinux10
-            version: v72
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-          cache: pip
-          cache-dependency-path: molecule/requirements.txt
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
-        run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        working-directory: molecule/zabbix_agent_tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule -c common/molecule.yml test -s ${{ matrix.scenario_name }}
-
-  legacy:
-    needs: build-collection
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        container:
-          - image: rockylinux8
-            ansible_core: ansible-core<2.17
-          - image: opensuseleap15
-            ansible_core: ansible-core<2.17
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-        scenario_name:
+        scenario:
           - default
           - agent2
           - autopsk
           - agent2autopsk
+    uses: ./.github/workflows/role-test.yml
+    with:
+      role: agent
+      working_directory: molecule/zabbix_agent_tests
+      molecule_config: common/molecule.yml
+      scenario: ${{ matrix.scenario }}
+
+  ci:
+    name: CI (agent)
+    if: always()
+    needs: [build-collection, molecule]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ hashFiles('molecule/requirements.txt', 'molecule/zabbix_agent_tests/common/collections.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install specific version ansible-core
-        if: matrix.container.ansible_core != null
-        run: pip install "${{ matrix.container.ansible_core }}"
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
+      - name: Coverage scope
+        if: always()
+        shell: bash
         run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
+          {
+            echo "## Coverage scope";
+            echo "";
+            echo "Full role-test matrix under test:";
+            echo "";
+            echo "- Zabbix: 6.0, 7.0, 7.4 (7.2 dropped - EOL; 8.0 has no packages yet - integration-only)";
+            echo "- Distros: rockylinux 8/9/10, ubuntu 22.04/24.04/26.04, debian 11/12/13, opensuse leap 15";
+            echo "- Arch: amd64 + arm64 (except debian11 arm64 - no Zabbix arm64 packages)";
+            echo "- ansible-core: 2.16 (floor) + 2.21 (latest); controller Python 3.12";
+            echo "";
+            echo "All supported combinations run. Any failures below are the current fix-list (real, fully visible - not hidden).";
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Aggregate matrix result
+        uses: re-actors/alls-green@release/v1
         with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        working-directory: molecule/zabbix_agent_tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule -c common/molecule.yml test -s ${{ matrix.scenario_name }}
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/build_collection.yml
+++ b/.github/workflows/build_collection.yml
@@ -56,6 +56,11 @@ jobs:
             ${{ runner.os }}-molecule-galaxy-
 
 
-      - name: Install Collections and Roles 
+      - name: Install Collections and Roles
+        # Retry to survive transient Galaxy 5xx responses while downloading deps.
         run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
+          for i in 1 2 3; do
+            ansible-galaxy collection install -f -vvvv community-zabbix-*.tar.gz && exit 0
+            echo "galaxy install failed (attempt $i), retrying"; sleep 15
+          done
+          exit 1

--- a/.github/workflows/javagateway.yml
+++ b/.github/workflows/javagateway.yml
@@ -2,12 +2,15 @@
 name: "community.zabbix.zabbix_javagateway"
 on:
   workflow_call:
+  workflow_dispatch:
   push:
     paths:
       - "roles/zabbix_javagateway/**"
       - "molecule/zabbix_javagateway/**"
       - "molecule/requirements.txt"
       - ".github/workflows/javagateway.yml"
+      - ".github/workflows/role-test.yml"
+      - ".github/actions/**"
       - "roles/zabbix_repo/**"
   pull_request:
     paths:
@@ -15,181 +18,51 @@ on:
       - "molecule/zabbix_javagateway/**"
       - "molecule/requirements.txt"
       - ".github/workflows/javagateway.yml"
+      - ".github/workflows/role-test.yml"
+      - ".github/actions/**"
       - "roles/zabbix_repo/**"
 concurrency:
   group: gateway-${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 jobs:
   build-collection:
     uses: ./.github/workflows/build_collection.yml
 
-  base:
+  molecule:
     needs: build-collection
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        container:
-          - image: rockylinux10
-          - image: rockylinux9
-          - image: ubuntu2404
-          - image: ubuntu2204
-          - image: debian13
-          - image: debian12
-          - image: debian11
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-        collection_role:
-          - zabbix_javagateway
-        exclude:
-          - container:
-              image: debian13
-            version: v72
-          - container:
-              image: rockylinux10
-            version: v72
-          - container:
-              image: rockylinux10
-            version: v70
-          - container:
-              image: rockylinux10
-            version: v60
+    uses: ./.github/workflows/role-test.yml
+    with:
+      role: javagateway
+      scenario: zabbix_javagateway
+
+  ci:
+    name: CI (javagateway)
+    if: always()
+    needs: [build-collection, molecule]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-          cache: pip
-          cache-dependency-path: molecule/requirements.txt
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
+      - name: Coverage scope
+        if: always()
+        shell: bash
         run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
+          {
+            echo "## Coverage scope";
+            echo "";
+            echo "Full role-test matrix under test:";
+            echo "";
+            echo "- Zabbix: 6.0, 7.0, 7.4 (7.2 dropped - EOL; 8.0 has no packages yet - integration-only)";
+            echo "- Distros: rockylinux 8/9/10, ubuntu 22.04/24.04/26.04, debian 11/12/13, opensuse leap 15";
+            echo "- Arch: amd64 + arm64 (except debian11 arm64 - no Zabbix arm64 packages)";
+            echo "- ansible-core: 2.16 (floor) + 2.21 (latest); controller Python 3.12";
+            echo "";
+            echo "All supported combinations run. Any failures below are the current fix-list (real, fully visible - not hidden).";
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Aggregate matrix result
+        uses: re-actors/alls-green@release/v1
         with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule test -s ${{ matrix.collection_role }}
-
-  legacy:
-    needs: build-collection
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        container:
-          - image: rockylinux8
-            ansible_core: ansible-core<2.17
-          - image: opensuseleap15
-            ansible_core: ansible-core<2.17
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-        collection_role:
-          - zabbix_javagateway
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ hashFiles('molecule/requirements.txt', 'molecule/zabbix_agent_tests/common/collections.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install specific version ansible-core
-        if: matrix.container.ansible_core != null
-        run: pip install "${{ matrix.container.ansible_core }}"
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
-        run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule test -s ${{ matrix.collection_role }}
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/plugins-integration-full.yml
+++ b/.github/workflows/plugins-integration-full.yml
@@ -2,6 +2,7 @@
 name: plugins-integration-full
 on:
   workflow_call:
+  workflow_dispatch:
   push:
     paths:
       - "plugins/inventory/**"
@@ -16,48 +17,62 @@ on:
       - "plugins/module_utils/**"
       - ".github/workflows/plugins-integration*.yml"
       - "tests/integration/targets/setup_zabbix/**"
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 concurrency:
   group: pi-full-${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
 jobs:
   integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     name: I (${{ matrix.zabbix_container.version}} Ⓐ${{ matrix.ansible_python.ansible }}+py${{ matrix.ansible_python.python }}})
     strategy:
       fail-fast: false
       matrix:
         zabbix_container:
           - version: "6.0"
+            image_tag: "ubuntu-6.0-latest"
           - version: "7.0"
-          - version: "7.2"
+            image_tag: "ubuntu-7.0-latest"
           - version: "7.4"
+            image_tag: "ubuntu-7.4-latest"
+          - version: "8.0-trunk"
+            image_tag: "ubuntu-trunk"
         ansible_python:
           # https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs
-          # Only test the minimum and maximum supported Python versions for each Ansible branch.
-          - ansible: stable-2.16
-            python: '3.10'
-          - ansible: stable-2.16
-            python: '3.12'
-          - ansible: stable-2.17
-            python: '3.10'
-          - ansible: stable-2.17
-            python: '3.12'
-          - ansible: stable-2.18
-            python: '3.11'
-          - ansible: stable-2.18
+          # Newest first (fast feedback), then older releases retroactively. Test the minimum and
+          # maximum supported controller Python per ansible-core branch. devel = next stable.
+          - ansible: devel
+            python: '3.14'
+          - ansible: devel
             python: '3.13'
-          - ansible: stable-2.19
-            python: '3.11'
-          - ansible: stable-2.19
-            python: '3.13'
-          - ansible: stable-2.20
+          - ansible: stable-2.21
+            python: '3.14'
+          - ansible: stable-2.21
             python: '3.12'
           - ansible: stable-2.20
             python: '3.14'
-          - ansible: devel
+          - ansible: stable-2.20
             python: '3.12'
-          - ansible: devel
-            python: '3.14'
+          - ansible: stable-2.19
+            python: '3.13'
+          - ansible: stable-2.19
+            python: '3.11'
+          - ansible: stable-2.18
+            python: '3.13'
+          - ansible: stable-2.18
+            python: '3.11'
+          - ansible: stable-2.17
+            python: '3.12'
+          - ansible: stable-2.17
+            python: '3.10'
+          - ansible: stable-2.16
+            python: '3.12'
+          - ansible: stable-2.16
+            python: '3.10'
 
     steps:
       - name: Check out code
@@ -75,7 +90,7 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_python.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Install ansible.netcommon collection
-        run: ansible-galaxy collection install ansible.netcommon -p $GITHUB_WORKSPACE
+        run: ansible-galaxy collection install ansible.netcommon -p "$GITHUB_WORKSPACE"
         working-directory: ./ansible_collections/community/zabbix
 
       # For Zabbix integration tests we need to test against different versions of
@@ -86,12 +101,14 @@ jobs:
         with:
           compose-file: "./ansible_collections/community/zabbix/docker-compose.yml"
         env:
-          zabbix_version: ${{ matrix.zabbix_container.version }}
+          ZABBIX_SERVER_IMAGE_TAG: ${{ matrix.zabbix_container.image_tag }}
+          ZABBIX_WEB_IMAGE_TAG: ${{ matrix.zabbix_container.image_tag }}
 
       # Run the integration tests
       # As we need to connect to an existing docker container we can't use `--docker` here as the VMs would be on different
       # (non-routing) networks, so we run them locally and ensure any required dependencies are installed via `--requirements`
       - name: Run integration test
+        id: run
         run: ansible-test integration -v --color --continue-on-error --diff --python ${{ matrix.ansible_python.python }} --requirements --coverage
         working-directory: ./ansible_collections/community/zabbix
 
@@ -104,3 +121,56 @@ jobs:
       - uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: false
+
+      - name: Publish test results
+        if: always()
+        uses: ./ansible_collections/community/zabbix/.github/actions/publish-test-results
+        with:
+          junit-path: tests/output/junit/*.xml
+          artifact-name: junit-pi-full-${{ matrix.zabbix_container.version }}-${{ matrix.ansible_python.ansible }}-py${{ matrix.ansible_python.python }}
+          check-name: JUnit pi-full ${{ matrix.zabbix_container.version }} ${{ matrix.ansible_python.ansible }}+py${{ matrix.ansible_python.python }}
+          working-directory: ansible_collections/community/zabbix
+
+      - name: Upload failure logs
+        if: failure()
+        uses: ./ansible_collections/community/zabbix/.github/actions/upload-failure-logs
+        with:
+          artifact-name: logs-pi-full-${{ matrix.zabbix_container.version }}-${{ matrix.ansible_python.ansible }}-py${{ matrix.ansible_python.python }}
+          paths: |
+            ansible_collections/community/zabbix/tests/output/
+
+      - name: Report result
+        if: always()
+        uses: ./ansible_collections/community/zabbix/.github/actions/report-result
+        with:
+          outcome: ${{ steps.run.outcome }}
+          scenario: integration-full
+          zabbix: ${{ matrix.zabbix_container.version }}
+          ansible: ${{ matrix.ansible_python.ansible }}
+          python: py${{ matrix.ansible_python.python }}
+
+  ci:
+    name: CI (integration full)
+    if: always()
+    needs: [integration]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Coverage scope
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Coverage scope";
+            echo "";
+            echo "Integration (plugin/module) matrix under test:";
+            echo "";
+            echo "- Zabbix: 6.0, 7.0, 7.4, 8.0 (pre-release via ubuntu-trunk docker image)";
+            echo "- ansible-core: 2.16 through 2.21 plus devel (each with min+max supported controller Python, up to 3.14)";
+            echo "";
+            echo "All supported combinations run. Any failures below are the current fix-list (real, fully visible - not hidden).";
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Aggregate matrix result
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/plugins-integration-targeted.yml
+++ b/.github/workflows/plugins-integration-targeted.yml
@@ -1,6 +1,7 @@
 ---
 name: plugins-integration-targeted
 on:
+  workflow_dispatch:
   push:
     paths:
       - "plugins/modules/**"
@@ -11,6 +12,10 @@ on:
       - "plugins/modules/**"
       - "tests/integration/**"
       - "!tests/integration/targets/setup_zabbix/**"
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -92,36 +97,52 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.has_targets == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     name: I (${{ matrix.zabbix_container.version}} Ⓐ${{ matrix.ansible_python.ansible }}+py${{ matrix.ansible_python.python }}})
     strategy:
       fail-fast: false
       matrix:
         zabbix_container:
           - version: "6.0"
+            image_tag: "ubuntu-6.0-latest"
           - version: "7.0"
-          - version: "7.2"
+            image_tag: "ubuntu-7.0-latest"
           - version: "7.4"
+            image_tag: "ubuntu-7.4-latest"
+          - version: "8.0-trunk"
+            image_tag: "ubuntu-trunk"
         ansible_python:
-          - ansible: stable-2.16
-            python: '3.10'
-          - ansible: stable-2.16
+          # https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs
+          # Newest first (fast feedback), then older releases retroactively. Test the minimum and
+          # maximum supported controller Python per ansible-core branch. devel = next stable.
+          - ansible: devel
+            python: '3.14'
+          - ansible: devel
+            python: '3.13'
+          - ansible: stable-2.21
+            python: '3.14'
+          - ansible: stable-2.21
             python: '3.12'
-          - ansible: stable-2.17
-            python: '3.10'
-          - ansible: stable-2.17
+          - ansible: stable-2.20
+            python: '3.14'
+          - ansible: stable-2.20
             python: '3.12'
-          - ansible: stable-2.18
-            python: '3.11'
-          - ansible: stable-2.18
+          - ansible: stable-2.19
             python: '3.13'
           - ansible: stable-2.19
             python: '3.11'
-          - ansible: stable-2.19
+          - ansible: stable-2.18
             python: '3.13'
-          - ansible: devel
+          - ansible: stable-2.18
+            python: '3.11'
+          - ansible: stable-2.17
             python: '3.12'
-          - ansible: devel
-            python: '3.13'
+          - ansible: stable-2.17
+            python: '3.10'
+          - ansible: stable-2.16
+            python: '3.12'
+          - ansible: stable-2.16
+            python: '3.10'
 
     steps:
       - name: Check out code
@@ -139,7 +160,7 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_python.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Install ansible.netcommon collection
-        run: ansible-galaxy collection install ansible.netcommon -p $GITHUB_WORKSPACE
+        run: ansible-galaxy collection install ansible.netcommon -p "$GITHUB_WORKSPACE"
         working-directory: ./ansible_collections/community/zabbix
 
       - name: Zabbix container server provisioning
@@ -147,9 +168,11 @@ jobs:
         with:
           compose-file: "./ansible_collections/community/zabbix/docker-compose.yml"
         env:
-          zabbix_version: ${{ matrix.zabbix_container.version }}
+          ZABBIX_SERVER_IMAGE_TAG: ${{ matrix.zabbix_container.image_tag }}
+          ZABBIX_WEB_IMAGE_TAG: ${{ matrix.zabbix_container.image_tag }}
 
       - name: Run targeted integration tests
+        id: run
         env:
           TARGETS: ${{ needs.prepare.outputs.targets }}
         shell: bash
@@ -166,3 +189,57 @@ jobs:
       - uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: false
+
+      - name: Publish test results
+        if: always()
+        uses: ./ansible_collections/community/zabbix/.github/actions/publish-test-results
+        with:
+          junit-path: tests/output/junit/*.xml
+          artifact-name: junit-pi-targeted-${{ matrix.zabbix_container.version }}-${{ matrix.ansible_python.ansible }}-py${{ matrix.ansible_python.python }}
+          check-name: JUnit pi-targeted ${{ matrix.zabbix_container.version }} ${{ matrix.ansible_python.ansible }}+py${{ matrix.ansible_python.python }}
+          working-directory: ansible_collections/community/zabbix
+
+      - name: Upload failure logs
+        if: failure()
+        uses: ./ansible_collections/community/zabbix/.github/actions/upload-failure-logs
+        with:
+          artifact-name: logs-pi-targeted-${{ matrix.zabbix_container.version }}-${{ matrix.ansible_python.ansible }}-py${{ matrix.ansible_python.python }}
+          paths: |
+            ansible_collections/community/zabbix/tests/output/
+
+      - name: Report result
+        if: always()
+        uses: ./ansible_collections/community/zabbix/.github/actions/report-result
+        with:
+          outcome: ${{ steps.run.outcome }}
+          scenario: integration-targeted
+          zabbix: ${{ matrix.zabbix_container.version }}
+          ansible: ${{ matrix.ansible_python.ansible }}
+          python: py${{ matrix.ansible_python.python }}
+
+  ci:
+    name: CI (integration targeted)
+    if: always()
+    needs: [prepare, integration]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Coverage scope
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Coverage scope";
+            echo "";
+            echo "Integration (plugin/module) matrix under test:";
+            echo "";
+            echo "- Zabbix: 6.0, 7.0, 7.4, 8.0 (pre-release via ubuntu-trunk docker image)";
+            echo "- ansible-core: 2.16 through 2.21 plus devel (each with min+max supported controller Python, up to 3.14)";
+            echo "";
+            echo "All supported combinations run. Any failures below are the current fix-list (real, fully visible - not hidden).";
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Aggregate matrix result
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: integration

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -2,12 +2,15 @@
 name: "community.zabbix.zabbix_proxy"
 on:
   workflow_call:
+  workflow_dispatch:
   push:
     paths:
       - "roles/zabbix_proxy/**"
       - "molecule/zabbix_proxy/**"
       - "molecule/requirements.txt"
       - ".github/workflows/proxy.yml"
+      - ".github/workflows/role-test.yml"
+      - ".github/actions/**"
       - "roles/zabbix_repo/**"
   pull_request:
     paths:
@@ -15,277 +18,66 @@ on:
       - "molecule/zabbix_proxy/**"
       - "molecule/requirements.txt"
       - ".github/workflows/proxy.yml"
+      - ".github/workflows/role-test.yml"
+      - ".github/actions/**"
       - "roles/zabbix_repo/**"
 concurrency:
   group: proxy-${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 jobs:
   build-collection:
     uses: ./.github/workflows/build_collection.yml
 
-  base:
+  molecule:
     needs: build-collection
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        container:
-          - image: rockylinux10
-          - image: rockylinux9
-          - image: ubuntu2404
-          - image: ubuntu2204
-          - image: debian13
-          - image: debian12
-          - image: debian11
-        collection_role:
-          - zabbix_proxy
-        database:
-          - mysql
-          - pgsql
-          - sqlite3
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-        exclude:
-          - container:
-              image: debian13
-            version: v72
-          - container:
-              image: rockylinux10
-            version: v72
-          - container:
-              image: rockylinux10
-            version: v70
-          - container:
-              image: rockylinux10
-            version: v60
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-          cache: pip
-          cache-dependency-path: molecule/requirements.txt
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
-        run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DATABASE=${{ matrix.database }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule test -s ${{ matrix.collection_role }}
-
-  psk:
-    needs: build-collection
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        container:
-          - image: rockylinux9
-          - image: ubuntu2204
-          - image: debian11
-        collection_role:
-          - zabbix_proxy_psk
-          - zabbix_proxy_psk_active
-        database:
-          - mysql
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-          cache: pip
-          cache-dependency-path: molecule/requirements.txt
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
-        run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DATABASE=${{ matrix.database }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule test -s ${{ matrix.collection_role }}
-
-  legacy:
-    needs: build-collection
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        container:
-          - image: rockylinux8
-            ansible_core: ansible-core<2.17
-          - image: opensuseleap15
-            ansible_core: ansible-core<2.17
-        collection_role:
-          - zabbix_proxy
-          - zabbix_proxy_psk
-          - zabbix_proxy_psk_active
-        database:
-          - mysql
-          - pgsql
-          - sqlite3
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-        exclude:
-          - collection_role: zabbix_proxy_psk
+        include:
+          - scenario: zabbix_proxy
+            database: mysql
+          - scenario: zabbix_proxy
             database: pgsql
-          - collection_role: zabbix_proxy_psk
+          - scenario: zabbix_proxy
             database: sqlite3
-          - collection_role: zabbix_proxy_psk_active
-            database: pgsql
-          - collection_role: zabbix_proxy_psk_active
-            database: sqlite3
+          - scenario: zabbix_proxy_psk
+            database: mysql
+          - scenario: zabbix_proxy_psk_active
+            database: mysql
+    uses: ./.github/workflows/role-test.yml
+    with:
+      role: proxy
+      scenario: ${{ matrix.scenario }}
+      database: ${{ matrix.database }}
+
+  ci:
+    name: CI (proxy)
+    if: always()
+    needs: [build-collection, molecule]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ hashFiles('molecule/requirements.txt', 'molecule/zabbix_agent_tests/common/collections.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install specific version ansible-core
-        if: matrix.container.ansible_core != null
-        run: pip install "${{ matrix.container.ansible_core }}"
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
+      - name: Coverage scope
+        if: always()
+        shell: bash
         run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
+          {
+            echo "## Coverage scope";
+            echo "";
+            echo "Full role-test matrix under test:";
+            echo "";
+            echo "- Zabbix: 6.0, 7.0, 7.4 (7.2 dropped - EOL; 8.0 has no packages yet - integration-only)";
+            echo "- Distros: rockylinux 8/9/10, ubuntu 22.04/24.04/26.04, debian 11/12/13, opensuse leap 15";
+            echo "- Arch: amd64 + arm64 (except debian11 arm64 - no Zabbix arm64 packages)";
+            echo "- ansible-core: 2.16 (floor) + 2.21 (latest); controller Python 3.12";
+            echo "";
+            echo "All supported combinations run. Any failures below are the current fix-list (real, fully visible - not hidden).";
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Aggregate matrix result
+        uses: re-actors/alls-green@release/v1
         with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DATABASE=${{ matrix.database }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule test -s ${{ matrix.collection_role }}
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -7,9 +7,12 @@ on:
 concurrency:
   group: sanity-${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   tox-linters:
     name: Tox-Lint (py${{ matrix.python }})
+    timeout-minutes: 30
     strategy:
       matrix:
         python:
@@ -31,25 +34,42 @@ jobs:
         run: pip install flake8 tox
 
       - name: Run lint test for py3
+        id: run
         run: tox -elinters-py3 -vv
         working-directory: ./ansible_collections/community/zabbix
 
+      - name: Report result
+        if: always()
+        uses: ./ansible_collections/community/zabbix/.github/actions/report-result
+        with:
+          outcome: ${{ steps.run.outcome }}
+          scenario: tox-lint
+          python: py${{ matrix.python }}
+
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
+    timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
-        ansible:
-          # It's important that Sanity is tested against all stable-X.Y branches
-          # Testing against `devel` may fail as new tests are added.
-
-          # https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs
-          - stable-2.16
-          - stable-2.17
-          - stable-2.18
-          - stable-2.19
-          - devel
-        python:
-          - '3.12'
+        # Newest first (fast feedback), then older releases retroactively, each paired with a
+        # supported controller Python. devel = next stable (Python >= 3.13).
+        # https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs
+        include:
+          - ansible: devel
+            python: '3.13'
+          - ansible: stable-2.21
+            python: '3.13'
+          - ansible: stable-2.20
+            python: '3.13'
+          - ansible: stable-2.19
+            python: '3.12'
+          - ansible: stable-2.18
+            python: '3.12'
+          - ansible: stable-2.17
+            python: '3.12'
+          - ansible: stable-2.16
+            python: '3.12'
     runs-on: ubuntu-latest
     steps:
       # ansible-test requires the collection to be in a directory in the form
@@ -74,5 +94,39 @@ jobs:
       # The docker container has all the pinned dependencies that are required.
       # Explicity specify the version of Python we want to test
       - name: Run sanity tests
+        id: run
         run: ansible-test sanity --docker -v --color --exclude molecule/ --python ${{ matrix.python }}
         working-directory: ./ansible_collections/community/zabbix
+
+      # ansible-test sanity emits no JUnit, so only a PASS/FAIL summary row is published here.
+      - name: Report result
+        if: always()
+        uses: ./ansible_collections/community/zabbix/.github/actions/report-result
+        with:
+          outcome: ${{ steps.run.outcome }}
+          scenario: sanity
+          ansible: ${{ matrix.ansible }}
+          python: py${{ matrix.python }}
+
+  ci:
+    name: CI (sanity)
+    if: always()
+    needs: [tox-linters, sanity]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Coverage scope
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Coverage scope";
+            echo "";
+            echo "Sanity + lint across ansible-core 2.16 through 2.21 plus devel.";
+            echo "";
+            echo "All supported combinations run. Any failures below are the current fix-list (real, fully visible - not hidden).";
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Aggregate matrix result
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/role-test.yml
+++ b/.github/workflows/role-test.yml
@@ -1,0 +1,215 @@
+---
+name: "Reusable role test"
+on:
+  workflow_call:
+    inputs:
+      role:
+        description: Label used in artifact/check/report names.
+        required: true
+        type: string
+      working_directory:
+        description: Working directory for the molecule run (default repo root).
+        required: false
+        type: string
+        default: "."
+      molecule_config:
+        description: "Value passed to molecule -c <x> (empty = no -c flag)."
+        required: false
+        type: string
+        default: ""
+      scenario:
+        description: "Molecule scenario name passed to molecule test -s <scenario>."
+        required: true
+        type: string
+      database:
+        description: "MY_MOLECULE_DATABASE value (empty = role does not use a DB)."
+        required: false
+        type: string
+        default: ""
+      web_server:
+        description: "MY_MOLECULE_WEB_SERVER value (empty = role does not use a web server)."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  # Zabbix does not ship every package for every distro/version/arch. The gating package
+  # differs per role (agent is widest; server/web need server-side packages that are absent
+  # on some distros). Rather than test unsupported cells and fail the role's version gate, we
+  # compute the per-role exclude list here (single source of truth, keyed on inputs.role) and
+  # feed it into the molecule matrix. Availability verified against repo.zabbix.com 2026-07-04.
+  setup:
+    runs-on: ubuntu-22.04
+    outputs:
+      exclude: ${{ steps.gen.outputs.exclude }}
+    steps:
+      - name: Compute per-role matrix excludes
+        id: gen
+        env:
+          ROLE: ${{ inputs.role }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os
+          role = os.environ["ROLE"]
+          # Common gaps (every role): no arm64 packages for Debian 11 bullseye (any version);
+          # no Zabbix 6.0 repo for Ubuntu 26.04 resolute; EL8 default python 3.6 is too old for
+          # ansible-core 2.21 modules.
+          exclude = [
+              {"distro": "debian11", "arch": "arm64"},
+              {"distro": "ubuntu2604", "zabbix": "v60"},
+              {"distro": "rockylinux8", "ansible": "2.21"},
+          ]
+          if role != "agent":
+              # EL10 (Rocky 10) Zabbix 6.0 ships zabbix-agent only; no server/proxy/web/java/web-service.
+              exclude.append({"distro": "rockylinux10", "zabbix": "v60"})
+          if role in ("server", "web"):
+              # Debian 11 (bullseye) ships no zabbix-server / zabbix-frontend-php for 7.0 or 7.4.
+              exclude.append({"distro": "debian11", "zabbix": "v70"})
+              exclude.append({"distro": "debian11", "zabbix": "v74"})
+          print("exclude=" + json.dumps(exclude))
+          PY
+
+  molecule:
+    needs: setup
+    # ubuntu-24.04 runners break systemd/sudo in EL/older geerlingguy containers (converge fact-gather
+    # fails with sudo PAM "authentication info" errors); classified on 2026-07-03 (same cell passes on
+    # 22.04, fails on 24.04). Use 22.04 (amd64) / 22.04-arm (arm64); revisit 24.04-compat later.
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - rockylinux8
+          - rockylinux9
+          - rockylinux10
+          - ubuntu2204
+          - ubuntu2404
+          - ubuntu2604
+          - debian11
+          - debian12
+          - debian13
+          - opensuseleap15
+        arch:
+          - amd64
+          - arm64
+        ansible:
+          - "2.16"
+          - "2.21"
+        zabbix:
+          - v60
+          - v70
+          - v74
+        # Computed per-role in the `setup` job (see comment there). Common exclusions:
+        # debian11 arm64 (no packages), ubuntu2604 + v60 (no 6.0 repo), rockylinux8 + ansible 2.21
+        # (EL8 default python 3.6 too old). Plus role-specific package-availability gaps.
+        exclude: ${{ fromJSON(needs.setup.outputs.exclude) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      # Python 3.12 is the only controller Python in BOTH ansible-core 2.16 (>=3.10) and
+      # 2.21 (>=3.12) ranges, so it works for every cell of the ansible matrix.
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: molecule/requirements.txt
+
+      - name: Install latest pip and yq
+        run: python -m pip install --upgrade pip yq
+
+      - name: Install ansible-core
+        run: pip install "ansible-core~=${{ matrix.ansible }}.0"
+
+      - name: Install dependencies
+        run: pip install -r molecule/requirements.txt
+
+      - name: Build the collection
+        run: |
+          yq -yi '
+            .dependencies."ansible.windows" = "2.8.0" |
+            .dependencies."ansible.netcommon" = "7.2.0" |
+            .dependencies."ansible.posix" = "2.0.0" |
+            .dependencies."community.general" = "10.5.0" |
+            .dependencies."community.mysql" = "3.13.0" |
+            .dependencies."community.postgresql" = "3.12.0"
+          ' galaxy.yml
+
+          ansible-galaxy collection build -f
+
+      - name: Cache Ansible Galaxy content
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.ansible/collections
+            ~/.ansible/roles
+            ~/.cache/ansible-compat
+          key: ${{ runner.os }}-${{ matrix.arch }}-molecule-galaxy-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-molecule-galaxy-
+
+      - name: Install Collections and Roles
+        # Retry to survive transient Galaxy 5xx responses while downloading deps.
+        run: |
+          for i in 1 2 3; do
+            ansible-galaxy collection install -f -vvvv community-zabbix-*.tar.gz && exit 0
+            echo "galaxy install failed (attempt $i), retrying"; sleep 15
+          done
+          exit 1
+
+      - name: Run role tests
+        id: run
+        working-directory: ${{ inputs.working_directory }}
+        env:
+          ANSIBLE_CALLBACKS_ENABLED: ansible.builtin.junit
+          JUNIT_OUTPUT_DIR: ${{ github.workspace }}/junit
+          MOL_CONFIG: ${{ inputs.molecule_config != '' && format('-c {0}', inputs.molecule_config) || '' }}
+        run: |
+          # shellcheck disable=SC2086
+          MY_MOLECULE_CONTAINER=${{ matrix.distro }} \
+          MY_MOLECULE_IMAGE=${{ matrix.distro }} \
+          MY_MOLECULE_VERSION=${{ matrix.zabbix }} \
+          MY_MOLECULE_DATABASE=${{ inputs.database }} \
+          MY_MOLECULE_WEB_SERVER=${{ inputs.web_server }} \
+          molecule $MOL_CONFIG test -s ${{ inputs.scenario }}
+
+      - name: Publish test results
+        if: always()
+        uses: ./.github/actions/publish-test-results
+        with:
+          junit-path: junit/*.xml
+          working-directory: "."
+          artifact-name: >-
+            junit-${{ inputs.role }}-${{ inputs.scenario }}-${{ inputs.database }}-${{ inputs.web_server }}-${{ matrix.distro }}-${{ matrix.zabbix }}-${{ matrix.arch }}-ac${{ matrix.ansible }}
+          check-name: >-
+            JUnit ${{ inputs.role }} ${{ inputs.scenario }} ${{ inputs.database }} ${{ inputs.web_server }} ${{ matrix.distro }} ${{ matrix.zabbix }} ${{ matrix.arch }} ac${{ matrix.ansible }}
+
+      - name: Upload failure logs
+        if: failure()
+        uses: ./.github/actions/upload-failure-logs
+        with:
+          artifact-name: >-
+            logs-${{ inputs.role }}-${{ inputs.scenario }}-${{ inputs.database }}-${{ inputs.web_server }}-${{ matrix.distro }}-${{ matrix.zabbix }}-${{ matrix.arch }}-ac${{ matrix.ansible }}
+          paths: |
+            junit/
+            ~/.cache/molecule/
+
+      - name: Report result
+        if: always()
+        uses: ./.github/actions/report-result
+        with:
+          outcome: ${{ steps.run.outcome }}
+          scenario: ${{ inputs.scenario }}
+          container: ${{ matrix.distro }}
+          zabbix: ${{ matrix.zabbix }}
+          arch: ${{ matrix.arch }}
+          ansible: ${{ matrix.ansible }}
+          python: "3.12"
+          database: "${{ inputs.database }}${{ inputs.web_server && format('/{0}', inputs.web_server) || '' }}"

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -2,12 +2,15 @@
 name: "community.zabbix.zabbix_server"
 on:
   workflow_call:
+  workflow_dispatch:
   push:
     paths:
       - "roles/zabbix_server/**"
       - "molecule/zabbix_server/**"
       - "molecule/requirements.txt"
       - ".github/workflows/server.yml"
+      - ".github/workflows/role-test.yml"
+      - ".github/actions/**"
       - "roles/zabbix_repo/**"
   pull_request:
     paths:
@@ -15,198 +18,58 @@ on:
       - "molecule/zabbix_server/**"
       - "molecule/requirements.txt"
       - ".github/workflows/server.yml"
+      - ".github/workflows/role-test.yml"
+      - ".github/actions/**"
       - "roles/zabbix_repo/**"
 concurrency:
   group: server-${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 jobs:
   build-collection:
     uses: ./.github/workflows/build_collection.yml
 
   molecule:
     needs: build-collection
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        container:
-          - image: rockylinux10
-          - image: rockylinux9
-          - image: ubuntu2404
-          - image: ubuntu2204
-          - image: debian13
-          - image: debian12
-          - image: debian11
-        collection_role:
-          - zabbix_server
         database:
           - mysql
           - pgsql
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-        exclude:
-          - container:
-              image: rockylinux10
-            version: v72
-          - container:
-              image: rockylinux10
-            version: v70
-          - container:
-              image: rockylinux10
-            version: v60
-          - container:
-              image: debian13
-            version: v72
-          - container:
-              image: debian11
-            version: v74
-          - container:
-              image: debian11
-            version: v72
-          - container:
-              image: debian11
-            version: v70
+    uses: ./.github/workflows/role-test.yml
+    with:
+      role: server
+      scenario: zabbix_server
+      database: ${{ matrix.database }}
+
+  ci:
+    name: CI (server)
+    if: always()
+    needs: [build-collection, molecule]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-          cache: pip
-          cache-dependency-path: molecule/requirements.txt
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
+      - name: Coverage scope
+        if: always()
+        shell: bash
         run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
+          {
+            echo "## Coverage scope";
+            echo "";
+            echo "Full role-test matrix under test:";
+            echo "";
+            echo "- Zabbix: 6.0, 7.0, 7.4 (7.2 dropped - EOL; 8.0 has no packages yet - integration-only)";
+            echo "- Distros: rockylinux 8/9/10, ubuntu 22.04/24.04/26.04, debian 11/12/13, opensuse leap 15";
+            echo "- Arch: amd64 + arm64 (except debian11 arm64 - no Zabbix arm64 packages)";
+            echo "- ansible-core: 2.16 (floor) + 2.21 (latest); controller Python 3.12";
+            echo "";
+            echo "All supported combinations run. Any failures below are the current fix-list (real, fully visible - not hidden).";
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Aggregate matrix result
+        uses: re-actors/alls-green@release/v1
         with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DATABASE=${{ matrix.database }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule test -s ${{ matrix.collection_role }}
-
-  legacy:
-    needs: build-collection
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        container:
-          - image: rockylinux8
-            ansible_core: ansible-core<2.17
-          - image: opensuseleap15
-            ansible_core: ansible-core<2.17
-        collection_role:
-          - zabbix_server
-        database:
-          - mysql
-          - pgsql
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ hashFiles('molecule/requirements.txt', 'molecule/zabbix_agent_tests/common/collections.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install specific version ansible-core
-        if: matrix.container.ansible_core != null
-        run: pip install "${{ matrix.container.ansible_core }}"
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
-        run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DATABASE=${{ matrix.database }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule test -s ${{ matrix.collection_role }}
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -2,12 +2,15 @@
 name: "community.zabbix.zabbix_web"
 on:
   workflow_call:
+  workflow_dispatch:
   push:
     paths:
       - "roles/zabbix_web/**"
       - "molecule/zabbix_web/**"
       - "molecule/requirements.txt"
       - ".github/workflows/web.yml"
+      - ".github/workflows/role-test.yml"
+      - ".github/actions/**"
       - "roles/zabbix_repo/**"
   pull_request:
     paths:
@@ -15,212 +18,62 @@ on:
       - "molecule/zabbix_web/**"
       - "molecule/requirements.txt"
       - ".github/workflows/web.yml"
+      - ".github/workflows/role-test.yml"
+      - ".github/actions/**"
       - "roles/zabbix_repo/**"
 concurrency:
   group: web-${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 jobs:
   build-collection:
     uses: ./.github/workflows/build_collection.yml
 
   molecule:
     needs: build-collection
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        container:
-          - image: rockylinux10
-          - image: rockylinux9
-          - image: ubuntu2404
-          - image: ubuntu2204
-          - image: debian13
-          - image: debian12
-          - image: debian11
-        collection_role:
-          - zabbix_web
         database:
           - mysql
           - pgsql
         web_server:
           - nginx
           - apache
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-        exclude:
-          - container:
-              image: rockylinux10
-            version: v72
-          - container:
-              image: rockylinux10
-            version: v70
-          - container:
-              image: rockylinux10
-            version: v60
-          - container:
-              image: debian13
-            version: v72
-          - container:
-              image: debian11
-            version: v74
-          - container:
-              image: debian11
-            version: v72
-          - container:
-              image: debian11
-            version: v70
+    uses: ./.github/workflows/role-test.yml
+    with:
+      role: web
+      scenario: zabbix_web
+      database: ${{ matrix.database }}
+      web_server: ${{ matrix.web_server }}
+
+  ci:
+    name: CI (web)
+    if: always()
+    needs: [build-collection, molecule]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-          cache: pip
-          cache-dependency-path: molecule/requirements.txt
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
+      - name: Coverage scope
+        if: always()
+        shell: bash
         run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
+          {
+            echo "## Coverage scope";
+            echo "";
+            echo "Full role-test matrix under test:";
+            echo "";
+            echo "- Zabbix: 6.0, 7.0, 7.4 (7.2 dropped - EOL; 8.0 has no packages yet - integration-only)";
+            echo "- Distros: rockylinux 8/9/10, ubuntu 22.04/24.04/26.04, debian 11/12/13, opensuse leap 15";
+            echo "- Arch: amd64 + arm64 (except debian11 arm64 - no Zabbix arm64 packages)";
+            echo "- ansible-core: 2.16 (floor) + 2.21 (latest); controller Python 3.12";
+            echo "";
+            echo "All supported combinations run. Any failures below are the current fix-list (real, fully visible - not hidden).";
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Aggregate matrix result
+        uses: re-actors/alls-green@release/v1
         with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DATABASE=${{ matrix.database }}
-          MY_MOLECULE_WEB_SERVER=${{ matrix.web_server }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule test -s ${{ matrix.collection_role }}
-
-  legacy:
-    needs: build-collection
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        container:
-          - image: rockylinux8
-            ansible_core: ansible-core<2.17
-          - image: rockylinux8
-            ansible_core: ansible-core<2.17
-          - image: opensuseleap15
-            ansible_core: ansible-core<2.17
-        collection_role:
-          - zabbix_web
-        database:
-          - mysql
-          - pgsql
-        web_server:
-          - nginx
-          - apache
-        version:
-          - v74
-          - v72
-          - v70
-          - v60
-        exclude:
-          - container:
-              image: opensuseleap15
-            version: v72
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.11
-
-      - name: Install latest pip
-        run: python -m pip install --upgrade pip yq
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ hashFiles('molecule/requirements.txt', 'molecule/zabbix_agent_tests/common/collections.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install specific version ansible-core
-        if: matrix.container.ansible_core != null
-        run: pip install "${{ matrix.container.ansible_core }}"
-
-      - name: Install dependencies
-        run: pip install -r molecule/requirements.txt
-
-      - name: Build the collection
-        run: |
-          yq -yi '
-            .dependencies."ansible.windows" = "2.8.0" |
-            .dependencies."ansible.netcommon" = "7.2.0" |
-            .dependencies."ansible.posix" = "2.0.0" |
-            .dependencies."community.general" = "10.5.0" |
-            .dependencies."community.mysql" = "3.13.0" |
-            .dependencies."community.postgresql" = "3.12.0"
-          ' galaxy.yml
-
-          ansible-galaxy collection build -f
-
-      - name: Cache Ansible Galaxy content
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.ansible/collections
-            ~/.ansible/roles
-            ~/.cache/ansible-compat
-          key: ${{ runner.os }}-molecule-galaxy-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-molecule-galaxy-
-
-      - name: Install Collections and Roles 
-        run: |
-          ansible-galaxy collection install -f -vvvv  community-zabbix-*.tar.gz
-
-      - name: Run role tests
-        run: >-
-          MY_MOLECULE_CONTAINER=${{ matrix.container.image }}
-          MY_MOLECULE_IMAGE=${{ matrix.container.image }}
-          MY_MOLECULE_VERSION=${{ matrix.version }}
-          MY_MOLECULE_DATABASE=${{ matrix.database }}
-          MY_MOLECULE_WEB_SERVER=${{ matrix.web_server }}
-          MY_MOLECULE_DOCKER_COMMAND=${{ matrix.command }}
-          molecule test -s ${{ matrix.collection_role }}          
+          jobs: ${{ toJSON(needs) }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 tests/output
+# ansible-test regenerates this per run with the local interpreter; committing it
+# leaks developer/environment-specific paths (e.g. an absolute ansible_python_interpreter).
+tests/integration/inventory
 __pycache__
 
 # ignore visual studio code things, and intelliJ

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: "zabbix"
       POSTGRES_PASSWORD: "zabbix"
   zabbix-server:
-    image: zabbix/zabbix-server-pgsql:ubuntu-${zabbix_version}-latest
+    image: zabbix/zabbix-server-pgsql:${ZABBIX_SERVER_IMAGE_TAG:-ubuntu-7.4-latest}
     environment:
       DB_SERVER_HOST: "zabbix-db"
       POSTGRES_USER: "zabbix"
@@ -21,7 +21,7 @@ services:
     env_file:
       - ./.env_srv
   zabbix-web:
-    image: zabbix/zabbix-web-nginx-pgsql:ubuntu-${zabbix_version}-latest
+    image: zabbix/zabbix-web-nginx-pgsql:${ZABBIX_WEB_IMAGE_TAG:-ubuntu-7.4-latest}
     environment:
       DB_SERVER_HOST: "zabbix-db"
       POSTGRES_USER: "zabbix"

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,5 +1,5 @@
 # Install CI dependencies for the Zabbix Roles
-ansible-core<2.19
+ansible-core
 docker
 molecule
 netaddr>=1.2.1

--- a/molecule/zabbix_agent_tests/common/molecule.yml
+++ b/molecule/zabbix_agent_tests/common/molecule.yml
@@ -48,8 +48,6 @@ provisioner:
         zabbix_agent_tlscafile: /etc/zabbix/ca
       v74:
         zabbix_agent_version: 7.4
-      v72:
-        zabbix_agent_version: 7.2
       v70:
         zabbix_agent_version: 7.0
       v60:

--- a/molecule/zabbix_javagateway/molecule.yml
+++ b/molecule/zabbix_javagateway/molecule.yml
@@ -37,8 +37,6 @@ provisioner:
         ansible_connection: community.docker.docker
       v74:
         zabbix_javagateway_version: 7.4
-      v72:
-        zabbix_javagateway_version: 7.2
       v70:
         zabbix_javagateway_version: 7.0
       v60:

--- a/molecule/zabbix_proxy/molecule.yml
+++ b/molecule/zabbix_proxy/molecule.yml
@@ -75,11 +75,6 @@ provisioner:
         zabbix_proxy_server: zabbix-server-v74
         zabbix_api_server_host: zabbix-web-v74
         zabbix_api_server_port: 8074
-      v72:
-        zabbix_proxy_version: "7.2"
-        zabbix_proxy_server: zabbix-server-v72
-        zabbix_api_server_host: zabbix-web-v72
-        zabbix_api_server_port: 8072
       v70:
         zabbix_proxy_version: "7.0"
         zabbix_proxy_server: zabbix-server-v70

--- a/molecule/zabbix_proxy_psk/molecule.yml
+++ b/molecule/zabbix_proxy_psk/molecule.yml
@@ -51,11 +51,6 @@ provisioner:
         zabbix_proxy_server: zabbix-server-v74
         zabbix_api_server_host: zabbix-web-v74
         zabbix_api_server_port: 8074
-      v72:
-        zabbix_proxy_version: "7.2"
-        zabbix_proxy_server: zabbix-server-v72
-        zabbix_api_server_host: zabbix-web-v72
-        zabbix_api_server_port: 8072
       v70:
         zabbix_proxy_version: "7.0"
         zabbix_proxy_server: zabbix-server-v70

--- a/molecule/zabbix_proxy_psk_active/molecule.yml
+++ b/molecule/zabbix_proxy_psk_active/molecule.yml
@@ -52,11 +52,6 @@ provisioner:
         zabbix_proxy_server: zabbix-server-v74
         zabbix_api_server_host: zabbix-web-v74
         zabbix_api_server_port: 8074
-      v72:
-        zabbix_proxy_version: "7.2"
-        zabbix_proxy_server: zabbix-server-v72
-        zabbix_api_server_host: zabbix-web-v72
-        zabbix_api_server_port: 8072
       v70:
         zabbix_proxy_version: "7.0"
         zabbix_proxy_server: zabbix-server-v70

--- a/molecule/zabbix_repo/molecule.yml
+++ b/molecule/zabbix_repo/molecule.yml
@@ -37,8 +37,6 @@ provisioner:
         ansible_connection: community.docker.docker
       v74:
         zabbix_proxy_version: 7.4
-      v72:
-        zabbix_server_version: 7.2
       v70:
         zabbix_server_version: 7.0
       v60:

--- a/molecule/zabbix_server/molecule.yml
+++ b/molecule/zabbix_server/molecule.yml
@@ -38,8 +38,6 @@ provisioner:
         ansible_connection: community.docker.docker
       v74:
         zabbix_server_version: 7.4
-      v72:
-        zabbix_server_version: 7.2
       v70:
         zabbix_server_version: 7.0
       v60:

--- a/molecule/zabbix_web/molecule.yml
+++ b/molecule/zabbix_web/molecule.yml
@@ -88,8 +88,6 @@ provisioner:
         zabbix_api_server_url: "{{ inventory_hostname }}"
       v74:
         zabbix_web_version: "7.4"
-      v72:
-        zabbix_web_version: "7.2"
       v70:
         zabbix_web_version: "7.0"
       v60:

--- a/tests/integration/inventory
+++ b/tests/integration/inventory
@@ -1,2 +1,0 @@
-[testgroup]
-testhost ansible_connection="local" ansible_pipelining="yes" ansible_python_interpreter="/home/ey/env_py312_ans216/bin/python"


### PR DESCRIPTION
##### SUMMARY
Brings the GitHub Actions test matrix up to the versions this collection supports today and makes results observable. No production role/plugin code is changed here.

This supersedes #1757 (which carried the first slice - the initial ansible-core/python matrix bump and dropping the generated inventory); everything in #1757 is included here. Running the fuller matrix this adds surfaces several real, mostly pre-existing role bugs; those are fixed in the companion PRs (role version maps #1759, zabbix_web apache #1760, EL aarch64 fping #1761, trigger idempotence #1758) so the matrix is green end to end.

- Add a reusable `role-test.yml` (`workflow_call`) that the agent/server/proxy/javagateway/web workflows call, replacing large blocks of duplicated matrix YAML; parametrize the molecule scenarios via env vars.
- Expand the role matrix to distro x {amd64, arm64} x ansible-core {2.16, 2.21} x Zabbix {6.0, 7.0, 7.4}, with per-role excludes computed from real Zabbix package availability; re-run role workflows when the shared engine changes; add `workflow_dispatch` for manual re-trigger.
- Modernize the integration/sanity matrix to current ansible-core/python; drop EOL Zabbix 7.2; integration covers Zabbix 6.0/7.0/7.4 (plus 8.0 trunk).
- Unpin `ansible-core<2.19` in `molecule/requirements.txt`.
- Add observability: JUnit reporting, per-job step-summary result tables, failure-log artifacts and aggregate gate checks, via composite actions under `.github/actions/`. Retry `ansible-galaxy install` to survive transient Galaxy 5xx.
- Stop tracking the auto-generated `tests/integration/inventory` (it embeds the local `ansible_python_interpreter` path) and gitignore it.

No breaking changes; the support floor (ansible-core 2.16) is preserved.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
.github/workflows (role-test, agent, server, proxy, javagateway, web, plugins-integration-full, plugins-integration-targeted, repo-sanity, build_collection), .github/actions, molecule, .gitignore

##### ADDITIONAL INFORMATION
Validated on our fork's GitHub Actions together with the companion fixes: the role workflows run green across the distro x arch x ansible-core x Zabbix matrix (the zabbix_web run is 390/390 jobs green, including amd64 + arm64, mysql + pgsql, Zabbix 7.0/7.4 on Ubuntu 26.04), and repo-sanity is green. See the validation note in the comments for run links. Refs #1513.
