### PR TITLE
workflows: fix the plugin integration and sanity matrices

### DIFF
--- a/.github/workflows/plugins-integration-full.yml
+++ b/.github/workflows/plugins-integration-full.yml
@@ -29,7 +29,6 @@ jobs:
         zabbix_container:
           - version: "6.0"
           - version: "7.0"
-          - version: "7.2"
           - version: "7.4"
         ansible_python:
           # https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs

--- a/.github/workflows/plugins-integration-full.yml
+++ b/.github/workflows/plugins-integration-full.yml
@@ -55,7 +55,7 @@ jobs:
           - ansible: stable-2.20
             python: '3.14'
           - ansible: devel
-            python: '3.12'
+            python: '3.13'
           - ansible: devel
             python: '3.14'
 

--- a/.github/workflows/plugins-integration-targeted.yml
+++ b/.github/workflows/plugins-integration-targeted.yml
@@ -99,7 +99,6 @@ jobs:
         zabbix_container:
           - version: "6.0"
           - version: "7.0"
-          - version: "7.2"
           - version: "7.4"
         ansible_python:
           - ansible: stable-2.16

--- a/.github/workflows/plugins-integration-targeted.yml
+++ b/.github/workflows/plugins-integration-targeted.yml
@@ -119,9 +119,9 @@ jobs:
           - ansible: stable-2.19
             python: '3.13'
           - ansible: devel
-            python: '3.12'
-          - ansible: devel
             python: '3.13'
+          - ansible: devel
+            python: '3.14'
 
     steps:
       - name: Check out code

--- a/.github/workflows/repo-sanity.yml
+++ b/.github/workflows/repo-sanity.yml
@@ -37,19 +37,26 @@ jobs:
   sanity:
     name: Sanity (Ⓐ${{ matrix.ansible }}+py${{ matrix.python }})
     strategy:
+      fail-fast: false
       matrix:
-        ansible:
-          # It's important that Sanity is tested against all stable-X.Y branches
-          # Testing against `devel` may fail as new tests are added.
+        # It's important that Sanity is tested against all stable-X.Y branches
+        # Testing against `devel` may fail as new tests are added.
 
-          # https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs
-          - stable-2.16
-          - stable-2.17
-          - stable-2.18
-          - stable-2.19
-          - devel
-        python:
-          - '3.12'
+        # https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-changelogs
+
+        # Each branch supports its own range of control node pythons, so pair
+        # them explicitly rather than running one python across them all.
+        include:
+          - ansible: stable-2.16
+            python: '3.12'
+          - ansible: stable-2.17
+            python: '3.12'
+          - ansible: stable-2.18
+            python: '3.12'
+          - ansible: stable-2.19
+            python: '3.12'
+          - ansible: devel
+            python: '3.13'
     runs-on: ubuntu-latest
     steps:
       # ansible-test requires the collection to be in a directory in the form
@@ -60,7 +67,7 @@ jobs:
         with:
           path: ansible_collections/community/zabbix
 
-      - name: Set up Python ${{ matrix.ansible }}
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}


### PR DESCRIPTION
##### SUMMARY
Two CI-only fixes to the plugin integration and sanity workflows, split out of #1711 so that PR
stays on the role/molecule side.

* **Give ansible-core `devel` a python it supports.** `devel` is `2.22.0.dev0` now and declares
  `requires-python >= 3.13`, so installing it under 3.12 fails before any collection code is
  touched:

  ```
  ERROR: Package 'ansible-core' requires a different Python: 3.12.14 not in '>=3.13'
  ```

  The sanity matrix crossed every branch with a single python, which forced `devel` onto 3.12.
  Each branch is now paired with a python it supports, and `fail-fast: false` keeps one bad
  combination from cancelling the other four. The `devel` legs of both plugin integration
  matrices move off 3.12 too.

* **Drop zabbix 7.2 from the integration matrices**, since it's been EOL'd by Zabbix.

##### ISSUE TYPE
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
CI workflows: `repo-sanity`, `plugins-integration-full`, `plugins-integration-targeted`
