### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
+    their Python standard library equivalents. ``ansible.module_utils.six`` is
+    deprecated in ansible-core 2.21 and is scheduled for removal in 2.24.

--- a/plugins/inventory/zabbix_inventory.py
+++ b/plugins/inventory/zabbix_inventory.py
@@ -302,12 +302,13 @@ auth_token: "{{ lookup('ansible.builtin.env', 'ZABBIX_API_KEY') }}"
 validate_certs: false
 """
 
+from urllib.error import URLError, HTTPError
+
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable, to_safe_group_name
 import os
 import atexit
 import json
 from ansible.module_utils.urls import Request
-from ansible.module_utils.six.moves.urllib.error import URLError, HTTPError
 from ansible.module_utils.compat.version import LooseVersion
 from ansible.errors import AnsibleParserError
 

--- a/scripts/inventory/zabbix.py
+++ b/scripts/inventory/zabbix.py
@@ -40,10 +40,10 @@ import sys
 import argparse
 import json
 import atexit
-from ansible.module_utils.six.moves import configparser
+import configparser
+from urllib.error import URLError, HTTPError
 from ansible.module_utils.compat.version import LooseVersion
 from ansible.module_utils.urls import Request
-from ansible.module_utils.six.moves.urllib.error import URLError, HTTPError
 
 
 class ZabbixInventory(object):


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24. Both uses in this collection are stdlib re-exports:

```python
-from ansible.module_utils.six.moves.urllib.error import URLError, HTTPError
-from ansible.module_utils.six.moves import configparser
+from urllib.error import URLError, HTTPError
+import configparser
```

On Python 3 `six.moves.configparser` is the stdlib `configparser` module and `six.moves.urllib.error` resolves to `urllib.error`, so `configparser.ConfigParser()` and the exception handlers behave identically. A changelog fragment is included.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

plugins/inventory/zabbix_inventory.py, scripts/inventory/zabbix.py
