### PR TITLE
Replace deprecated ansible.module_utils._text

### DIFF
--- a/plugins/module_utils/api_request.py
+++ b/plugins/module_utils/api_request.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 from ssl import CertificateError
 from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.connection import Connection
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 class ZabbixApiRequest(object):

--- a/plugins/modules/zabbix_configuration.py
+++ b/plugins/modules/zabbix_configuration.py
@@ -101,7 +101,7 @@ EXAMPLES = r"""
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
 import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils

--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -293,7 +293,7 @@ import json
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
 from ansible.module_utils.compat.version import LooseVersion
 

--- a/plugins/modules/zabbix_template_info.py
+++ b/plugins/modules/zabbix_template_info.py
@@ -231,7 +231,7 @@ import xml.etree.ElementTree as ET
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.compat.version import LooseVersion
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.zabbix.plugins.module_utils.base import ZabbixBase
 import ansible_collections.community.zabbix.plugins.module_utils.helpers as zabbix_utils


### PR DESCRIPTION
##### SUMMARY
Replace deprecated `ansible.module_utils._text` imports with `ansible.module_utils.common.text.converters`.

The _text module is deprecated in newer Ansible versions. This change updates all remaining imports to use the supported module_utils location.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.module_utils.common.text.converters

##### ADDITIONAL INFORMATION
Updated all occurrences of the deprecated ansible.module_utils._text import across the collection, including
`plugins/module_utils/api_request.py`
`plugins/modules/zabbix_configuration.py`
`plugins/modules/zabbix_template.py`
`plugins/modules/zabbix_template_info.py`