### PR TITLE
zabbix_maintenance: default start_date to today for frequency=once

### DIFF
--- a/changelogs/fragments/1774-zabbix-maintenance-once-start-date-default.yaml
+++ b/changelogs/fragments/1774-zabbix-maintenance-once-start-date-default.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_maintenance - fix a crash (``unsupported operand type(s) for +: 'NoneType' and 'str'``) when a ``time_periods`` entry has ``frequency: once`` and omits ``start_date``. The module now falls back to today's date as documented instead of failing (https://github.com/ansible-collections/community.zabbix/issues/1774).

--- a/plugins/modules/zabbix_maintenance.py
+++ b/plugins/modules/zabbix_maintenance.py
@@ -137,7 +137,7 @@ options:
                 description:
                     - The date that the outage will occur on.
                     - for a I(frequency) of I(once) only.
-                    - Uses `datetime.date.today() if not specified.
+                    - Uses C(datetime.date.today()) if not specified.
                 type: str
             start_time:
                 description:
@@ -603,6 +603,9 @@ def parse_periods(module, time_periods, start_date):
 
         # Parse start_date/time fields
         if frequeny == "once":
+            if not start_date:
+                # Match the documented behavior: default to today when omitted.
+                start_date = datetime.date.today().isoformat()
             start_date = start_date + " " + start_time
             start_date = datetime.datetime.fromisoformat(start_date)
             start_date = int(time.mktime(start_date.timetuple()))


### PR DESCRIPTION
##### SUMMARY
Fixes a crash reported in #1774. The docs for `zabbix_maintenance`'s `start_date` option say:

> Uses `datetime.date.today()` if not specified.

but `parse_periods()` never actually implemented that fallback -- it read `start_date` from the `time_periods` entry and unconditionally concatenated it with `start_time`. Omitting `start_date` for a `frequency: once` entry crashed with:

```
unsupported operand type(s) for +: 'NoneType' and 'str'
```

This adds the missing default (today's date, matching the docs) and fixes a small typo in the same doc string (missing closing backtick).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_maintenance

##### ADDITIONAL INFORMATION
Minimal, targeted fix -- no other behavior in `parse_periods()` changed. Included a changelog fragment per CONTRIBUTING.md. I don't have a live Zabbix instance handy to run the integration target locally, so I'd appreciate a second look from a maintainer/CI on that front.