### PR TITLE
fix: zabbix_inventory use selectHostGroups host groups on Zabbix 7.0+

### DIFF
--- a/changelogs/fragments/1507-zabbix-inventory-selecthostgroups.yaml
+++ b/changelogs/fragments/1507-zabbix-inventory-selecthostgroups.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - zabbix_inventory - use the ``selectHostGroups`` host.get parameter on Zabbix 7.0+ (``selectGroups`` was deprecated in 7.0 and removed in 7.2) and translate user-provided ``host_zapi_query`` group selectors by server version, keeping Zabbix 6.0 LTS working (https://github.com/ansible-collections/community.zabbix/issues/1507).
+  - zabbix inventory script - use the ``selectHostGroups`` host.get parameter on Zabbix 7.0+ (``selectGroups`` removed in 7.2) so the legacy ``scripts/inventory/zabbix.py`` works on current Zabbix (https://github.com/ansible-collections/community.zabbix/issues/1507).

--- a/plugins/inventory/zabbix_inventory.py
+++ b/plugins/inventory/zabbix_inventory.py
@@ -87,6 +87,18 @@ options:
                     - Can be limited to different fields for example setting the vaule to ['name'] will only return the name
                     - Additional fields can be specified by comma seperated value ['name', 'field2']
                     - Please see U(https://www.zabbix.com/documentation/current/manual/api/reference/hostgroup/object) for more details on field names
+                    - Removed in Zabbix 7.2; the plugin automatically uses selectHostGroups on Zabbix >= 7.0.
+            selectHostGroups:
+                type: str
+                description:
+                    - query
+                    - Return a hostgroups property with host groups data that the host belongs to.
+                    - Replacement for selectGroups, available from Zabbix 7.0 and required from Zabbix 7.2.
+                    - To return all values specify 'extend'
+                    - Can be limited to different fields for example setting the value to ['name'] will only return the name
+                    - Additional fields can be specified by comma separated value ['name', 'field2']
+                    - Please see U(https://www.zabbix.com/documentation/current/manual/api/reference/hostgroup/object) for more details on field names
+                    - The plugin automatically translates selectGroups to selectHostGroups on Zabbix >= 7.0 and vice versa.
             selectHostDiscovery:
                 type: str
                 description:
@@ -244,7 +256,7 @@ login_password: password
 host_zapi_query:
   selectApplications: ['name', 'applicationid']
   selectParentTemplates: ['name']
-  selectGroups: ['name']
+  selectHostGroups: ['name']
 validate_certs: false
 groups:
   enabled: zbx_status == "0"
@@ -373,6 +385,19 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         res = json.load(response)
         self.zabbix_version = res['result']
 
+    def _translate_hostgroup_query(self, query):
+        # host.get: 'selectGroups' was deprecated in Zabbix 7.0 and removed in 7.2; 'selectHostGroups'
+        # is the replacement (available from 7.0). Translate by server version so queries work on every
+        # supported Zabbix version. Returns a new dict; never mutates the caller's value.
+        translated = dict(query)
+        if LooseVersion(self.zabbix_version) >= LooseVersion('7.0'):
+            if 'selectGroups' in translated:
+                translated['selectHostGroups'] = translated.pop('selectGroups')
+        else:
+            if 'selectHostGroups' in translated:
+                translated['selectGroups'] = translated.pop('selectHostGroups')
+        return translated
+
     def logout_zabbix(self):
         self.api_request(
             'user.logout',
@@ -421,7 +446,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         self.get_version()
         self.login_zabbix()
-        zapi_query = self.get_option('host_zapi_query')
+        zapi_query = self._translate_hostgroup_query(self.get_option('host_zapi_query'))
         response = self.api_request(
             'host.get',
             zapi_query
@@ -451,17 +476,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             response = self.api_request(
                 'host.get',
-                {
-                    'selectGroups': ['name']
-                }
+                self._translate_hostgroup_query({'selectGroups': ['name']})
             )
             res = json.load(response)
             content = res['result']
 
             for record in content:
                 host_name = record['host']
-                if len(record['groups']) >= 1:
-                    for group in record['groups']:
+                host_groups = record.get('hostgroups', record.get('groups', []))
+                if len(host_groups) >= 1:
+                    for group in host_groups:
                         group_name = to_safe_group_name(group['name'])
                         self.inventory.add_group(group_name)
                         self.inventory.add_child(group_name, host_name)

--- a/scripts/inventory/zabbix.py
+++ b/scripts/inventory/zabbix.py
@@ -165,7 +165,8 @@ class ZabbixInventory(object):
         )
 
     def get_host(self, name):
-        api_query = {"output": "extend", "selectGroups": "extend", "filter": {"host": [name]}}
+        group_key = "selectHostGroups" if LooseVersion(self.zabbix_version) >= LooseVersion("7.0") else "selectGroups"
+        api_query = {"output": "extend", group_key: "extend", "filter": {"host": [name]}}
         if self.use_host_interface:
             api_query["selectInterfaces"] = ["useip", "ip", "dns"]
         if self.read_host_inventory:
@@ -191,7 +192,10 @@ class ZabbixInventory(object):
         return data
 
     def get_list(self):
-        api_query = {"output": "extend", "selectGroups": "extend"}
+        if LooseVersion(self.zabbix_version) >= LooseVersion("7.0"):
+            api_query = {"output": "extend", "selectHostGroups": "extend"}
+        else:
+            api_query = {"output": "extend", "selectGroups": "extend"}
         if self.use_host_interface:
             api_query["selectInterfaces"] = ["useip", "ip", "dns"]
         if self.read_host_inventory:
@@ -206,7 +210,7 @@ class ZabbixInventory(object):
             hostvars = dict()
             data[self.defaultgroup]["hosts"].append(hostname)
 
-            for group in host["groups"]:
+            for group in host.get("hostgroups", host.get("groups", [])):
                 groupname = group["name"]
 
                 if groupname not in data:

--- a/tests/integration/targets/test_zabbix_inventory/files/groups_zabbix_inventory.yml
+++ b/tests/integration/targets/test_zabbix_inventory/files/groups_zabbix_inventory.yml
@@ -1,0 +1,7 @@
+---
+plugin: community.zabbix.zabbix_inventory
+server_url: http://127.0.0.1:8080
+login_user: Admin
+login_password: zabbix
+validate_certs: false
+add_zabbix_groups: true

--- a/tests/integration/targets/test_zabbix_inventory/files/zabbix.ini
+++ b/tests/integration/targets/test_zabbix_inventory/files/zabbix.ini
@@ -1,0 +1,5 @@
+[zabbix]
+server = http://127.0.0.1:8080
+username = Admin
+password = zabbix
+validate_certs = false

--- a/tests/integration/targets/test_zabbix_inventory/files/zapi_zabbix_inventory.yml
+++ b/tests/integration/targets/test_zabbix_inventory/files/zapi_zabbix_inventory.yml
@@ -1,0 +1,8 @@
+---
+plugin: community.zabbix.zabbix_inventory
+server_url: http://127.0.0.1:8080
+login_user: Admin
+login_password: zabbix
+validate_certs: false
+host_zapi_query:
+  selectGroups: ['name']

--- a/tests/integration/targets/test_zabbix_inventory/meta/main.yml
+++ b/tests/integration/targets/test_zabbix_inventory/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_zabbix

--- a/tests/integration/targets/test_zabbix_inventory/tasks/main.yml
+++ b/tests/integration/targets/test_zabbix_inventory/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+- name: "test - create a host in a known group on the real Zabbix"
+  community.zabbix.zabbix_host:
+    host_name: ExampleHostForInventoryPlugin
+    host_groups:
+      - Linux servers
+    interfaces:
+      - type: 1
+        main: 1
+        useip: 1
+        ip: 192.168.0.50
+        dns: ""
+        port: 10050
+    status: enabled
+    state: present
+
+- name: "test - run plugin with add_zabbix_groups"
+  ansible.builtin.command:
+    cmd: ansible-inventory -i {{ role_path }}/files/groups_zabbix_inventory.yml --list
+  changed_when: false
+  register: inv_groups
+
+- name: "assert - host group present via add_zabbix_groups"
+  ansible.builtin.assert:
+    that:
+      - "inv_groups.stdout is search('Linux_servers')"
+      - "inv_groups.stdout is search('ExampleHostForInventoryPlugin')"
+    fail_msg: "add_zabbix_groups did not yield the group (stdout: {{ inv_groups.stdout }})"
+
+- name: "test - run plugin with host_zapi_query selectGroups (legacy param)"
+  ansible.builtin.command:
+    cmd: ansible-inventory -i {{ role_path }}/files/zapi_zabbix_inventory.yml --list
+  changed_when: false
+  register: inv_zapi
+
+- name: "assert - host_zapi_query returned host group data (not silently dropped)"
+  ansible.builtin.assert:
+    that:
+      - "inv_zapi.stdout is search('zbx_hostgroups') or inv_zapi.stdout is search('zbx_groups')"
+      - "inv_zapi.stdout is search('Linux servers')"
+    fail_msg: "host_zapi_query did not return host group data (stdout: {{ inv_zapi.stdout }})"
+
+- name: "test - run legacy inventory script --list"
+  ansible.builtin.command:
+    cmd: python {{ role_path.split('/tests/')[0] }}/scripts/inventory/zabbix.py --list
+    chdir: "{{ role_path }}/files"
+  changed_when: false
+  failed_when: false
+  register: legacy_out
+
+- name: "assert - legacy script produced the host group"
+  ansible.builtin.assert:
+    that:
+      - "legacy_out.stdout is search('Linux servers')"
+      - "legacy_out.stdout is search('ExampleHostForInventoryPlugin')"
+    fail_msg: "legacy script did not yield the group (rc={{ legacy_out.rc }} stderr={{ legacy_out.stderr }} stdout={{ legacy_out.stdout }})"


### PR DESCRIPTION
##### SUMMARY
Fixes #1507. The `host.get` parameter `selectGroups` was deprecated in Zabbix 7.0 and removed in 7.2 (7.4 ignores it and returns hosts without a group field). As a result the `zabbix_inventory` plugin's `add_zabbix_groups` path returned no groups on Zabbix 7.2+, and a user-provided `host_zapi_query` with `selectGroups` silently returned no group data. The legacy `scripts/inventory/zabbix.py` had the same problem.

This makes host-group querying version-aware (mirroring the existing pattern in the modules):
- Use `selectHostGroups` on Zabbix >= 7.0 and `selectGroups` on 6.0, reading the response from `hostgroups` or `groups` accordingly.
- Auto-translate a user-provided `host_zapi_query` group selector by server version, so Zabbix 6.0 LTS keeps working, and document the new `selectHostGroups` sub-option.
- Apply the same version-aware fix to the legacy `scripts/inventory/zabbix.py`.
- Add a real-Zabbix integration target (`test_zabbix_inventory`, depends on `setup_zabbix`) that creates a host in a group and asserts the plugin (`add_zabbix_groups` and `host_zapi_query`) and the legacy script both surface it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_inventory (inventory plugin); scripts/inventory/zabbix.py

##### ADDITIONAL INFORMATION
Validated against real Zabbix on both 7.4 (7.4.11) and 6.0 (6.0.46) via the collection's docker-compose stack and `ansible-test integration test_zabbix_inventory` - all three exercises (plugin `add_zabbix_groups`, plugin `host_zapi_query`, legacy script) pass on both versions. The bug is real on 7.4: a raw `host.get` with `selectGroups: ['name']` returns hosts with no group field, while `selectHostGroups: ['name']` returns `hostgroups`. `ansible-test sanity` on the changed files and `yamllint` are clean.
